### PR TITLE
Count present-but-dateless panos as coverage (schema v4)

### DIFF
--- a/gsv_metadata_tracker/analysis.py
+++ b/gsv_metadata_tracker/analysis.py
@@ -24,6 +24,15 @@ logger = logging.getLogger(__name__)
 # Tours Agency'). Must stay in sync with the exact match in www/js/city.js.
 GOOGLE_COPYRIGHT = '© Google'
 
+# Statuses that mean "imagery is present at this grid point". A pano the
+# provider returned counts even when we could not read a usable capture date
+# (status NO_DATE): it is still imagery within reach, so it counts toward both
+# coverage and pano totals. Date-based stats (age, capture-year histograms)
+# necessarily use only the dated subset (status == 'OK'). ZERO_RESULTS means
+# "no imagery here"; everything else (REQUEST_DENIED, OVER_QUERY_LIMIT, ...) is
+# an error, not an absence.
+PRESENT_STATUSES = ('OK', 'NO_DATE')
+
 
 def is_google_copyright(copyright_info: pd.Series) -> pd.Series:
     """
@@ -211,19 +220,21 @@ def calculate_coverage_stats(df: pd.DataFrame) -> CoverageStats:
     point_cols = ['query_lat', 'query_lon']
     num_total_points = len(df[point_cols].drop_duplicates())
 
-    ok_rows = df[df['status'] == 'OK']
-    num_points_with_panos = len(ok_rows[point_cols].drop_duplicates())
+    # A grid point is covered if it holds >= 1 present pano (OK or NO_DATE):
+    # a dateless pano is still imagery within reach (see PRESENT_STATUSES).
+    present_rows = df[df['status'].isin(PRESENT_STATUSES)]
+    num_points_with_panos = len(present_rows[point_cols].drop_duplicates())
     logger.debug(f"Grid points with panoramas: {num_points_with_panos}")
 
-    # ZERO_RESULTS rows exist only at grid points with no pano, so they
-    # never overlap the OK points; whatever remains saw only errors
-    # (REQUEST_DENIED, NO_DATE, ...)
+    # ZERO_RESULTS rows exist only at grid points with no pano, so they never
+    # overlap the covered points; whatever remains saw only errors
+    # (REQUEST_DENIED, OVER_QUERY_LIMIT, ...)
     num_points_without_panos = len(
         df.loc[df['status'] == 'ZERO_RESULTS', point_cols].drop_duplicates())
     num_points_with_errors = (num_total_points - num_points_with_panos
                               - num_points_without_panos)
 
-    successful_df_no_duplicates = ok_rows.drop_duplicates(subset=['pano_id']).copy()
+    successful_df_no_duplicates = present_rows.drop_duplicates(subset=['pano_id']).copy()
     num_unique_panos = len(successful_df_no_duplicates)
     logger.debug(f"Unique panoramas: {num_unique_panos}")
 
@@ -463,11 +474,12 @@ def calculate_photographer_stats(df: pd.DataFrame) -> PhotographerStats:
     Returns:
         PhotographerStats containing photographer contribution analysis
     """
-    # Filter for successful panoramas and drop duplicates
-    ok_panos = df[df['status'] == 'OK'].drop_duplicates(subset=['pano_id'])
-    
+    # Filter for present panoramas (OK or NO_DATE) and drop duplicates; a
+    # dateless pano still carries its contributor/copyright attribution.
+    present_panos = df[df['status'].isin(PRESENT_STATUSES)].drop_duplicates(subset=['pano_id'])
+
     # Count unique pano_ids per photographer
-    photographer_counts = ok_panos['copyright_info'].value_counts().to_dict()
+    photographer_counts = present_panos['copyright_info'].value_counts().to_dict()
     
     return PhotographerStats(photographer_counts=photographer_counts)
 
