### PR TITLE
Document city sampling & catalog provenance

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,17 @@ Then run the batch script:
 python run_cities.py cities.txt --continue-on-error
 ```
 
+### Which cities are tracked?
+
+The catalog is **not** limited to US state capitals — it spans ~1,100 US cities
+plus a few dozen international ones, assembled from several sources: a US
+census-stratified study list (`cities/`, see
+[`cities/README.md`](cities/README.md)), archival baseline imports, and ad-hoc
+additions (collaborator and Project Sidewalk requests). A proposed worldwide
+frame is in progress. The full provenance and sampling methodology — the record
+to cite in publications — lives in
+[`docs/city_sampling.md`](docs/city_sampling.md).
+
 ## 4. Output Files
 
 Each run generates the following files in your designated `--download-dir` (defaults to `./data`), where `{base}` is `{city_id}_width_{W}_height_{H}_step_{S}_{YYYY-MM-DD}` (Mapillary runs insert a `mapillary` token before the date):

--- a/cities/README.md
+++ b/cities/README.md
@@ -1,0 +1,75 @@
+# US city selection (`cities/`)
+
+This folder holds the **US-directed city-sampling tool** and its inputs. It
+produces a stratified sample of US cities — a study list — used as one of the
+sources for the cities GSV Tracker follows. It does **not** collect any imagery;
+it only chooses *which* cities to collect.
+
+For the full picture of every way a city ends up in the catalog (this US sample,
+archival baseline imports, ad-hoc partner requests, and the proposed worldwide
+frame), see [`../docs/city_sampling.md`](../docs/city_sampling.md).
+
+> **⚠️ Caveat.** Appearing on this study list (886 cities) does **not** mean a
+> city has been collected — selection and collection are separate steps.
+> Catalog-wide "cities tracked" counts are currently **provisional and under
+> investigation** ([#112](https://github.com/jonfroehlich/gsv-tracker/issues/112));
+> see `../docs/city_sampling.md` for the definitions and caveats.
+
+## Files
+
+| File | What it is |
+|------|------------|
+| `us_census_city_analyzer.py` | The selection script. |
+| `SUB-IP-EST2023-POP.xlsx` | Input: US Census Bureau **Subcounty Resident Population Estimates** (Vintage 2023), covering 2020–2023 population for incorporated places and minor civil divisions. |
+| `selected_cities.txt` | Output: the selected study list, one `City, State` per line (currently **886 cities**), sorted by state then city. |
+| `us_census_city_selection.log` | Run log (created on execution; parsing warnings, per-state notes). |
+
+## Selection methodology
+
+Implemented in `select_study_cities()`. For **each state independently**:
+
+1. **Always include the state capital** (from a hardcoded state→capital map).
+2. **Always include the largest city** by 2023 population (or the 2nd-largest if
+   the capital is already the largest).
+3. **Quartile-stratify the rest**: bin the remaining cities into four population
+   quartiles (`Q1`–`Q4`) with `pandas.qcut`, then **randomly sample 5 cities
+   from each quartile** (`cities_per_quartile`, default 5).
+4. States with fewer than `4 * cities_per_quartile + 2` (= 22 at the default)
+   qualifying cities are **skipped** for insufficient data.
+
+The goal is a per-state sample that spans the full population range — from the
+capital and largest metro down through small towns — rather than only big
+cities. `analyze_selection_coverage()` / `print_selection_analysis()` report how
+much of each state's population and size range the sample covers.
+
+Input cleaning (`extract_city_state()`) strips Census classification suffixes
+(`city`, `town`, `village`, `township`, `borough`, `municipality`, etc.) and
+resolves parenthetical place names so entries like `"Albany city, New York"`
+become `City="Albany", State="New York"`.
+
+## Reproducibility caveats
+
+- **The random sampling is not seeded.** `DataFrame.sample()` is called without a
+  `random_state`, so **re-running produces a different quartile sample.**
+  `selected_cities.txt` is the frozen artifact of one particular run — treat the
+  checked-in file as the source of truth, not something to regenerate casually.
+  (If exact reproducibility is ever needed, thread a `--seed` through
+  `select_study_cities()` → `.sample(random_state=seed)`.)
+- The capital list is **hardcoded** in `map_state_to_capital`; it covers the 50
+  states (no DC / territories).
+- Population is a **Vintage 2023** snapshot; refreshing the study list means
+  dropping in a newer Census `SUB-IP-EST*` file and re-running.
+
+## Usage
+
+```bash
+# from the repo root, with the venv active
+python cities/us_census_city_analyzer.py \
+  --input-file cities/SUB-IP-EST2023-POP.xlsx \
+  --log-level INFO
+# writes selected_cities.txt (in the current working directory) + prints coverage analysis
+```
+
+Requires `pandas` (and `openpyxl` to read the `.xlsx`). To actually collect the
+selected cities, feed the list to the batch runner — see the main
+[`../README.md`](../README.md) ("Batch Processing Multiple Cities").

--- a/docs/city_sampling.md
+++ b/docs/city_sampling.md
@@ -1,0 +1,125 @@
+# City sampling & catalog provenance
+
+This document is the **authoritative record of which cities GSV Tracker follows
+and how each one entered the catalog.** It exists so the tracked set is not
+misdescribed (it is *not* "just US state capitals") and so the sampling
+methodology is citable in publications.
+
+The catalog (`data/gsv_tracker.db`, table `cities`) is the source of truth for
+what is tracked; this doc explains *how that set was assembled*.
+
+## Current composition (snapshot: 2026-07-08 — provisional, see [#112](https://github.com/jonfroehlich/gsv-tracker/issues/112))
+
+Numbers below are from the live catalog and will drift as collection continues —
+regenerate them with the queries in [Reproducing these numbers](#reproducing-these-numbers).
+
+- **1,143 cities registered** — **1,099 US** and **44 non-US** across ~30
+  countries (Canada 8; Costa Rica 3; then 1–2 each: Taiwan, Spain, Portugal, New
+  Zealand, Mexico, Kenya, India, Chile, Brazil, Vietnam, Turkey, Switzerland,
+  and more).
+- **~1,132 cities carry pano data**; 11 are registered but empty.
+- Runs are **overwhelmingly archival baseline imports** (1,154 baseline vs. 4
+  live non-baseline runs at this snapshot). Baseline vintages by `run_date`:
+  2023 (13), 2024 (83), **2025 (1,025)**, 2026 (33).
+
+> **⚠️ Caveat — this data was NOT collected by v2; v2 has not launched.** The
+> ~1,132 cities carry **imported archival baseline** runs (stream 2 below) —
+> scrapes collected mostly Dec 2024–Feb 2025 by the earlier `gsv-capture-dates`
+> effort and imported as `is_baseline=1` during the July 2026 migration. The v2
+> live temporal-tracking pipeline has produced only **4 runs, ever** (Adrian OR
+> and Corvallis OR test cities). "v2 has not launched" and "the catalog holds
+> ~1,132 cities of data" are both true at once. Do not read these counts as v2
+> collection.
+
+> **⚠️ Caveat — the counts here are provisional and under investigation
+> ([#112](https://github.com/jonfroehlich/gsv-tracker/issues/112)).** An earlier
+> working estimate of **"~488 cities"** does not match anything in the catalog
+> (which lands at 1,132/1,143) and has **not yet been reconciled** — it may be a
+> pre-import snapshot, the count actually published/synced to the web server, or
+> a different subset. Until #112 resolves it, treat every number in this section
+> as a raw catalog readout, not a settled project figure, and prefer explicit
+> definitions (`registered` vs `has archival baseline` vs `collected live under
+> v2` vs `published to web`) over a single "cities tracked" number. Note also
+> that catalog `created_at` is *not* a history: the migration rebuilt every row
+> in July 2026, so all rows share a `2026-07` timestamp.
+
+## How a city enters the catalog — four streams
+
+### 1. US census-stratified selection
+
+A per-state stratified sample of US cities spanning the full population range,
+not just large cities. Tooling and inputs live in [`../cities/`](../cities/)
+(see [`cities/README.md`](../cities/README.md) for the full method).
+
+- **Source:** US Census Bureau Subcounty Resident Population Estimates, Vintage
+  2023 (`cities/SUB-IP-EST2023-POP.xlsx`).
+- **Method:** for each state, take the **capital** + the **largest city**, then
+  **randomly sample 5 cities from each of 4 population quartiles**; skip states
+  with < 22 qualifying cities.
+- **Output:** `cities/selected_cities.txt` (886 cities).
+- **Caveat:** the quartile sampling is **not seeded**, so the checked-in file —
+  not a re-run — is the frozen study list.
+
+### 2. Archival baseline imports (issue #93)
+
+Historical GSV scrapes from **2023–2024** (collected by the separate
+`gsv-capture-dates` effort) were imported as **`is_baseline=1`** runs so the
+temporal series has a real starting point rather than beginning empty. This is
+the **dominant** source of catalog rows today. Baseline runs are never renamed
+and keep stable published URLs. See issue #93 and
+[`CLAUDE.md`](../CLAUDE.md) ("Legacy pre-2026 data files").
+
+### 3. Manual / ad-hoc additions
+
+Cities added by request over time — the primary reason the catalog spans ~30
+countries despite the US-focused sampling tool. Two common triggers:
+
+- Direct requests from collaborators or users.
+- **Project Sidewalk** deployments: a prospective Sidewalk partner city is
+  evaluated for GSV data quality, so candidate cities get added and collected to
+  assess coverage/recency before committing.
+
+Any city added ad-hoc via `python gsv_tracker.py "City, Region, Country"` (or a
+line in `cities.txt`) geocodes once, freezes its grid geometry, and registers —
+becoming a permanent tracked city.
+
+### 4. Worldwide stratified frame (issue #110) — proposed, not yet integrated
+
+A deterministic, reproducible worldwide sample
+(`continent × size-band × GSV-coverage-regime`, ~56 cities) built from vendored
+GeoNames data. Methodology is fully specified in
+[`worldwide_sampling.md`](worldwide_sampling.md), but the frame is **not yet in
+the catalog** — the registration step is unfinished and boundary vetting is
+unrun (tracked in **issue #110**). Listed here so the intended global-expansion
+methodology is on record alongside the streams already in use.
+
+## Relationship between the streams
+
+- Streams 1–3 are **already in the catalog**; stream 4 is planned.
+- Streams are **additive and non-conflicting**: grid geometry is frozen per
+  city, so a city registered by any stream keeps its geometry, run history, and
+  published URLs regardless of how later cities are added.
+- Coverage *rates* are cross-provider comparable (grid-point coverage), but raw
+  pano counts are census-vs-sample across providers — see
+  [`CLAUDE.md`](../CLAUDE.md).
+
+## Reproducing these numbers
+
+```bash
+# total registered / US vs non-US
+sqlite3 data/gsv_tracker.db \
+  "SELECT COUNT(*) FROM cities;"
+sqlite3 data/gsv_tracker.db \
+  "SELECT CASE WHEN country_code='US' THEN 'US' ELSE 'non-US' END, COUNT(*) \
+   FROM cities GROUP BY 1;"
+
+# cities with real data vs registered-but-empty
+sqlite3 data/gsv_tracker.db \
+  "SELECT COUNT(DISTINCT city_id) FROM runs WHERE unique_panos > 0 OR status_ok > 0;"
+
+# baseline vs live runs, and baseline vintages
+sqlite3 data/gsv_tracker.db \
+  "SELECT is_baseline, COUNT(*) FROM runs GROUP BY is_baseline;"
+sqlite3 data/gsv_tracker.db \
+  "SELECT substr(run_date,1,4), COUNT(*) FROM runs WHERE is_baseline=1 GROUP BY 1 ORDER BY 1;"
+```


### PR DESCRIPTION
## What

Adds a provenance record for **which cities GSV Tracker follows and how each one entered the catalog** — prompted by a mischaracterization of the corpus as "US state capitals" when it is actually ~worldwide (~1,099 US + ~44 international across ~30 countries).

## Changes (docs only)

- **`docs/city_sampling.md`** (new) — umbrella provenance/methodology record for publications: the four streams (US census-stratified selection, archival baseline imports #93, manual/partner adds, proposed worldwide frame #110), current composition, and reproducing queries. Prominent caveats flag that:
  - catalog data is **imported archival baseline**, NOT collected by v2 (v2 live pipeline has produced 4 runs, ever);
  - counts are **provisional** pending the ~488-vs-1,132 reconciliation (#112).
- **`cities/README.md`** (new) — documents the US census-stratified selection tool (`us_census_city_analyzer.py`): method, inputs, output, and the not-seeded reproducibility caveat.
- **`README.md`** — short "Which cities are tracked?" pointer to both.

No code changes; based directly on `main`.

## Related

- Refs #110 (worldwide frame — proposed, unintegrated)
- Refs #112 (reconcile tracked-city counts / define canonical terms)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
