### PR TITLE
Rebrand to Streetscape Tracker for v2 (multi-provider)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# GSV Tracker
+# Streetscape Tracker
 
-GSV Tracker is a Python tool for analyzing street-level imagery coverage and temporal patterns in cities **over time** — Google Street View (GSV) and, as of 2026, [Mapillary](https://www.mapillary.com/) 360° panoramas. It samples geographic grids around city centers, queries each provider's metadata API, and produces dated snapshots per city — computing what changed between snapshots (panoramas added/removed, capture dates updated, coverage deltas) and rendering interactive visualizations of when and where imagery was captured.
+Streetscape Tracker (formerly *GSV Tracker*) is a Python tool for analyzing street-level imagery coverage and temporal patterns in cities **over time** — Google Street View (GSV) and, as of 2026, [Mapillary](https://www.mapillary.com/) 360° panoramas. It samples geographic grids around city centers, queries each provider's metadata API, and produces dated snapshots per city — computing what changed between snapshots (panoramas added/removed, capture dates updated, coverage deltas) and rendering interactive visualizations of when and where imagery was captured.
 
 This research project began in 2021 by Professor Jon E. Froehlich and was also part of the [UC Berkeley Data Science Discovery Program](https://cdss.berkeley.edu/discovery/projects) in 2023 with students Joseph Chen, Wenjing Yi, and Jingfeng Yang. Here's the [original pitch sheet in Google Docs](https://docs.google.com/document/d/1hfgvS_JHRmhkVtj_LBZ2qd_TO-50L6g0crlV8nTBy9s/edit?tab=t.0). The [v1.0.0 release](https://github.com/jonfroehlich/gsv-tracker/releases/tag/v1.0.0) of this tool supported our [GeoIndustry 2025 paper](https://doi.org/10.1145/3764919.3770883) on GSV coverage and socioeconomic indicators (see also [GSVantage](https://github.com/makeabilitylab/GSVantage)).
 
@@ -53,7 +53,7 @@ We recommend using a standard Python virtual environment (`.venv`) to manage dep
 1. **Clone the repository:**
 
 ```bash
-git clone https://github.com/yourusername/gsv-tracker.git
+git clone https://github.com/jonfroehlich/gsv-tracker.git
 cd gsv-tracker
 ```
 

--- a/www/city.html
+++ b/www/city.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Street View Panorama Ages</title>
+  <title>Streetscape Tracker — Panorama Ages</title>
 
   <!-- Stylesheets -->
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/leaflet.min.css" />

--- a/www/index.html
+++ b/www/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>GSV City Explorer</title>
+  <title>Streetscape Tracker — City Explorer</title>
 
   <!-- Stylesheets -->
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/leaflet.css" />
@@ -49,7 +49,7 @@
     <ul id="city-search-results" class="city-search-results" role="listbox"></ul>
   </div>
 
-  <div id="map" role="application" aria-label="World map of GSV city coverage"></div>
+  <div id="map" role="application" aria-label="World map of street-level imagery coverage"></div>
 
   <div id="loading" class="loading" role="status" aria-live="polite">
     Loading city data…


### PR DESCRIPTION
## What

Rebrands the project from **GSV Tracker** to **Streetscape Tracker** for v2, reflecting that it now tracks multiple providers (Google Street View **and** Mapillary), not just GSV.

## Changes

- `README.md` — title → "Streetscape Tracker (formerly *GSV Tracker*)"; also fixes the clone URL placeholder to the real repo.
- `www/city.html` — page title → "Streetscape Tracker — Panorama Ages".
- `www/index.html` — page title → "Streetscape Tracker — City Explorer"; map aria-label generalized to "street-level imagery coverage".

Text/branding only — no code, filenames, package names (`gsv_metadata_tracker`), CLI (`gsv_tracker.py`), or data-file/URL conventions change, so nothing downstream breaks.

## Note

Rebased onto current `main`, so it no longer touches the no-backend ADR (#94) or the viz guard/test (#107).