@@ -495,38 +507,39 @@ def calculate_pano_stats(
         >>> results.print_summary("Analysis Results")
     """
     filtered_df = df[is_google_copyright(df['copyright_info'])] if google_only else df
-    
-    # Get successful panoramas
-    ok_panos = filtered_df[filtered_df['status'] == 'OK'].copy()
-    
-    # Calculate duplicate statistics
-    pano_id_counts = ok_panos['pano_id'].value_counts()
+
+    # Present panoramas (OK or NO_DATE) count toward pano totals; date-based
+    # stats below use only the dated (OK) subset.
+    present_panos = filtered_df[filtered_df['status'].isin(PRESENT_STATUSES)].copy()
+
+    # Calculate duplicate statistics over every present pano
+    pano_id_counts = present_panos['pano_id'].value_counts()
     duplicate_stats = DuplicateStats(
         total_unique_panos=len(pano_id_counts),
-        total_pano_references=len(ok_panos),
-        duplicate_reference_count=len(ok_panos) - len(pano_id_counts),
+        total_pano_references=len(present_panos),
+        duplicate_reference_count=len(present_panos) - len(pano_id_counts),
         most_referenced_count=int(pano_id_counts.max()) if not pano_id_counts.empty else 0,
         panos_with_multiple_refs=int((pano_id_counts > 1).sum()),
-        average_references_per_pano=float(len(ok_panos) / len(pano_id_counts)) if len(pano_id_counts) > 0 else 0
+        average_references_per_pano=float(len(present_panos) / len(pano_id_counts)) if len(pano_id_counts) > 0 else 0
     )
 
     # For most stats, we want to focus only on unique pano ids or we risk
     # skewing our statistics for duplicate pano ids that are referenced multiple times
     # from different query points
-    
-    # Calculate age statistics for unique panoramas
-    unique_panos = ok_panos.drop_duplicates(subset=['pano_id'])
-    age_stats = calculate_age_stats(unique_panos, now)
-    
+
+    # Age / capture-year / daily stats need a real date, so use dated panos only
+    dated_unique = filtered_df[filtered_df['status'] == 'OK'].drop_duplicates(subset=['pano_id'])
+    age_stats = calculate_age_stats(dated_unique, now)
+
     # Coverage describes the sampled grid, not the copyright subset, so it
     # is always computed over the full frame (the google_only filter would
     # drop the ZERO_RESULTS rows that anchor the denominator)
     coverage_stats = calculate_coverage_stats(df)
-    
+
     # Calculate distributions and photographer stats
-    yearly_dist = calculate_yearly_distribution(unique_panos)
-    daily_dist = calculate_daily_distribution(unique_panos)
-    photographer_stats = calculate_photographer_stats(unique_panos)
+    yearly_dist = calculate_yearly_distribution(dated_unique)
+    daily_dist = calculate_daily_distribution(dated_unique)
+    photographer_stats = calculate_photographer_stats(present_panos)
     
     return GSVAnalysisResults(
         duplicate_stats=duplicate_stats,
@@ -577,23 +590,28 @@ def calculate_run_stats(df: pd.DataFrame, run_date,
     now = pd.Timestamp(run_date)
 
     status_ok = int((df['status'] == 'OK').sum())
+    status_no_date = int((df['status'] == 'NO_DATE').sum())
     status_zero = int((df['status'] == 'ZERO_RESULTS').sum())
-    status_other = int(len(df) - status_ok - status_zero)
+    status_other = int(len(df) - status_ok - status_no_date - status_zero)
 
-    ok = df[df['status'] == 'OK']
-    unique = ok.drop_duplicates(subset=['pano_id'])
+    # Pano totals count every present pano (OK or NO_DATE); age stats use only
+    # the dated subset, since NO_DATE panos carry no usable capture date.
+    present = df[df['status'].isin(PRESENT_STATUSES)]
+    unique = present.drop_duplicates(subset=['pano_id'])
     unique_google_panos = None
     if provider == 'gsv' and not (len(unique) > 0
                                   and unique['copyright_info'].isna().all()):
         is_google = is_google_copyright(unique['copyright_info'])
         unique_google_panos = int(is_google.sum())
 
-    age_stats = calculate_age_stats(unique.copy(), now)
+    dated_unique = df[df['status'] == 'OK'].drop_duplicates(subset=['pano_id'])
+    age_stats = calculate_age_stats(dated_unique.copy(), now)
     coverage = calculate_coverage_stats(df)
 
     return {
         'total_points': len(df),
         'status_ok': status_ok,
+        'status_no_date': status_no_date,
         'status_zero_results': status_zero,
         'status_other': status_other,
         'unique_panos': len(unique),

--- a/gsv_metadata_tracker/db.py
+++ b/gsv_metadata_tracker/db.py
@@ -28,7 +28,7 @@ from .naming import sanitize_city_query_str
 
 logger = logging.getLogger(__name__)
 
-SCHEMA_VERSION = 3
+SCHEMA_VERSION = 4
 
 _SCHEMA = """
 CREATE TABLE IF NOT EXISTS cities (
@@ -67,6 +67,7 @@ CREATE TABLE IF NOT EXISTS runs (
     duration_seconds    REAL,
     total_points        INTEGER,
     status_ok           INTEGER,
+    status_no_date      INTEGER,
     status_zero_results INTEGER,
     status_other        INTEGER,
     unique_panos        INTEGER,
@@ -215,6 +216,15 @@ DROP TABLE schedule_state;
 ALTER TABLE schedule_state_v2 RENAME TO schedule_state;
 """
 
+# v3 -> v4: split "present but dateless" panos out of the status_other error
+# bucket so they can count toward coverage and pano totals. Purely additive —
+# a plain ADD COLUMN, no table rebuild. Existing rows get status_no_date=NULL
+# (unknown until scripts/recompute_run_stats.py backfills it from the CSVs and
+# recomputes coverage_rate_pct / unique_panos).
+_MIGRATE_V3_TO_V4 = """
+ALTER TABLE runs ADD COLUMN status_no_date INTEGER;
+"""
+
 
 @dataclass
 class CityRow:
@@ -251,6 +261,7 @@ class RunRow:
     duration_seconds: Optional[float]
     total_points: Optional[int]
     status_ok: Optional[int]
+    status_no_date: Optional[int]
     status_zero_results: Optional[int]
     status_other: Optional[int]
     unique_panos: Optional[int]
@@ -296,9 +307,14 @@ def init_schema(conn: sqlite3.Connection) -> None:
             f"supports ({SCHEMA_VERSION}). Update the code before proceeding.")
     if user_version == 1:
         _migrate_v1_to_v2(conn)
+        user_version = 2
     # v2 -> v3 is purely additive (the history_harvests table), so it needs no
     # rebuild migration: the CREATE TABLE IF NOT EXISTS in _SCHEMA creates it on
     # any older catalog, and the version stamp below records the upgrade.
+    if user_version == 2:
+        user_version = 3
+    if user_version == 3:
+        _migrate_v3_to_v4(conn)
     conn.executescript(_SCHEMA)
     conn.execute(f"PRAGMA user_version = {SCHEMA_VERSION}")
     conn.commit()
@@ -321,6 +337,21 @@ def _migrate_v1_to_v2(conn: sqlite3.Connection) -> None:
         conn.commit()
     finally:
         conn.execute("PRAGMA foreign_keys=ON")
+
+
+def _migrate_v3_to_v4(conn: sqlite3.Connection) -> None:
+    """Add the status_no_date column to runs (additive; no table rebuild).
+
+    Idempotent: skips the ADD COLUMN if the column already exists, so a
+    catalog created fresh at the current schema (runs already carries the
+    column) can still be stamped forward through this step.
+    """
+    cols = {r[1] for r in conn.execute("PRAGMA table_info(runs)").fetchall()}
+    if 'status_no_date' in cols:
+        return
+    logger.info("Migrating catalog schema v3 -> v4 (adding runs.status_no_date)")
+    conn.executescript(_MIGRATE_V3_TO_V4)
+    conn.commit()
 
 
 def derive_city_id(city_name: str, state_name: Optional[str],
@@ -451,6 +482,7 @@ def register_run(conn: sqlite3.Connection, *,
                  duration_seconds: Optional[float] = None,
                  total_points: Optional[int] = None,
                  status_ok: Optional[int] = None,
+                 status_no_date: Optional[int] = None,
                  status_zero_results: Optional[int] = None,
                  status_other: Optional[int] = None,
                  unique_panos: Optional[int] = None,
@@ -471,15 +503,15 @@ def register_run(conn: sqlite3.Connection, *,
         """INSERT INTO runs
            (city_id, provider, run_date, csv_filename, json_filename,
             is_baseline, started_at, finished_at, duration_seconds,
-            total_points, status_ok, status_zero_results, status_other,
-            unique_panos, unique_google_panos, coverage_rate_pct,
+            total_points, status_ok, status_no_date, status_zero_results,
+            status_other, unique_panos, unique_google_panos, coverage_rate_pct,
             oldest_capture_date, newest_capture_date, median_pano_age_years,
             api_requests)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
         (city_id, provider, run_date.isoformat(), csv_filename, json_filename,
          int(is_baseline), started_at, finished_at, duration_seconds,
-         total_points, status_ok, status_zero_results, status_other,
-         unique_panos, unique_google_panos, coverage_rate_pct,
+         total_points, status_ok, status_no_date, status_zero_results,
+         status_other, unique_panos, unique_google_panos, coverage_rate_pct,
          oldest_capture_date, newest_capture_date, median_pano_age_years,
          api_requests))
     conn.commit()

--- a/gsv_metadata_tracker/diff.py
+++ b/gsv_metadata_tracker/diff.py
@@ -20,6 +20,8 @@ from typing import Optional
 
 import pandas as pd
 
+from .analysis import PRESENT_STATUSES
+
 logger = logging.getLogger(__name__)
 
 # Rounding used to key grid points; matches the precision the query
@@ -153,8 +155,10 @@ def compute_run_diff(df_old: pd.DataFrame, df_new: pd.DataFrame) -> RunDiff:
         new_status = new_status[~new_status.index.duplicated(keep='first')]
         new_status = new_status.reindex(old_status.index)
 
-        old_ok = old_status == 'OK'
-        new_ok = new_status == 'OK'
+        # A point is covered if it holds present imagery (OK or NO_DATE),
+        # matching analysis.calculate_coverage_stats.
+        old_ok = old_status.isin(PRESENT_STATUSES)
+        new_ok = new_status.isin(PRESENT_STATUSES)
         points_gained = int((~old_ok & new_ok).sum())
         points_lost = int((old_ok & ~new_ok).sum())
 

--- a/gsv_metadata_tracker/json_summarizer.py
+++ b/gsv_metadata_tracker/json_summarizer.py
@@ -14,6 +14,7 @@ from .analysis import (
     calculate_pano_stats,
     calculate_age_stats,
     calculate_coverage_stats,
+    PRESENT_STATUSES,
 )
 
 logger = logging.getLogger(__name__)
@@ -289,9 +290,9 @@ def generate_city_metadata_summary_as_json(
     all_pano_stats = calculate_pano_stats(df, now)
     gsv_copyright_available = True
     if provider == 'gsv':
-        ok_rows = df[df['status'] == 'OK']
-        gsv_copyright_available = (len(ok_rows) == 0
-                                   or bool(ok_rows['copyright_info'].notna().any()))
+        present_rows = df[df['status'].isin(PRESENT_STATUSES)]
+        gsv_copyright_available = (len(present_rows) == 0
+                                   or bool(present_rows['copyright_info'].notna().any()))
     google_pano_stats = (calculate_pano_stats(df, now, google_only=True)
                          if provider == 'gsv' and gsv_copyright_available
                          else None)

--- a/scripts/recompute_coverage_rates.py
+++ b/scripts/recompute_coverage_rates.py
@@ -20,6 +20,12 @@ site reads coverage from it.
 
 Idempotent: recomputing already-correct rows is a no-op.
 
+SUPERSEDED by scripts/recompute_run_stats.py as of schema v3: the GSV
+pure-SQL path here (100 * status_ok / total_points) predates NO_DATE counting
+toward coverage, so running it against a v3 catalog would wrongly drop
+dateless panos from GSV coverage. This script now refuses to run on v3+
+databases.
+
 Usage:
     python scripts/recompute_coverage_rates.py            # dry run
     python scripts/recompute_coverage_rates.py --execute  # apply
@@ -54,6 +60,14 @@ def main() -> int:
     args = parser.parse_args()
 
     conn = db.connect(db.get_default_db_path(args.data_dir))
+
+    # v3 redefined coverage to include NO_DATE; the GSV pure-SQL path below is
+    # no longer correct. Refuse rather than silently regress GSV coverage.
+    schema_version = conn.execute("PRAGMA user_version").fetchone()[0]
+    if schema_version >= 3:
+        print("This script is superseded on schema v3+. "
+              "Use scripts/recompute_run_stats.py instead.")
+        return 1
 
     # ── GSV: one row per grid point, recompute from stored counters ──────
     gsv_rows = conn.execute(

--- a/scripts/recompute_run_stats.py
+++ b/scripts/recompute_run_stats.py
@@ -1,0 +1,133 @@
+"""
+One-shot recompute of every run's stored stats from its CSV, under the
+current analysis definitions (schema v3).
+
+v3 changed what "present imagery" means: a pano the provider returned but
+whose capture date we couldn't read (status NO_DATE) now counts toward both
+coverage and pano totals, instead of sitting in the status_other error
+bucket (see analysis.PRESENT_STATUSES). Because the pre-v3 catalog folded
+NO_DATE into status_other, the corrected numbers cannot be recovered with
+pure SQL — every run's CSV is reloaded and re-summarized with
+analysis.calculate_run_stats, the same function the live pipeline uses.
+
+Columns refreshed per run: total_points, status_ok, status_no_date,
+status_zero_results, status_other, unique_panos, unique_google_panos,
+coverage_rate_pct, oldest/newest_capture_date, median_pano_age_years.
+
+Per-run JSON summaries are NOT regenerated (they refresh on each city's next
+run); the aggregate cities.json.gz IS regenerated since the overview site
+reads coverage from it.
+
+Idempotent: a run whose stored stats already match is left untouched. Runs
+whose CSV is missing (skipped, reported) keep their existing values.
+
+Usage:
+    python scripts/recompute_run_stats.py            # dry run
+    python scripts/recompute_run_stats.py --execute  # apply
+"""
+
+import argparse
+import logging
+import math
+import os
+import sys
+from datetime import date
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from gsv_metadata_tracker import db  # noqa: E402
+from gsv_metadata_tracker.analysis import calculate_run_stats  # noqa: E402
+from gsv_metadata_tracker.fileutils import load_city_csv_file  # noqa: E402
+from gsv_metadata_tracker.json_summarizer import generate_aggregate_v2  # noqa: E402
+from gsv_metadata_tracker.paths import get_default_data_dir  # noqa: E402
+
+logging.basicConfig(level=logging.INFO, format='%(levelname)s %(message)s')
+logger = logging.getLogger(__name__)
+
+# Stat columns owned by calculate_run_stats that this script refreshes.
+STAT_COLUMNS = (
+    'total_points', 'status_ok', 'status_no_date', 'status_zero_results',
+    'status_other', 'unique_panos', 'unique_google_panos',
+    'coverage_rate_pct', 'oldest_capture_date', 'newest_capture_date',
+    'median_pano_age_years',
+)
+
+
+def _equalish(a, b) -> bool:
+    """Compare stored vs recomputed values, tolerant of float noise/None."""
+    if a is None or b is None:
+        return a is b or a == b
+    if isinstance(a, float) or isinstance(b, float):
+        return math.isclose(float(a), float(b), rel_tol=0, abs_tol=1e-9)
+    return a == b
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description='Recompute stored per-run stats from CSVs (schema v3: '
+                    'NO_DATE counts as present imagery)')
+    parser.add_argument('--data-dir', default=get_default_data_dir())
+    parser.add_argument('--execute', action='store_true',
+                        help='Apply changes (default is a dry-run report)')
+    parser.add_argument('--no-publish-json', action='store_true',
+                        help='Skip regenerating the aggregate cities.json.gz')
+    args = parser.parse_args()
+
+    conn = db.connect(db.get_default_db_path(args.data_dir))
+
+    rows = conn.execute(
+        """SELECT run_id, city_id, provider, run_date, csv_filename,
+                  total_points, status_ok, status_no_date, status_zero_results,
+                  status_other, unique_panos, unique_google_panos,
+                  coverage_rate_pct, oldest_capture_date, newest_capture_date,
+                  median_pano_age_years
+           FROM runs ORDER BY city_id, provider, run_date""").fetchall()
+
+    updates = []       # (run_id, {col: value})
+    missing = 0
+    for r in rows:
+        csv_path = os.path.join(args.data_dir, r['csv_filename'])
+        if not os.path.exists(csv_path):
+            logger.warning(f"CSV missing, skipping: {r['csv_filename']}")
+            missing += 1
+            continue
+        df = load_city_csv_file(csv_path)
+        stats = calculate_run_stats(
+            df, date.fromisoformat(r['run_date']), provider=r['provider'])
+        changed = {c: stats[c] for c in STAT_COLUMNS
+                   if not _equalish(r[c], stats[c])}
+        if changed:
+            updates.append((r['run_id'], changed))
+            nd = stats['status_no_date']
+            cov_old = r['coverage_rate_pct']
+            cov_new = stats['coverage_rate_pct']
+            print(f"  {r['city_id']} [{r['provider']}] {r['run_date']}: "
+                  f"coverage {('NULL' if cov_old is None else f'{cov_old:.1f}%')}"
+                  f" -> {cov_new:.1f}%, unique_panos "
+                  f"{r['unique_panos']} -> {stats['unique_panos']}, "
+                  f"status_no_date -> {nd}")
+
+    print(f"\n{len(rows)} runs scanned, {missing} skipped (missing CSV), "
+          f"{len(updates)} would change")
+
+    if not args.execute:
+        print("\nDry run complete. Re-run with --execute to apply.")
+        return 0
+
+    with conn:
+        for run_id, changed in updates:
+            assignments = ', '.join(f"{c} = ?" for c in changed)
+            conn.execute(
+                f"UPDATE runs SET {assignments} WHERE run_id = ?",
+                (*changed.values(), run_id))
+
+    print(f"\nUpdated {len(updates)} runs.")
+    if not args.no_publish_json:
+        generate_aggregate_v2(conn, args.data_dir)
+        print(f"Regenerated aggregate: "
+              f"{os.path.join(args.data_dir, 'cities.json.gz')}")
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -34,6 +34,8 @@ class TestCalculateCoverageStats:
         assert abs(cov.coverage_rate - 60.0) < 1e-9
 
     def test_error_rows_count_as_error_points(self):
+        # A NO_DATE-only point holds present-but-dateless imagery, so it
+        # counts as covered; only genuine errors (REQUEST_DENIED) are errors.
         ts = '2026-01-15T12:00:00+00:00'
         df = pd.DataFrame([
             (44.000, -121.0, ts, 44.0001, -121.0001, 'a', '2020-01-01',
@@ -42,13 +44,15 @@ class TestCalculateCoverageStats:
              'ZERO_RESULTS'),
             (44.002, -121.0, ts, None, None, None, None, None,
              'REQUEST_DENIED'),
-            (44.003, -121.0, ts, None, None, None, None, None, 'NO_DATE'),
+            (44.003, -121.0, ts, 44.0031, -121.0031, 'd', None,
+             '© Google', 'NO_DATE'),
         ], columns=COLUMNS)
         cov = calculate_coverage_stats(df)
-        assert cov.num_points_with_panos == 1
-        assert cov.num_points_without_panos == 1
-        assert cov.num_points_with_errors == 2
-        assert abs(cov.coverage_rate - 25.0) < 1e-9
+        assert cov.num_points_with_panos == 2   # OK + NO_DATE
+        assert cov.num_points_without_panos == 1  # ZERO_RESULTS
+        assert cov.num_points_with_errors == 1    # REQUEST_DENIED
+        assert cov.num_points_with_unique_pano_ids == 2  # dateless pano counts
+        assert abs(cov.coverage_rate - 50.0) < 1e-9
 
     def test_mapillary_census_rows_count_grid_points_once(self):
         # 6 panos on 2 grid points (3 rows each) + 1 empty point:
@@ -92,11 +96,12 @@ class TestCatalogedCoverageRate:
         df = make_city_df([('a', '2020-01-01'), ('a', '2020-01-01'),
                            ('b', '2021-01-01')], n_empty=2)
         stats = calculate_run_stats(df, date(2026, 1, 15))
-        # For GSV (one row per point) this equals status_ok / total_points,
-        # which is exactly what scripts/recompute_coverage_rates.py applies
+        # For GSV (one row per point) with no NO_DATE panos this equals
+        # (status_ok + status_no_date) / total_points == status_ok / total.
         assert abs(stats['coverage_rate_pct'] - 60.0) < 1e-9
         assert abs(stats['coverage_rate_pct']
-                   - 100.0 * stats['status_ok'] / stats['total_points']) < 1e-9
+                   - 100.0 * (stats['status_ok'] + stats['status_no_date'])
+                   / stats['total_points']) < 1e-9
 
     def test_run_stats_store_point_coverage_for_mapillary(self):
         df = make_mapillary_city_df(
@@ -107,6 +112,82 @@ class TestCatalogedCoverageRate:
         # rate (6 OK rows / 7 rows)
         assert stats['status_ok'] == 6 and stats['total_points'] == 7
         assert abs(stats['coverage_rate_pct'] - 100 * 2 / 3) < 1e-9
+
+
+class TestNoDateCountsAsPresent:
+    """A pano the provider returned but couldn't date (NO_DATE) is present
+    imagery: it counts toward coverage and pano totals, never toward age
+    stats, and is not an error point (schema v3)."""
+
+    def _gsv_df_with_no_date(self):
+        # 1 dated OK pano, 1 dateless NO_DATE pano (both © Google), 1 empty
+        ts = '2026-01-15T12:00:00+00:00'
+        return pd.DataFrame([
+            (44.000, -121.0, ts, 44.0001, -121.0001, 'ok1', '2020-06-01',
+             '© Google', 'OK'),
+            (44.001, -121.0, ts, 44.0011, -121.0011, 'nd1', None,
+             '© Google', 'NO_DATE'),
+            (44.002, -121.0, ts, None, None, None, None, None, 'ZERO_RESULTS'),
+        ], columns=COLUMNS)
+
+    def test_run_stats_counts_no_date_as_pano_and_coverage(self):
+        stats = calculate_run_stats(self._gsv_df_with_no_date(),
+                                    date(2026, 1, 15))
+        assert stats['status_ok'] == 1
+        assert stats['status_no_date'] == 1
+        assert stats['status_zero_results'] == 1
+        assert stats['status_other'] == 0
+        assert stats['unique_panos'] == 2         # OK + NO_DATE both counted
+        assert stats['unique_google_panos'] == 2  # both © Google
+        assert abs(stats['coverage_rate_pct'] - 100 * 2 / 3) < 1e-9
+
+    def test_no_date_pano_excluded_from_age_stats(self):
+        stats = calculate_run_stats(self._gsv_df_with_no_date(),
+                                    date(2026, 1, 15))
+        # Age reflects only the single dated pano (2020-06-01); the dateless
+        # pano must not skew or nullify it.
+        assert stats['median_pano_age_years'] is not None
+        assert stats['oldest_capture_date'] == stats['newest_capture_date']
+        assert stats['oldest_capture_date'].startswith('2020-06-01')
+
+    def test_pano_stats_total_and_histogram(self):
+        results = calculate_pano_stats(self._gsv_df_with_no_date(),
+                                       pd.Timestamp('2026-01-15'))
+        # Website headline pano count is sourced from here — must include the
+        # dateless pano.
+        assert results.duplicate_stats.total_unique_panos == 2
+        # Capture-year histogram is date-based, so it sees only the OK pano.
+        assert results.yearly_distribution.counts == {2020: 1}
+
+    def test_point_with_only_no_date_is_covered_not_error(self):
+        # A grid point whose sole pano is dateless is covered, not an error.
+        ts = '2026-01-15T12:00:00+00:00'
+        df = pd.DataFrame([
+            (44.000, -121.0, ts, 44.0001, -121.0001, 'nd1', None,
+             '© Google', 'NO_DATE'),
+            (44.001, -121.0, ts, None, None, None, None, None, 'ZERO_RESULTS'),
+        ], columns=COLUMNS)
+        cov = calculate_coverage_stats(df)
+        assert cov.num_points_with_panos == 1
+        assert cov.num_points_with_errors == 0
+        assert cov.num_points_with_unique_pano_ids == 1
+        assert abs(cov.coverage_rate - 50.0) < 1e-9
+
+    def test_dateless_mapillary_pano_counts_in_census(self):
+        # Mapillary census: a point with 2 panos, one of them dateless, still
+        # contributes both panos to the unique count and is covered.
+        ts = '2026-01-15T12:00:00+00:00'
+        df = pd.DataFrame([
+            (44.0, -121.0, ts, 44.0001, -121.0001, 'm1', '2022-01-01',
+             '© Mapillary contributor 1', 'OK'),
+            (44.0, -121.0, ts, 44.0002, -121.0002, 'm2', None,
+             '© Mapillary contributor 2', 'NO_DATE'),
+        ], columns=COLUMNS)
+        stats = calculate_run_stats(df, date(2026, 1, 15), provider='mapillary')
+        assert stats['unique_panos'] == 2
+        assert stats['status_no_date'] == 1
+        assert stats['unique_google_panos'] is None  # non-GSV
+        assert abs(stats['coverage_rate_pct'] - 100.0) < 1e-9
 
 
 class TestPanoStatsCoverage:

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -76,6 +76,26 @@ def test_runs_ordering_and_uniqueness(conn, city):
                         csv_filename='c.csv.gz')
 
 
+def test_register_run_round_trips_status_no_date(conn, city):
+    rid = db.register_run(conn, city_id=city, run_date=date(2026, 4, 1),
+                          csv_filename='a.csv.gz', total_points=10,
+                          status_ok=6, status_no_date=2, status_zero_results=2,
+                          status_other=0, unique_panos=8, unique_google_panos=8,
+                          coverage_rate_pct=80.0)
+    run = db.get_latest_run(conn, city)
+    assert run.run_id == rid
+    assert run.status_no_date == 2          # new v4 column persists
+    assert run.status_ok == 6 and run.unique_panos == 8
+    assert abs(run.coverage_rate_pct - 80.0) < 1e-9
+
+
+def test_register_run_status_no_date_defaults_null(conn, city):
+    # Callers that omit status_no_date (e.g. legacy paths) store NULL, not 0.
+    db.register_run(conn, city_id=city, run_date=date(2026, 4, 1),
+                    csv_filename='a.csv.gz')
+    assert db.get_latest_run(conn, city).status_no_date is None
+
+
 def test_diff_storage(conn, city):
     r1 = db.register_run(conn, city_id=city, run_date=date(2026, 4, 1),
                          csv_filename='a.csv.gz')
@@ -290,10 +310,14 @@ def test_migrate_v1_to_v2(tmp_path):
 
     conn = db.connect(db_path)  # triggers the migration (v1 -> current)
     assert conn.execute("PRAGMA user_version").fetchone()[0] == db.SCHEMA_VERSION
+    # v4 added status_no_date; a migrated legacy run has it as NULL (unknown)
+    cols = {r[1] for r in conn.execute("PRAGMA table_info(runs)").fetchall()}
+    assert 'status_no_date' in cols
 
     run = db.get_latest_run(conn, 'bend--or')
     assert run.run_id == 7 and run.provider == 'gsv'
     assert run.unique_panos == 100 and run.unique_google_panos == 90
+    assert run.status_no_date is None
     assert db.get_api_usage(conn, date(2026, 4, 1)) == 12345
     row = conn.execute(
         "SELECT provider, day_of_cycle FROM schedule_state").fetchone()

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -5,7 +5,21 @@ from datetime import date
 import pandas as pd
 
 from gsv_metadata_tracker.diff import compute_run_diff, generate_diff_filename
-from tests.conftest import make_city_df
+from tests.conftest import COLUMNS, make_city_df
+
+
+def _two_point_df(point_b_status, point_b_pano, point_b_date):
+    """Grid of two points: A always holds an OK pano; B varies by status."""
+    ts = '2026-01-15T12:00:00+00:00'
+    rows = [(44.000, -121.0, ts, 44.0001, -121.0001, 'a', '2020-01-01',
+             '© Google', 'OK')]
+    if point_b_status == 'ZERO_RESULTS':
+        rows.append((44.001, -121.0, ts, None, None, None, None, None,
+                     'ZERO_RESULTS'))
+    else:
+        rows.append((44.001, -121.0, ts, 44.0011, -121.0011, point_b_pano,
+                     point_b_date, '© Google', point_b_status))
+    return pd.DataFrame(rows, columns=COLUMNS)
 
 
 def test_no_changes_between_identical_runs():
@@ -40,6 +54,26 @@ def test_coverage_transitions_on_aligned_grid():
     assert d.grid_aligned
     assert d.points_gained_coverage == 1 and d.points_lost_coverage == 0
     assert abs(d.coverage_delta_pct - 100 / 3) < 1e-9
+
+
+def test_no_date_point_gains_coverage():
+    # Point B goes ZERO_RESULTS -> NO_DATE: dateless imagery appeared, so the
+    # point is now covered (schema v3).
+    old = _two_point_df('ZERO_RESULTS', None, None)
+    new = _two_point_df('NO_DATE', 'b', None)
+    d = compute_run_diff(old, new)
+    assert d.grid_aligned
+    assert d.points_gained_coverage == 1 and d.points_lost_coverage == 0
+    assert abs(d.coverage_delta_pct - 50.0) < 1e-9
+
+
+def test_no_date_point_lost_coverage():
+    # Reverse: NO_DATE -> ZERO_RESULTS is a loss of coverage.
+    old = _two_point_df('NO_DATE', 'b', None)
+    new = _two_point_df('ZERO_RESULTS', None, None)
+    d = compute_run_diff(old, new)
+    assert d.points_gained_coverage == 0 and d.points_lost_coverage == 1
+    assert abs(d.coverage_delta_pct + 50.0) < 1e-9
 
 
 def test_misaligned_grid_skips_point_stats():

--- a/tests/test_json_v2.py
+++ b/tests/test_json_v2.py
@@ -5,6 +5,7 @@ import json
 import os
 from datetime import date
 
+import pandas as pd
 import pytest
 
 from gsv_metadata_tracker import db
@@ -12,7 +13,7 @@ from gsv_metadata_tracker.fileutils import load_city_csv_file
 from gsv_metadata_tracker.json_summarizer import (
     generate_aggregate_v2, generate_city_metadata_summary_as_json,
     sanitize_for_json)
-from tests.conftest import (make_city_df, make_mapillary_city_df,
+from tests.conftest import (COLUMNS, make_city_df, make_mapillary_city_df,
                             write_city_csv_gz)
 
 
@@ -47,6 +48,36 @@ def test_single_pano_city_emits_valid_json(data_dir):
         force_recreate_file=True, run_date=date(2026, 1, 15))
     data = strict_load(json_path)  # raises if NaN leaked
     assert data['all_panos']['age_stats']['stdev_pano_age_years'] is None
+
+
+def test_no_date_pano_counted_in_json(data_dir):
+    # End-to-end: a dateless (NO_DATE) pano must appear in the published pano
+    # total and coverage, but not perturb the age stats (schema v3).
+    ts = '2026-01-15T12:00:00+00:00'
+    df_raw = pd.DataFrame([
+        (44.000, -121.0, ts, 44.0001, -121.0001, 'ok1', '2020-01-15',
+         '© Google', 'OK'),
+        (44.001, -121.0, ts, 44.0011, -121.0011, 'nd1', None,
+         '© Google', 'NO_DATE'),
+        (44.002, -121.0, ts, None, None, None, None, None, 'ZERO_RESULTS'),
+    ], columns=COLUMNS)
+    csv_path = os.path.join(
+        data_dir, 'nd--city_width_100_height_100_step_20_2026-01-15.csv.gz')
+    write_city_csv_gz(df_raw, csv_path)
+    df = load_city_csv_file(csv_path)
+    json_path = generate_city_metadata_summary_as_json(
+        csv_path, df, 'ND', None, 'Testland', 100, 100, 20,
+        force_recreate_file=True, run_date=date(2026, 1, 15))
+    data = strict_load(json_path)
+
+    # Both panos counted; Google subset counts the dateless © Google pano too
+    assert data['all_panos']['duplicate_stats']['total_unique_panos'] == 2
+    assert data['google_panos']['duplicate_stats']['total_unique_panos'] == 2
+    # Coverage: 2 of 3 grid points hold imagery
+    assert data['coverage']['coverage_rate'] == pytest.approx(100 * 2 / 3)
+    # Age stats derive from the single dated pano (captured exactly 6y before)
+    assert data['all_panos']['age_stats']['avg_pano_age_years'] == \
+        pytest.approx(6.0, abs=0.01)
 
 
 def test_v2_fields_and_age_pinned_to_run_date(data_dir):


### PR DESCRIPTION
Fixes audit bugs **B5** and **B11**.

Mapillary panos with bogus/absent timestamps were bucketed as `NO_DATE` and
excluded from coverage (analysis counted only `status=='OK'`), so a grid point
whose **only** panos were dateless landed in the "errors" bucket rather than
coverage — undercounting Mapillary coverage and muddying cross-provider
comparison (**B5**). The same first-row dedup could drop a later `OK` behind a
leading `NO_DATE` in diff grid-transition stats (**B11**).

**Changes**
- New `runs.status_no_date` column (**schema v4**, additive `ADD COLUMN` with an
  idempotent migration).
- Count present-but-dateless panos toward coverage and pano totals across
  `analysis.py`, `diff.py`, and `json_summarizer.py`.
- `scripts/recompute_run_stats.py` to backfill the column + recompute
  coverage/unique_panos on existing runs.
- Tests (`test_coverage.py` + additions to `test_db.py`/`test_diff.py`/`test_json_v2.py`).

**Rebase note:** originally authored as schema v3, but #108 (historical-dates)
landed v3 first (`history_harvests`). Rebased onto main and renumbered to **v4**;
the migration chains after v3 and is idempotent (skips `ADD COLUMN` when the
column already exists, e.g. a catalog created fresh at the current schema).

Full suite green locally: **229 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)