### PR TITLE
Guard viz coverage-density against 0-area bbox (issue #69)

### DIFF
--- a/gsv_metadata_tracker/vis.py
+++ b/gsv_metadata_tracker/vis.py
@@ -275,8 +275,12 @@ def create_visualization_map(df: pd.DataFrame, city_name: str,
 
     logger.info(f"Average age: {avg_age:.1f} years, Median age: {median_age:.1f} years, Total panos: {total_panos}, Area: {area_km2:.1f} km²")
     
-    # Calculate coverage density
-    density_per_km2 = total_panos / area_km2
+    # Calculate coverage density. Guard against a degenerate 0-area bbox (a
+    # single pano, or collinear panos, gives a 0 x 0 bounding box), which would
+    # otherwise raise ZeroDivisionError and crash the run's local viz step
+    # after the run is already cataloged (issue #69).
+    density_per_km2 = total_panos / area_km2 if area_km2 > 0 else float('nan')
+    density_str = f"{density_per_km2:.1f}" if area_km2 > 0 else "n/a"
     
     # Calculate temporal coverage
     date_range = (valid_rows['capture_date'].max() - valid_rows['capture_date'].min()).days / 365.25
@@ -303,7 +307,7 @@ def create_visualization_map(df: pd.DataFrame, city_name: str,
             <strong>Grid Area:</strong> {width_meters:,.0f} x {height_meters:,.0f}m ({area_km2:.1f} km²)
         </div>
         <div style='margin-bottom: 4px'>
-            <strong>Total {label} Panos:</strong> {total_panos:,} ({density_per_km2:.1f} panos/km²)
+            <strong>Total {label} Panos:</strong> {total_panos:,} ({density_str} panos/km²)
         </div>
         <div style='margin-bottom: 4px'>
             <strong>Avg Pano Age:</strong> {avg_age:.1f} yrs (SD={age_std:.1f} yrs)

--- a/tests/test_vis.py
+++ b/tests/test_vis.py
@@ -1,0 +1,61 @@
+"""
+Tests for map-visualization edge cases (gsv_metadata_tracker/vis.py).
+
+Pure-logic / no-network: these build a tiny in-memory metadata DataFrame and
+call create_visualization_map, asserting it produces a folium.Map without
+raising. The focus is the degenerate-geometry guard from issue #69.
+"""
+
+import folium
+import pandas as pd
+
+from gsv_metadata_tracker import vis
+from gsv_metadata_tracker.config import METADATA_DTYPES
+
+
+def _row(pano_id, lat, lon):
+    """One valid, official-Google GSV metadata row (config.METADATA_DTYPES)."""
+    return {
+        'query_lat': lat,
+        'query_lon': lon,
+        'query_timestamp': '2026-07-01T00:00:00+00:00',
+        'pano_lat': lat,
+        'pano_lon': lon,
+        'pano_id': pano_id,
+        'capture_date': '2024-08-01',
+        'copyright_info': '© Google',
+        'status': 'OK',
+    }
+
+
+def _frame(rows):
+    df = pd.DataFrame(rows, columns=list(METADATA_DTYPES.keys()))
+    return df.astype({'pano_id': 'string', 'copyright_info': 'string'})
+
+
+def test_single_pano_city_does_not_crash():
+    """
+    A city with exactly one valid pano yields a 0 x 0 bounding box, so the
+    coverage-density division would raise ZeroDivisionError without the guard
+    (issue #69 — e.g. Eastsound, WA / Kodiak, AK). It must return a map instead.
+    """
+    result = vis.create_visualization_map(_frame([_row('p1', 47.62, -122.35)]),
+                                           'Eastsound, WA')
+    assert isinstance(result, folium.Map)
+
+
+def test_no_valid_panos_returns_empty_map():
+    """Zero valid rows is already guarded and returns an empty map, not a crash."""
+    row = _row('p1', 47.62, -122.35)
+    row['status'] = 'ZERO_RESULTS'  # filtered out -> no valid rows
+    result = vis.create_visualization_map(_frame([row]), 'Nowhere, WA')
+    assert isinstance(result, folium.Map)
+
+
+def test_multi_pano_city_still_builds():
+    """A normal multi-pano city (non-zero area) is unaffected by the guard."""
+    rows = [_row('p1', 47.60, -122.33),
+            _row('p2', 47.62, -122.35),
+            _row('p3', 47.64, -122.31)]
+    result = vis.create_visualization_map(_frame(rows), 'Seattle, WA')
+    assert isinstance(result, folium.Map)


### PR DESCRIPTION
## Summary
A city with a single valid pano (e.g. **Eastsound, WA** / **Kodiak, AK**) yields a 0 × 0 bounding box, so `density_per_km2 = total_panos / area_km2` raised `ZeroDivisionError` and crashed the run's local **visualization** step — *after* the run had already been cataloged. The `len == 0` case was guarded; `len == 1` (or collinear panos) was not.

## What changed
- `gsv_metadata_tracker/vis.py`: when the bbox area is 0, fall back to `NaN` density and an `"n/a"` popup string instead of dividing by zero.
- `tests/test_vis.py` (new): covers single-pano, no-valid-pano, and normal multi-pano cases.

## Scope / risk
- Visualization-only guard; does not touch collection, cataloging, diffs, or the aggregate. The crash never corrupted data — it only aborted the local viz after the run was saved.
- Low risk, narrow change, ships with tests.

## Test plan
- `pytest tests/test_vis.py` → 3 passed (single-pano, no-valid-pano, normal).
- Full suite: `149 passed`.

Closes #69.

🤖 Generated with [Claude Code](https://claude.com/claude-code)