### PR TITLE
Add GitHub Actions CI and Ruff lint/format tooling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,50 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+# Cancel superseded runs on the same ref (e.g. rapid pushes to a PR).
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: Lint (ruff)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: requirements-dev.txt
+      - run: pip install ruff==0.15.21
+      - name: ruff check
+        run: ruff check --output-format=github .
+      - name: ruff format --check
+        run: ruff format --check .
+
+  test:
+    name: Tests (py${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12", "3.13"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: requirements-dev.txt
+      - run: pip install -r requirements-dev.txt
+      - name: pytest
+        run: pytest

--- a/check_status_codes.py
+++ b/check_status_codes.py
@@ -1,11 +1,13 @@
-import pandas as pd
 import argparse
-import sys
 import os
+import sys
 from pathlib import Path
-from typing import Tuple, Optional, List
+
+import pandas as pd
 from tabulate import tabulate
+
 from gsv_metadata_tracker.analysis import analyze_gsv_status
+
 
 def format_status_table(df: pd.DataFrame) -> str:
     """Format status code counts and percentages as a table."""
@@ -13,10 +15,13 @@ def format_status_table(df: pd.DataFrame) -> str:
     rows = [
         [status, f"{count:,}", f"{stats['status_percentages'][status]:.1f}%"]
         for status, count in sorted(
-            stats['status_counts'].items(), key=lambda x: x[1], reverse=True)
+            stats["status_counts"].items(), key=lambda x: x[1], reverse=True
+        )
     ]
-    return tabulate(rows, headers=["Status", "Count", "Percent"],
-                    tablefmt="simple", numalign="right")
+    return tabulate(
+        rows, headers=["Status", "Count", "Percent"], tablefmt="simple", numalign="right"
+    )
+
 
 def format_record_counts_table(valid_records: int, malformed_count: int) -> str:
     """Format valid/malformed record counts as a table."""
@@ -24,27 +29,29 @@ def format_record_counts_table(valid_records: int, malformed_count: int) -> str:
         ["Valid records", f"{valid_records:,}"],
         ["Malformed lines", f"{malformed_count:,}"],
     ]
-    return tabulate(rows, headers=["Metric", "Count"],
-                    tablefmt="simple", numalign="right")
+    return tabulate(rows, headers=["Metric", "Count"], tablefmt="simple", numalign="right")
 
-def format_query_limit_table(files_with_limits: List[Tuple[str, int]]) -> str:
+
+def format_query_limit_table(files_with_limits: list[tuple[str, int]]) -> str:
     """Format files containing OVER_QUERY_LIMIT statuses as a table."""
     rows = [[path, f"{count:,}"] for path, count in files_with_limits]
-    return tabulate(rows, headers=["File", "OVER_QUERY_LIMIT count"],
-                    tablefmt="simple", numalign="right")
+    return tabulate(
+        rows, headers=["File", "OVER_QUERY_LIMIT count"], tablefmt="simple", numalign="right"
+    )
 
-def read_csv_file(filepath: str) -> Tuple[Optional[pd.DataFrame], List[str]]:
+
+def read_csv_file(filepath: str) -> tuple[pd.DataFrame | None, list[str]]:
     """
     Read a GSV metadata file (CSV/gzipped CSV) and handle malformed lines.
-    
+
     Args:
         filepath: Path to the file to read
-        
+
     Returns:
         Tuple of (DataFrame or None if error, list of malformed lines)
     """
     malformed_lines = []
-    
+
     try:
         # Custom handler for bad lines
         def bad_line_handler(bad_line):
@@ -52,74 +59,67 @@ def read_csv_file(filepath: str) -> Tuple[Optional[pd.DataFrame], List[str]]:
             return None
 
         # Read the file with appropriate compression based on extension
-        compression = 'gzip' if filepath.lower().endswith('.gz') else None
+        compression = "gzip" if filepath.lower().endswith(".gz") else None
         df = pd.read_csv(
-            filepath, 
-            compression=compression, 
-            on_bad_lines=bad_line_handler, 
-            engine='python'
+            filepath, compression=compression, on_bad_lines=bad_line_handler, engine="python"
         )
-        
+
         return df, malformed_lines
-        
+
     except Exception as e:
         print(f"Error reading file: {str(e)}")
         return None, malformed_lines
 
+
 def should_process_file(filepath: str) -> bool:
     """Check if the file should be processed based on its extension."""
-    if filepath.endswith('.json.gz'):
+    if filepath.endswith(".json.gz"):
         return False
-    
-    extensions = {'.gz', '.csv', '.downloading'}
+
+    extensions = {".gz", ".csv", ".downloading"}
     return Path(filepath).suffix.lower() in extensions
 
-def find_files_to_process(directory: str) -> List[str]:
+
+def find_files_to_process(directory: str) -> list[str]:
     """Find all GSV metadata files in directory and subdirectories."""
     files_to_process = []
-    
+
     for root, _, files in os.walk(directory):
         for file in files:
             filepath = os.path.join(root, file)
             if should_process_file(filepath):
                 files_to_process.append(filepath)
-    
+
     return sorted(files_to_process)
 
-def print_malformed_lines(malformed_lines: List[str]) -> None:
+
+def print_malformed_lines(malformed_lines: list[str]) -> None:
     """Print malformed lines in a readable format."""
     if not malformed_lines:
         return
-        
+
     print("\nMalformed Lines:")
     print("-" * 50)
     for i, line in enumerate(malformed_lines, 1):
         print(f"Line {i}: {line.strip()}")
 
+
 def main():
-    parser = argparse.ArgumentParser(
-        description='Analyze status codes in GSV metadata files.'
-    )
+    parser = argparse.ArgumentParser(description="Analyze status codes in GSV metadata files.")
+    parser.add_argument("paths", nargs="+", help="Paths to files and/or directories to analyze")
     parser.add_argument(
-        'paths', 
-        nargs='+', 
-        help='Paths to files and/or directories to analyze'
+        "--hide-malformed", action="store_true", help="Hide content of malformed lines"
     )
-    parser.add_argument(
-        '--hide-malformed',
-        action='store_true',
-        help='Hide content of malformed lines'
-    )
-    
+
     args = parser.parse_args()
-    
+
     # Find all files to process
     files_to_process = []
     for path in args.paths:
         if not os.path.exists(path):
             print(f"Error: Path not found: {path}")
             continue
-            
+
         if os.path.isdir(path):
             dir_files = find_files_to_process(path)
             if not dir_files:
@@ -130,14 +130,14 @@ def main():
                 files_to_process.append(path)
             else:
                 print(f"Skipping file with unsupported extension: {path}")
-    
+
     if not files_to_process:
         print("No files to process!")
         sys.exit(1)
-    
+
     # Remove duplicates and sort
     files_to_process = sorted(set(files_to_process))
-    
+
     # Track overall statistics
     overall_data = []
     files_with_query_limit = []
@@ -148,30 +148,31 @@ def main():
     for i, file_path in enumerate(files_to_process, 1):
         print(f"\nAnalyzing file {i} of {total_files}: {file_path}")
         print("=" * 50)
-        
+
         df, malformed_lines = read_csv_file(file_path)
-        
+
         if df is not None:
             # Analyze and print status distribution
             print("\nStatus Code Distribution Across Queries:")
             print(format_status_table(df))
-            
+
             # Print record counts
             print("\nRecord Counts:")
-            print(format_record_counts_table(
-                valid_records=len(df),
-                malformed_count=len(malformed_lines)
-            ))
-            
+            print(
+                format_record_counts_table(
+                    valid_records=len(df), malformed_count=len(malformed_lines)
+                )
+            )
+
             # Track statistics for overall summary
             overall_data.append(df)
             total_malformed += len(malformed_lines)
-            
+
             # Track files with OVER_QUERY_LIMIT
-            limit_count = len(df[df['status'] == 'OVER_QUERY_LIMIT'])
+            limit_count = len(df[df["status"] == "OVER_QUERY_LIMIT"])
             if limit_count > 0:
                 files_with_query_limit.append((file_path, limit_count))
-            
+
             # Show malformed lines if requested
             if not args.hide_malformed:
                 print_malformed_lines(malformed_lines)
@@ -180,27 +181,29 @@ def main():
     if len(files_to_process) > 1 and overall_data:
         print("\nOVERALL SUMMARY")
         print("=" * 50)
-        
+
         # Combine all DataFrames
         combined_df = pd.concat(overall_data, ignore_index=True)
-        
+
         print(f"\nProcessed Files: {total_files}")
-        
+
         # Print overall record counts
         print("\nTotal Record Counts:")
-        print(format_record_counts_table(
-            valid_records=len(combined_df),
-            malformed_count=total_malformed
-        ))
-        
+        print(
+            format_record_counts_table(
+                valid_records=len(combined_df), malformed_count=total_malformed
+            )
+        )
+
         # Print overall status distribution
         print("\nOverall Status Code Distribution:")
         print(format_status_table(combined_df))
-        
+
         # Print files with query limits
         if files_with_query_limit:
             print("\nFiles with OVER_QUERY_LIMIT status:")
             print(format_query_limit_table(files_with_query_limit))
+
 
 if __name__ == "__main__":
     main()

--- a/cities/us_census_city_analyzer.py
+++ b/cities/us_census_city_analyzer.py
@@ -1,204 +1,248 @@
-import pandas as pd
-import matplotlib.pyplot as plt
-import seaborn as sns
-import numpy as np
-from typing import Tuple, Dict, Any
-import logging
 import argparse
+import logging
+from typing import Any
 
+import pandas as pd
 
 logger = logging.getLogger(__name__)
 
 map_state_to_capital = {
-    'Alabama': 'Montgomery', 'Alaska': 'Juneau', 'Arizona': 'Phoenix', 'Arkansas': 'Little Rock',
-    'California': 'Sacramento', 'Colorado': 'Denver', 'Connecticut': 'Hartford', 'Delaware': 'Dover',
-    'Florida': 'Tallahassee', 'Georgia': 'Atlanta', 'Hawaii': 'Honolulu', 'Idaho': 'Boise',
-    'Illinois': 'Springfield', 'Indiana': 'Indianapolis', 'Iowa': 'Des Moines', 'Kansas': 'Topeka',
-    'Kentucky': 'Frankfort', 'Louisiana': 'Baton Rouge', 'Maine': 'Augusta', 'Maryland': 'Annapolis',
-    'Massachusetts': 'Boston', 'Michigan': 'Lansing', 'Minnesota': 'St. Paul', 'Mississippi': 'Jackson',
-    'Missouri': 'Jefferson City', 'Montana': 'Helena', 'Nebraska': 'Lincoln', 'Nevada': 'Carson City',
-    'New Hampshire': 'Concord', 'New Jersey': 'Trenton', 'New Mexico': 'Santa Fe', 'New York': 'Albany',
-    'North Carolina': 'Raleigh', 'North Dakota': 'Bismarck', 'Ohio': 'Columbus', 'Oklahoma': 'Oklahoma City',
-    'Oregon': 'Salem', 'Pennsylvania': 'Harrisburg', 'Rhode Island': 'Providence', 'South Carolina': 'Columbia',
-    'South Dakota': 'Pierre', 'Tennessee': 'Nashville', 'Texas': 'Austin', 'Utah': 'Salt Lake City',
-    'Vermont': 'Montpelier', 'Virginia': 'Richmond', 'Washington': 'Olympia', 'West Virginia': 'Charleston',
-    'Wisconsin': 'Madison', 'Wyoming': 'Cheyenne'
+    "Alabama": "Montgomery",
+    "Alaska": "Juneau",
+    "Arizona": "Phoenix",
+    "Arkansas": "Little Rock",
+    "California": "Sacramento",
+    "Colorado": "Denver",
+    "Connecticut": "Hartford",
+    "Delaware": "Dover",
+    "Florida": "Tallahassee",
+    "Georgia": "Atlanta",
+    "Hawaii": "Honolulu",
+    "Idaho": "Boise",
+    "Illinois": "Springfield",
+    "Indiana": "Indianapolis",
+    "Iowa": "Des Moines",
+    "Kansas": "Topeka",
+    "Kentucky": "Frankfort",
+    "Louisiana": "Baton Rouge",
+    "Maine": "Augusta",
+    "Maryland": "Annapolis",
+    "Massachusetts": "Boston",
+    "Michigan": "Lansing",
+    "Minnesota": "St. Paul",
+    "Mississippi": "Jackson",
+    "Missouri": "Jefferson City",
+    "Montana": "Helena",
+    "Nebraska": "Lincoln",
+    "Nevada": "Carson City",
+    "New Hampshire": "Concord",
+    "New Jersey": "Trenton",
+    "New Mexico": "Santa Fe",
+    "New York": "Albany",
+    "North Carolina": "Raleigh",
+    "North Dakota": "Bismarck",
+    "Ohio": "Columbus",
+    "Oklahoma": "Oklahoma City",
+    "Oregon": "Salem",
+    "Pennsylvania": "Harrisburg",
+    "Rhode Island": "Providence",
+    "South Carolina": "Columbia",
+    "South Dakota": "Pierre",
+    "Tennessee": "Nashville",
+    "Texas": "Austin",
+    "Utah": "Salt Lake City",
+    "Vermont": "Montpelier",
+    "Virginia": "Richmond",
+    "Washington": "Olympia",
+    "West Virginia": "Charleston",
+    "Wisconsin": "Madison",
+    "Wyoming": "Cheyenne",
 }
+
 
 def setup_logger(log_level):
     """
     Sets up global logging to both console and file.
-    
+
     Args:
         log_level (str): Desired logging level (DEBUG, INFO, WARNING, ERROR, CRITICAL)
     """
-    
+
     # Convert string level to logging constant
     numeric_level = getattr(logging, log_level.upper(), None)
     if not isinstance(numeric_level, int):
-        raise ValueError(f'Invalid log level: {log_level}')
-    
+        raise ValueError(f"Invalid log level: {log_level}")
+
     logger.setLevel(numeric_level)
-    
+
     # Create formatter
-    formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s')
-    
+    formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
+
     # Create console handler
     console_handler = logging.StreamHandler()
     console_handler.setLevel(numeric_level)
     console_handler.setFormatter(formatter)
-    
+
     # Create file handler
-    file_handler = logging.FileHandler('us_census_city_selection.log')
+    file_handler = logging.FileHandler("us_census_city_selection.log")
     file_handler.setLevel(numeric_level)
     file_handler.setFormatter(formatter)
-    
+
     # Add handlers to logger
     logger.addHandler(console_handler)
     logger.addHandler(file_handler)
 
+
 def extract_city_state(geo_area):
     """
     Extracts city and state from geographic area string, removing classification suffixes.
-    
+
     Args:
         geo_area (str): Geographic area string (e.g., "Albany city, New York")
-        
+
     Returns:
         pd.Series: Series containing cleaned city name and state
     """
     try:
         # Split on the last comma
-        parts = geo_area.rsplit(', ', 1)
+        parts = geo_area.rsplit(", ", 1)
         if len(parts) != 2:
             logger.warning(f"Could not split city and state for: {geo_area}")
             return pd.Series([geo_area, None])
-        
+
         city, state = parts[0], parts[1]
-        
+
         # List of lowercase suffixes to remove
         suffixes = [
-            ' charter township',
-            ' unified government',
-            ' consolidated government',
-            ' metro township',
-            ' municipality',
-            ' borough',
-            ' village',
-            ' township',
-            ' city',
-            ' town'
+            " charter township",
+            " unified government",
+            " consolidated government",
+            " metro township",
+            " municipality",
+            " borough",
+            " village",
+            " township",
+            " city",
+            " town",
         ]
-        
+
         # Handle parenthetical cases first
-        if '(' in city and ')' in city:
+        if "(" in city and ")" in city:
             # Extract content within parentheses and rest of the name
-            main_part = city.split('(')[0].strip()
-            paren_part = city.split('(')[1].split(')')[0].strip()
+            main_part = city.split("(")[0].strip()
+            paren_part = city.split("(")[1].split(")")[0].strip()
             # Use the parenthetical part if it exists, otherwise use main part
             city = paren_part if paren_part else main_part
             logger.debug(f"Extracted '{city}' from parenthetical format in '{geo_area}'")
-        
+
         # Remove suffixes if they appear at the end of the city name
         # Only match exact lowercase suffixes
         original_city = city
         for suffix in suffixes:
             if city.endswith(suffix):
-                city = city[:-len(suffix)]
+                city = city[: -len(suffix)]
                 logger.debug(f"Removed suffix '{suffix}' from '{original_city}' to get '{city}'")
                 break
-        
+
         return pd.Series([city.strip(), state])
-        
+
     except Exception as e:
         logger.exception(f"Error processing {geo_area}: {str(e)}")
         return pd.Series([None, None])
+
 
 def clean_and_prepare_data(file_path):
     """
     Reads and prepares census data from Excel file for analysis.
     Logs parsing errors and problematic entries.
-    
+
     Args:
         file_path (str): Path to the census Excel file
-        
+
     Returns:
         pd.DataFrame: Cleaned and prepared DataFrame
     """
     logger.info("Starting data cleaning process...")
-    
+
     # Skip the first 4 rows and use custom column names
     df = pd.read_excel(
-        file_path, 
-        skiprows=4,
-        names=['Geographic Area', 'Est_Base', '2020', '2021', '2022', '2023']
+        file_path, skiprows=4, names=["Geographic Area", "Est_Base", "2020", "2021", "2022", "2023"]
     )
-    
+
     initial_rows = len(df)
     logger.info(f"Initially loaded {initial_rows} rows")
-    
+
     # Check for missing data and report specifics
-    for col in ['Geographic Area', '2023']:
+    for col in ["Geographic Area", "2023"]:
         missing = df[df[col].isna()]
         if not missing.empty:
             logger.warning(f"\nFound {len(missing)} rows with missing {col}:")
             for idx, row in missing.iterrows():
                 # Get the row number in Excel (accounting for header rows and 0-based index)
                 excel_row = idx + 5  # 4 header rows + 1 for 1-based Excel rows
-                if col == 'Geographic Area' and not pd.isna(row['2023']):
-                    logger.warning(f"Row {excel_row}: Missing city/state but has 2023 population of {row['2023']}")
-                elif col == '2023' and not pd.isna(row['Geographic Area']):
-                    logger.warning(f"Row {excel_row}: Missing 2023 population for {row['Geographic Area']}")
+                if col == "Geographic Area" and not pd.isna(row["2023"]):
+                    logger.warning(
+                        f"Row {excel_row}: Missing city/state but has 2023 population of {row['2023']}"
+                    )
+                elif col == "2023" and not pd.isna(row["Geographic Area"]):
+                    logger.warning(
+                        f"Row {excel_row}: Missing 2023 population for {row['Geographic Area']}"
+                    )
                 else:
                     logger.warning(f"Row {excel_row}: Complete empty row")
-    
+
     # Clean up any potential missing data
-    df = df.dropna(subset=['Geographic Area', '2023'])
+    df = df.dropna(subset=["Geographic Area", "2023"])
     rows_after_na = len(df)
     if rows_after_na < initial_rows:
         logger.info(f"\nRemoved {initial_rows - rows_after_na} rows with missing essential data")
-    
+
     # Apply the city/state extraction
-    df[['City', 'State']] = df['Geographic Area'].apply(extract_city_state)
-    
+    df[["City", "State"]] = df["Geographic Area"].apply(extract_city_state)
+
     # Remove any rows where we couldn't extract state properly
     rows_before_state = len(df)
-    df = df.dropna(subset=['State'])
+    df = df.dropna(subset=["State"])
     rows_after_state = len(df)
-    
+
     if rows_before_state > rows_after_state:
-        logger.warning(f"Removed {rows_before_state - rows_after_state} rows with invalid state data")
-    
+        logger.warning(
+            f"Removed {rows_before_state - rows_after_state} rows with invalid state data"
+        )
+
     # Convert population columns to numeric, handling any potential non-numeric values
-    for col in ['2020', '2021', '2022', '2023']:
+    for col in ["2020", "2021", "2022", "2023"]:
         try:
-            numeric_series = pd.to_numeric(df[col], errors='coerce')
+            numeric_series = pd.to_numeric(df[col], errors="coerce")
             invalid_rows = df[numeric_series.isna() & df[col].notna()]
             if not invalid_rows.empty:
-                for idx, row in invalid_rows.iterrows():
+                for _idx, row in invalid_rows.iterrows():
                     logger.warning(
                         f"Non-numeric value in {col} for {row['Geographic Area']}: {row[col]}"
                     )
             df[col] = numeric_series
         except Exception as e:
             logger.error(f"Error converting {col} to numeric: {str(e)}")
-    
+
     # Print final statistics
     logger.info(f"\nFinal dataset contains {len(df)} rows")
     logger.info(f"States found: {', '.join(sorted(df['State'].unique()))}")
-    
+
     return df
 
-def select_study_cities(df: pd.DataFrame, cities_per_quartile: int = 5) -> Tuple[pd.DataFrame, Dict[str, Any]]:
+
+def select_study_cities(
+    df: pd.DataFrame, cities_per_quartile: int = 5
+) -> tuple[pd.DataFrame, dict[str, Any]]:
     """
     Selects cities for study using a stratified sampling approach:
     - Automatically includes state capital and largest city
     - Randomly samples additional cities from each population quartile
-    
+
     Args:
         df (pd.DataFrame): Prepared census DataFrame with City, State, and population columns
         cities_per_quartile (int): Number of cities to randomly select from each quartile
-        
+
     Returns:
         pd.DataFrame: Selected cities with their selection method and quartile
         dict: Statistics about the selection process
@@ -206,193 +250,204 @@ def select_study_cities(df: pd.DataFrame, cities_per_quartile: int = 5) -> Tuple
 
     if cities_per_quartile < 1:
         raise ValueError("cities_per_quartile must be at least 1")
-    
+
     # Create empty DataFrame to store selections
     selected_cities = pd.DataFrame()
     selection_stats = {}
-    
-    for state in df['State'].unique():
-        state_df = df[df['State'] == state].copy()
+
+    for state in df["State"].unique():
+        state_df = df[df["State"] == state].copy()
         logger.info(f"Selecting cities for {state}...")
 
         state_df = state_df.reset_index(drop=True)  # Reset index for state DataFrame
-        
+
         # Skip if insufficient data
         min_cities_required = 4 * cities_per_quartile + 2
-        if len(state_df) < min_cities_required: 
-            logger.warning(f"Warning: Insufficient data for {state} ({len(state_df)} cities)."
-                  f"With {cities_per_quartile} cities per quartile, need at least {min_cities_required} cities per state.")
+        if len(state_df) < min_cities_required:
+            logger.warning(
+                f"Warning: Insufficient data for {state} ({len(state_df)} cities)."
+                f"With {cities_per_quartile} cities per quartile, need at least {min_cities_required} cities per state."
+            )
             continue
-            
+
         state_selections = pd.DataFrame()
-        
+
         # 1. Add state capital
-        capital_city_name = map_state_to_capital.get(state) 
-        if capital_city_name: 
-            capital_city = state_df[state_df['City'] == capital_city_name] 
-            capital_city = capital_city.assign(selection_method='capital')
-            state_selections = pd.concat([state_selections, capital_city], ignore_index=True)  # Reset index during concat
-            state_df = state_df[state_df['City'] != capital_city_name].reset_index(drop=True)  # Reset index after filtering
-        
+        capital_city_name = map_state_to_capital.get(state)
+        if capital_city_name:
+            capital_city = state_df[state_df["City"] == capital_city_name]
+            capital_city = capital_city.assign(selection_method="capital")
+            state_selections = pd.concat(
+                [state_selections, capital_city], ignore_index=True
+            )  # Reset index during concat
+            state_df = state_df[state_df["City"] != capital_city_name].reset_index(
+                drop=True
+            )  # Reset index after filtering
+
         # 2. Add largest city by population
-        top_2_cities = state_df.nlargest(2, '2023').copy()
-        
+        top_2_cities = state_df.nlargest(2, "2023").copy()
+
         # Check if capital was found and is the largest city
         if not capital_city.empty and capital_city.index[0] == top_2_cities.index[0]:
             largest_city = top_2_cities.iloc[[1]]
         else:
             largest_city = top_2_cities.iloc[[0]]
-    
-        largest_city = largest_city.assign(selection_method='largest' if not capital_city.empty and capital_city.index[0] != top_2_cities.index[0] else 'largest (2nd)')
-        state_selections = pd.concat([state_selections, largest_city], ignore_index=True)  # Reset index during concat
-        
+
+        largest_city = largest_city.assign(
+            selection_method="largest"
+            if not capital_city.empty and capital_city.index[0] != top_2_cities.index[0]
+            else "largest (2nd)"
+        )
+        state_selections = pd.concat(
+            [state_selections, largest_city], ignore_index=True
+        )  # Reset index during concat
+
         # 3. Calculate quartiles for remaining cities
         remaining_cities = state_df[~state_df.index.isin(largest_city.index)].copy()
         remaining_cities = remaining_cities.reset_index(drop=True)  # Reset index after filtering
-        remaining_cities['population_quartile'] = pd.qcut(
-            remaining_cities['2023'], 
-            q=4, 
-            labels=['Q1', 'Q2', 'Q3', 'Q4']
+        remaining_cities["population_quartile"] = pd.qcut(
+            remaining_cities["2023"], q=4, labels=["Q1", "Q2", "Q3", "Q4"]
         )
-        
+
         # 4. Sample from each quartile
-        for quartile in ['Q1', 'Q2', 'Q3', 'Q4']:
-            quartile_cities = remaining_cities[
-                remaining_cities['population_quartile'] == quartile
-            ]
-            
+        for quartile in ["Q1", "Q2", "Q3", "Q4"]:
+            quartile_cities = remaining_cities[remaining_cities["population_quartile"] == quartile]
+
             # Sample cities (or take all if fewer than requested)
             sample_size = min(cities_per_quartile, len(quartile_cities))
             if sample_size > 0:
                 sampled = quartile_cities.sample(n=sample_size).copy()
-                sampled = sampled.assign(selection_method=f'random_{quartile}')
-                state_selections = pd.concat([state_selections, sampled], ignore_index=True)  # Reset index during concat
-        
+                sampled = sampled.assign(selection_method=f"random_{quartile}")
+                state_selections = pd.concat(
+                    [state_selections, sampled], ignore_index=True
+                )  # Reset index during concat
+
         # Store statistics
         selection_stats[state] = {
-            'total_selected': len(state_selections),
-            'largest_city': largest_city['City'].iloc[0],
-            'quartile_counts': state_selections['selection_method'].value_counts().to_dict()
+            "total_selected": len(state_selections),
+            "largest_city": largest_city["City"].iloc[0],
+            "quartile_counts": state_selections["selection_method"].value_counts().to_dict(),
         }
-        
+
         # Add to main selection DataFrame
-        selected_cities = pd.concat([selected_cities, state_selections], ignore_index=True)  # Reset index during final concat
-    
+        selected_cities = pd.concat(
+            [selected_cities, state_selections], ignore_index=True
+        )  # Reset index during final concat
+
     return selected_cities, selection_stats
+
 
 def analyze_selection_coverage(selected_cities, original_df):
     """
     Analyzes the coverage and representativeness of selected cities.
     Provides detailed statistics per state including capital and largest city populations,
     and quartile statistics.
-    
+
     Args:
         selected_cities (pd.DataFrame): DataFrame of selected cities
         original_df (pd.DataFrame): Original complete DataFrame
-        
+
     Returns:
         dict: Analysis metrics including detailed state-by-state analysis
     """
     analysis = {}
-    
+
     # Calculate population coverage
-    total_pop = original_df['2023'].sum()
-    selected_pop = selected_cities['2023'].sum()
-    
-    analysis['population_coverage'] = {
-        'total_population': total_pop,
-        'selected_population': selected_pop,
-        'coverage_percentage': (selected_pop / total_pop) * 100
+    total_pop = original_df["2023"].sum()
+    selected_pop = selected_cities["2023"].sum()
+
+    analysis["population_coverage"] = {
+        "total_population": total_pop,
+        "selected_population": selected_pop,
+        "coverage_percentage": (selected_pop / total_pop) * 100,
     }
-    
+
     # Analyze geographic distribution
-    analysis['geographic_distribution'] = {
-        'cities_per_state': selected_cities['State'].value_counts().to_dict(),
-        'total_states': len(selected_cities['State'].unique())
+    analysis["geographic_distribution"] = {
+        "cities_per_state": selected_cities["State"].value_counts().to_dict(),
+        "total_states": len(selected_cities["State"].unique()),
     }
-    
+
     # Analyze population size distribution
-    analysis['size_distribution'] = {
-        'mean_pop': selected_cities['2023'].mean(),
-        'median_pop': selected_cities['2023'].median(),
-        'min_pop': selected_cities['2023'].min(),
-        'max_pop': selected_cities['2023'].max()
+    analysis["size_distribution"] = {
+        "mean_pop": selected_cities["2023"].mean(),
+        "median_pop": selected_cities["2023"].median(),
+        "min_pop": selected_cities["2023"].min(),
+        "max_pop": selected_cities["2023"].max(),
     }
-    
+
     # Add detailed state analysis
-    analysis['state_details'] = {}
-    
-    for state in selected_cities['State'].unique():
-        state_selections = selected_cities[selected_cities['State'] == state]
-        
+    analysis["state_details"] = {}
+
+    for state in selected_cities["State"].unique():
+        state_selections = selected_cities[selected_cities["State"] == state]
+
         # Get capital city info
-        capital_city = state_selections[state_selections['selection_method'] == 'capital']
-        capital_pop = capital_city['2023'].iloc[0] if not capital_city.empty else None
-        
+        capital_city = state_selections[state_selections["selection_method"] == "capital"]
+        capital_pop = capital_city["2023"].iloc[0] if not capital_city.empty else None
+
         # Get largest/second largest city info
         largest_city = state_selections[
-            state_selections['selection_method'].isin(['largest', 'largest (2nd)'])
+            state_selections["selection_method"].isin(["largest", "largest (2nd)"])
         ]
-        largest_pop = largest_city['2023'].iloc[0] if not largest_city.empty else None
-        largest_name = largest_city['City'].iloc[0] if not largest_city.empty else None
-        largest_type = largest_city['selection_method'].iloc[0] if not largest_city.empty else None
-        
+        largest_pop = largest_city["2023"].iloc[0] if not largest_city.empty else None
+        largest_name = largest_city["City"].iloc[0] if not largest_city.empty else None
+        largest_type = largest_city["selection_method"].iloc[0] if not largest_city.empty else None
+
         # Calculate quartile statistics
         quartile_stats = {}
-        for quartile in ['Q1', 'Q2', 'Q3', 'Q4']:
+        for quartile in ["Q1", "Q2", "Q3", "Q4"]:
             quartile_cities = state_selections[
-                state_selections['selection_method'] == f'random_{quartile}'
+                state_selections["selection_method"] == f"random_{quartile}"
             ]
             if not quartile_cities.empty:
                 quartile_stats[quartile] = {
-                    'avg': quartile_cities['2023'].mean(),
-                    'median': quartile_cities['2023'].median(),
-                    'std': quartile_cities['2023'].std(),
-                    'count': len(quartile_cities)
+                    "avg": quartile_cities["2023"].mean(),
+                    "median": quartile_cities["2023"].median(),
+                    "std": quartile_cities["2023"].std(),
+                    "count": len(quartile_cities),
                 }
-        
-        analysis['state_details'][state] = {
-            'capital': {
-                'name': capital_city['City'].iloc[0] if not capital_city.empty else None,
-                'population': capital_pop
+
+        analysis["state_details"][state] = {
+            "capital": {
+                "name": capital_city["City"].iloc[0] if not capital_city.empty else None,
+                "population": capital_pop,
             },
-            'largest_city': {
-                'name': largest_name,
-                'population': largest_pop,
-                'type': largest_type
-            },
-            'quartile_stats': quartile_stats
+            "largest_city": {"name": largest_name, "population": largest_pop, "type": largest_type},
+            "quartile_stats": quartile_stats,
         }
-    
+
     return analysis
+
 
 def print_selection_analysis(analysis):
     """
     Prints a formatted analysis of city selection coverage and statistics.
-    
+
     Args:
         analysis (dict): Analysis dictionary from analyze_selection_coverage()
-        
+
     Example:
         analysis = analyze_selection_coverage(selected_df, original_df)
         print_selection_analysis(analysis)
     """
+
     # Helper function for number formatting
     def format_num(n):
         if n is None:
             return "N/A"
         return f"{n:,.0f}"
-    
+
     # Print overall coverage
     print("\n=== POPULATION COVERAGE ===")
-    cov = analysis['population_coverage']
+    cov = analysis["population_coverage"]
     print(f"Total Population:     {format_num(cov['total_population'])}")
     print(f"Selected Population:  {format_num(cov['selected_population'])}")
     print(f"Coverage Percentage:  {cov['coverage_percentage']:.1f}%")
 
     # Print size distribution
     print("\n=== CITY SIZE DISTRIBUTION ===")
-    size = analysis['size_distribution']
+    size = analysis["size_distribution"]
     print(f"Mean Population:   {format_num(size['mean_pop'])}")
     print(f"Median Population: {format_num(size['median_pop'])}")
     print(f"Minimum:          {format_num(size['min_pop'])}")
@@ -401,93 +456,104 @@ def print_selection_analysis(analysis):
     # Print geographic distribution
     print("\n=== GEOGRAPHIC DISTRIBUTION ===")
     print(f"Total States Covered: {analysis['geographic_distribution']['total_states']}")
-    
+
     # Print state details
     print("\n=== STATE-BY-STATE ANALYSIS ===")
-    for state, details in sorted(analysis['state_details'].items()):
+    for state, details in sorted(analysis["state_details"].items()):
         print(f"\n{state}")
-        
+
         # Capital info
-        cap = details['capital']
+        cap = details["capital"]
         print(f"  Capital: {cap['name'] or 'N/A'} ({format_num(cap['population'])})")
-        
+
         # Largest city info
-        largest = details['largest_city']
-        if largest['name']:
-            print(f"  {largest['type'].title()}: {largest['name']} ({format_num(largest['population'])})")
-        
+        largest = details["largest_city"]
+        if largest["name"]:
+            print(
+                f"  {largest['type'].title()}: {largest['name']} ({format_num(largest['population'])})"
+            )
+
         # Quartile stats
-        if details['quartile_stats']:
+        if details["quartile_stats"]:
             print("  Quartile Statistics:")
-            for q, stats in details['quartile_stats'].items():
-                print(f"    {q}: {stats['count']} cities, "
-                      f"avg={format_num(stats['avg'])}, "
-                      f"median={format_num(stats['median'])}")
+            for q, stats in details["quartile_stats"].items():
+                print(
+                    f"    {q}: {stats['count']} cities, "
+                    f"avg={format_num(stats['avg'])}, "
+                    f"median={format_num(stats['median'])}"
+                )
+
 
 def analyze_state_statistics(df):
     """
     Calculates key statistics for each state from census data.
-    
+
     Args:
         df (pd.DataFrame): Prepared census DataFrame
-        
+
     Returns:
         dict: Dictionary containing statistical analysis by state
     """
     stats_by_state = {}
-    
-    for state in df['State'].unique():
-        state_data = df[df['State'] == state].copy()  # Create a copy to avoid SettingWithCopyWarning
-        
+
+    for state in df["State"].unique():
+        state_data = df[
+            df["State"] == state
+        ].copy()  # Create a copy to avoid SettingWithCopyWarning
+
         # Skip if no data for state
         if len(state_data) == 0:
             continue
-            
+
         # Calculate 2020-2023 growth rates
-        state_data['growth_rate'] = ((state_data['2023'] - state_data['2020']) / state_data['2020']) * 100
-        
+        state_data["growth_rate"] = (
+            (state_data["2023"] - state_data["2020"]) / state_data["2020"]
+        ) * 100
+
         stats_by_state[state] = {
-            'num_cities': len(state_data),
-            'avg_population_2023': state_data['2023'].mean(),
-            'median_population_2023': state_data['2023'].median(),
-            'std_population_2023': state_data['2023'].std(),
-            'total_population_2023': state_data['2023'].sum(),
-            'largest_city': {
-                'name': state_data.loc[state_data['2023'].idxmax(), 'City'],
-                'population': state_data['2023'].max()
+            "num_cities": len(state_data),
+            "avg_population_2023": state_data["2023"].mean(),
+            "median_population_2023": state_data["2023"].median(),
+            "std_population_2023": state_data["2023"].std(),
+            "total_population_2023": state_data["2023"].sum(),
+            "largest_city": {
+                "name": state_data.loc[state_data["2023"].idxmax(), "City"],
+                "population": state_data["2023"].max(),
             },
-            'smallest_city': {
-                'name': state_data.loc[state_data['2023'].idxmin(), 'City'],
-                'population': state_data['2023'].min()
+            "smallest_city": {
+                "name": state_data.loc[state_data["2023"].idxmin(), "City"],
+                "population": state_data["2023"].min(),
             },
-            'avg_growth_rate': state_data['growth_rate'].mean(),
-            'fastest_growing': {
-                'name': state_data.loc[state_data['growth_rate'].idxmax(), 'City'],
-                'rate': state_data['growth_rate'].max()
-            }
+            "avg_growth_rate": state_data["growth_rate"].mean(),
+            "fastest_growing": {
+                "name": state_data.loc[state_data["growth_rate"].idxmax(), "City"],
+                "rate": state_data["growth_rate"].max(),
+            },
         }
-    
+
     return stats_by_state
 
-def write_selected_cities(selected_cities: pd.DataFrame, output_file: str = 'selected_cities.txt'):
+
+def write_selected_cities(selected_cities: pd.DataFrame, output_file: str = "selected_cities.txt"):
     """
     Writes selected cities to a text file, one city per line in 'city, state' format.
-    
+
     Args:
         selected_cities (pd.DataFrame): DataFrame containing selected cities with City and State columns
         output_file (str): Path to output text file (default: 'selected_cities.txt')
     """
     logger.info(f"Writing selected cities to {output_file}")
-    
+
     try:
-        with open(output_file, 'w') as f:
+        with open(output_file, "w") as f:
             # Sort by state then city for consistent output
-            sorted_cities = selected_cities.sort_values(['State', 'City'])
+            sorted_cities = selected_cities.sort_values(["State", "City"])
             for _, row in sorted_cities.iterrows():
                 f.write(f"{row['City']}, {row['State']}\n")
         logger.info(f"Successfully wrote {len(selected_cities)} cities to {output_file}")
     except Exception as e:
         logger.error(f"Error writing to {output_file}: {str(e)}")
+
 
 # Main execution
 if __name__ == "__main__":
@@ -495,32 +561,34 @@ if __name__ == "__main__":
     # Set up command line argument parsing
     # file_path = "SUB-IP-EST2023-POP.xlsx"
 
-    parser = argparse.ArgumentParser(description='Process US Census data with configurable logging.')
-    
-    parser.add_argument(
-        '--input-file', 
-        default='SUB-IP-EST2023-POP.xlsx',
-        help='Path to the census Excel file (default: SUB-IP-EST2023-POP.xlsx)'
+    parser = argparse.ArgumentParser(
+        description="Process US Census data with configurable logging."
     )
 
     parser.add_argument(
-        '--log-level', 
-        default='INFO',
-        choices=['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'],
-        help='Set the logging level'
+        "--input-file",
+        default="SUB-IP-EST2023-POP.xlsx",
+        help="Path to the census Excel file (default: SUB-IP-EST2023-POP.xlsx)",
     )
-    
+
+    parser.add_argument(
+        "--log-level",
+        default="INFO",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
+        help="Set the logging level",
+    )
+
     args = parser.parse_args()
-    
+
     # Set up logging
     setup_logger(args.log_level)
-    
+
     # Prepare data
     df = clean_and_prepare_data(args.input_file)
-    
+
     # Calculate statistics
     # stats = analyze_state_statistics(df)
-    
+
     # # Print statistics for each state
     # for state, state_stats in stats.items():
     #     print(f"\n{'='*50}")
@@ -546,6 +614,6 @@ if __name__ == "__main__":
 
     # Write selected cities to file
     write_selected_cities(selected_cities)
-    
+
     # Create visualizations
     # create_visualizations(df)

--- a/generate_json.py
+++ b/generate_json.py
@@ -1,46 +1,47 @@
-import os
 import logging
+import os
 
 from gsv_metadata_tracker import get_default_data_dir
 from gsv_metadata_tracker.json_summarizer import (
-    generate_missing_city_json_files,
     generate_aggregate_summary_as_json,
+    generate_missing_city_json_files,
 )
 
 logger = logging.getLogger(__name__)
 
+
 def main():
     """Command-line entry point for metadata generation."""
     import argparse
-    
+
     parser = argparse.ArgumentParser(
-        description='Generate missing JSON metadata files for GSV data'
+        description="Generate missing JSON metadata files for GSV data"
     )
-    
+
     parser.add_argument(
-        '--data-dir',
+        "--data-dir",
         type=str,
         default=get_default_data_dir(),
-        help='Directory containing GSV metadata files (default: project data directory)'
+        help="Directory containing GSV metadata files (default: project data directory)",
     )
-    
+
     parser.add_argument(
-        '--log-level',
+        "--log-level",
         type=str,
-        choices=['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'],
-        default='INFO',
-        help='Set the logging level (default: INFO)'
+        choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
+        default="INFO",
+        help="Set the logging level (default: INFO)",
     )
-    
+
     args = parser.parse_args()
-    
+
     # Configure logging
     logging.basicConfig(
         level=getattr(logging, args.log_level),
-        format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
-        datefmt='%Y-%m-%d %H:%M:%S'
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
     )
-    
+
     logger.debug(f"Input parameters: {args}")
     logger.debug(f"Logging level set to: {args.log_level}")
     logger.debug(f"Data directory: {args.data_dir}")
@@ -48,11 +49,12 @@ def main():
     if not os.path.exists(args.data_dir):
         print(f"Error: Directory {args.data_dir} does not exist")
         return 1
-        
+
     generate_missing_city_json_files(args.data_dir)
     generate_aggregate_summary_as_json(args.data_dir)
 
     return 0
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()

--- a/gsv_compare_data.py
+++ b/gsv_compare_data.py
@@ -26,13 +26,18 @@ from gsv_metadata_tracker.fileutils import load_city_csv_file
 
 
 def main() -> int:
-    parser = argparse.ArgumentParser(description='Compare two GSV metadata files')
-    parser.add_argument('file_old', help='Path to the earlier GSV metadata file (.csv.gz)')
-    parser.add_argument('file_new', help='Path to the later GSV metadata file (.csv.gz)')
-    parser.add_argument('--verbose', '-v', action='store_true',
-                        help='Show per-file status counts and change detail rows')
-    parser.add_argument('--out', metavar='DIFF.csv.gz',
-                        help='Write the detailed change rows to a gzipped CSV')
+    parser = argparse.ArgumentParser(description="Compare two GSV metadata files")
+    parser.add_argument("file_old", help="Path to the earlier GSV metadata file (.csv.gz)")
+    parser.add_argument("file_new", help="Path to the later GSV metadata file (.csv.gz)")
+    parser.add_argument(
+        "--verbose",
+        "-v",
+        action="store_true",
+        help="Show per-file status counts and change detail rows",
+    )
+    parser.add_argument(
+        "--out", metavar="DIFF.csv.gz", help="Write the detailed change rows to a gzipped CSV"
+    )
     args = parser.parse_args()
 
     logging.basicConfig(level=logging.INFO)
@@ -60,9 +65,9 @@ def main() -> int:
 
         if args.verbose:
             print(f"\nFile 1 ({args.file_old}): {len(df_old):,} rows")
-            print(df_old['status'].value_counts().to_string())
+            print(df_old["status"].value_counts().to_string())
             print(f"\nFile 2 ({args.file_new}): {len(df_new):,} rows")
-            print(df_new['status'].value_counts().to_string())
+            print(df_new["status"].value_counts().to_string())
             if diff.has_changes:
                 print("\nChange detail:")
                 print(diff.detail.to_string(index=False, max_rows=50))
@@ -78,5 +83,5 @@ def main() -> int:
         return 2
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     sys.exit(main())

--- a/gsv_metadata_tracker/__init__.py
+++ b/gsv_metadata_tracker/__init__.py
@@ -1,10 +1,10 @@
 # Import everything we want to expose at package level
+from .config import load_config
 from .download_async import download_gsv_metadata_async
 from .download_mapillary import download_mapillary_metadata_async
-from .config import load_config
-from .geoutils import get_city_location_data, get_search_dimensions
-from .vis import display_search_area, create_visualization_map
 from .fileutils import load_city_csv_file, open_in_browser
+from .geoutils import get_city_location_data, get_search_dimensions
+from .json_summarizer import generate_aggregate_summary_as_json
 from .naming import (
     ParsedFilename,
     generate_base_filename,
@@ -13,25 +13,25 @@ from .naming import (
     sanitize_city_query_str,
 )
 from .paths import get_default_data_dir, get_default_vis_dir
-from .json_summarizer import generate_aggregate_summary_as_json
+from .vis import create_visualization_map, display_search_area
 
 # Define what's available when someone does "from gsv_metadata_tracker import *"
 __all__ = [
-    'ParsedFilename',
-    'create_visualization_map',
-    'display_search_area',
-    'download_gsv_metadata_async',
-    'download_mapillary_metadata_async',
-    'generate_aggregate_summary_as_json',
-    'generate_base_filename',
-    'generate_run_filename',
-    'get_city_location_data',
-    'get_default_data_dir',
-    'get_default_vis_dir',
-    'get_search_dimensions',
-    'load_city_csv_file',
-    'load_config',
-    'open_in_browser',
-    'parse_filename',
-    'sanitize_city_query_str',
+    "ParsedFilename",
+    "create_visualization_map",
+    "display_search_area",
+    "download_gsv_metadata_async",
+    "download_mapillary_metadata_async",
+    "generate_aggregate_summary_as_json",
+    "generate_base_filename",
+    "generate_run_filename",
+    "get_city_location_data",
+    "get_default_data_dir",
+    "get_default_vis_dir",
+    "get_search_dimensions",
+    "load_city_csv_file",
+    "load_config",
+    "open_in_browser",
+    "parse_filename",
+    "sanitize_city_query_str",
 ]

--- a/gsv_metadata_tracker/analysis.py
+++ b/gsv_metadata_tracker/analysis.py
@@ -1,20 +1,19 @@
 """
 analysis.py - Module for analyzing and displaying GSV metadata statistics.
 
-This module provides functions and classes for analyzing Google Street View metadata and 
+This module provides functions and classes for analyzing Google Street View metadata and
 displaying formatted statistics tables. It's designed to be used by multiple
 components like json_summarizer.py, check_status_codes.py, and cli.py.
 """
 
+import logging
+from collections import Counter
 from dataclasses import dataclass
-from typing import Dict, Any, Optional, List, Tuple, ClassVar
+from typing import Any, ClassVar
+
+import numpy as np
 import pandas as pd
 from tabulate import tabulate
-from datetime import datetime
-import numpy as np
-import os
-from collections import Counter
-import logging
 
 logger = logging.getLogger(__name__)
 
@@ -22,7 +21,7 @@ logger = logging.getLogger(__name__)
 # else is a third-party photographer. Substring matching is wrong because
 # photographer names can contain 'Google' (e.g. '© MIB 360 - Google Virtual
 # Tours Agency'). Must stay in sync with the exact match in www/js/city.js.
-GOOGLE_COPYRIGHT = '© Google'
+GOOGLE_COPYRIGHT = "© Google"
 
 # Statuses that mean "imagery is present at this grid point". A pano the
 # provider returned counts even when we could not read a usable capture date
@@ -31,7 +30,7 @@ GOOGLE_COPYRIGHT = '© Google'
 # necessarily use only the dated subset (status == 'OK'). ZERO_RESULTS means
 # "no imagery here"; everything else (REQUEST_DENIED, OVER_QUERY_LIMIT, ...) is
 # an error, not an absence.
-PRESENT_STATUSES = ('OK', 'NO_DATE')
+PRESENT_STATUSES = ("OK", "NO_DATE")
 
 
 def is_google_copyright(copyright_info: pd.Series) -> pd.Series:
@@ -41,9 +40,11 @@ def is_google_copyright(copyright_info: pd.Series) -> pd.Series:
     """
     return copyright_info == GOOGLE_COPYRIGHT
 
+
 @dataclass
 class DistanceStats:
     """Statistics about distances between query points and panoramas."""
+
     min_meters: float
     max_meters: float
     avg_meters: float
@@ -51,20 +52,21 @@ class DistanceStats:
     stdev_meters: float
 
     # Class variable mapping internal field names to human-readable labels
-    FIELD_LABELS: ClassVar[Dict[str, str]] = {
-        'min_meters': 'Min Distance (m)',
-        'max_meters': 'Max Distance (m)',
-        'avg_meters': 'Avg Distance (m)',
-        'median_meters': 'Median Distance (m)',
-        'stdev_meters': 'Std Dev Distance (m)'
+    FIELD_LABELS: ClassVar[dict[str, str]] = {
+        "min_meters": "Min Distance (m)",
+        "max_meters": "Max Distance (m)",
+        "avg_meters": "Avg Distance (m)",
+        "median_meters": "Median Distance (m)",
+        "stdev_meters": "Std Dev Distance (m)",
     }
 
-    def to_rows(self) -> List[List[str]]:
+    def to_rows(self) -> list[list[str]]:
         """Convert stats to formatted rows for tabulation."""
         return [
             [self.FIELD_LABELS[field], f"{getattr(self, field):.2f}"]
             for field in self.FIELD_LABELS.keys()
         ]
+
 
 @dataclass
 class CoverageStats:
@@ -76,32 +78,37 @@ class CoverageStats:
     field name num_points_with_unique_pano_ids is kept for per-run JSON
     key stability but holds the count of unique panoramas.
     """
+
     num_points_with_panos: int
     num_points_with_unique_pano_ids: int
     num_points_with_errors: int
     num_points_without_panos: int
     coverage_rate: float
-    pano_distance_stats: Optional[DistanceStats] = None
+    pano_distance_stats: DistanceStats | None = None
 
-    FIELD_LABELS: ClassVar[Dict[str, str]] = {
-        'num_points_with_panos': 'Points with Panoramas',
-        'num_points_with_unique_pano_ids': 'Unique Panoramas',
-        'num_points_without_panos': 'Points without Panoramas',
-        'num_points_with_errors': 'Points with Errors',
-        'coverage_rate': 'Points with Panos / Total Points'
+    FIELD_LABELS: ClassVar[dict[str, str]] = {
+        "num_points_with_panos": "Points with Panoramas",
+        "num_points_with_unique_pano_ids": "Unique Panoramas",
+        "num_points_without_panos": "Points without Panoramas",
+        "num_points_with_errors": "Points with Errors",
+        "coverage_rate": "Points with Panos / Total Points",
     }
 
-    def to_rows(self) -> List[List[str]]:
+    def to_rows(self) -> list[list[str]]:
         """Convert stats to formatted rows for tabulation."""
         rows = [
-            [self.FIELD_LABELS[field], 
-             f"{getattr(self, field):.2f}%" if field == 'coverage_rate' else str(getattr(self, field))]
+            [
+                self.FIELD_LABELS[field],
+                f"{getattr(self, field):.2f}%"
+                if field == "coverage_rate"
+                else str(getattr(self, field)),
+            ]
             for field in self.FIELD_LABELS.keys()
         ]
-        
+
         if self.pano_distance_stats:
             rows.extend(self.pano_distance_stats.to_rows())
-            
+
         return rows
 
     def format_table(self) -> str:
@@ -111,27 +118,29 @@ class CoverageStats:
             headers=["Metric", "Value"],
             tablefmt="simple",
             numalign="right",
-            stralign="left"
+            stralign="left",
         )
+
 
 @dataclass
 class AgeStats:
     """Statistics about panorama ages."""
-    count: int
-    oldest_pano_date: Optional[str]
-    newest_pano_date: Optional[str]
-    avg_pano_age_years: Optional[float]
-    median_pano_age_years: Optional[float]
-    stdev_pano_age_years: Optional[float]
-    age_percentiles_years: Optional[Dict[str, float]]
 
-    FIELD_LABELS: ClassVar[Dict[str, str]] = {
-        'count': 'Total Panoramas',
-        'oldest_pano_date': 'Oldest Panorama',
-        'newest_pano_date': 'Newest Panorama',
-        'avg_pano_age_years': 'Average Age (years)',
-        'median_pano_age_years': 'Median Age (years)',
-        'stdev_pano_age_years': 'Std Dev Age (years)'
+    count: int
+    oldest_pano_date: str | None
+    newest_pano_date: str | None
+    avg_pano_age_years: float | None
+    median_pano_age_years: float | None
+    stdev_pano_age_years: float | None
+    age_percentiles_years: dict[str, float] | None
+
+    FIELD_LABELS: ClassVar[dict[str, str]] = {
+        "count": "Total Panoramas",
+        "oldest_pano_date": "Oldest Panorama",
+        "newest_pano_date": "Newest Panorama",
+        "avg_pano_age_years": "Average Age (years)",
+        "median_pano_age_years": "Median Age (years)",
+        "stdev_pano_age_years": "Std Dev Age (years)",
     }
 
     def format_field_value(self, field: Any) -> str:
@@ -146,7 +155,7 @@ class AgeStats:
             return f"{value:.1f}"
         return str(value)
 
-    def to_rows(self) -> List[List[str]]:
+    def to_rows(self) -> list[list[str]]:
         """Convert stats to formatted rows for tabulation."""
         return [
             [self.FIELD_LABELS[field], self.format_field_value(field)]
@@ -160,8 +169,9 @@ class AgeStats:
             headers=["Metric", "Value"],
             tablefmt="simple",
             numalign="right",
-            stralign="left"
+            stralign="left",
         )
+
 
 def calculate_age_stats(df: pd.DataFrame, now: pd.Timestamp) -> AgeStats:
     """Helper function to calculate age statistics for panoramas."""
@@ -173,22 +183,26 @@ def calculate_age_stats(df: pd.DataFrame, now: pd.Timestamp) -> AgeStats:
             avg_pano_age_years=None,
             median_pano_age_years=None,
             stdev_pano_age_years=None,
-            age_percentiles_years=None
+            age_percentiles_years=None,
         )
-    
+
     # Convert capture_date to datetime if necessary
-    if not pd.api.types.is_datetime64_any_dtype(df['capture_date']):
-        df['capture_date'] = pd.to_datetime(df['capture_date'])
-    
-    valid_dates_mask = df['capture_date'].notna()
+    if not pd.api.types.is_datetime64_any_dtype(df["capture_date"]):
+        df["capture_date"] = pd.to_datetime(df["capture_date"])
+
+    valid_dates_mask = df["capture_date"].notna()
     df_with_dates = df[valid_dates_mask]
-    
-    ages = (now - df_with_dates['capture_date']).dt.total_seconds() / (365.25 * 24 * 3600)
-    
+
+    ages = (now - df_with_dates["capture_date"]).dt.total_seconds() / (365.25 * 24 * 3600)
+
     return AgeStats(
         count=len(df),
-        oldest_pano_date=df_with_dates['capture_date'].min().isoformat() if len(df_with_dates) > 0 else None,
-        newest_pano_date=df_with_dates['capture_date'].max().isoformat() if len(df_with_dates) > 0 else None,
+        oldest_pano_date=df_with_dates["capture_date"].min().isoformat()
+        if len(df_with_dates) > 0
+        else None,
+        newest_pano_date=df_with_dates["capture_date"].max().isoformat()
+        if len(df_with_dates) > 0
+        else None,
         avg_pano_age_years=float(ages.mean()) if len(ages) > 0 else None,
         median_pano_age_years=float(ages.median()) if len(ages) > 0 else None,
         # std() with a single sample returns NaN (ddof=1), which is not valid JSON
@@ -197,9 +211,10 @@ def calculate_age_stats(df: pd.DataFrame, now: pd.Timestamp) -> AgeStats:
             "p10": float(ages.quantile(0.1)) if len(ages) > 0 else None,
             "p25": float(ages.quantile(0.25)) if len(ages) > 0 else None,
             "p75": float(ages.quantile(0.75)) if len(ages) > 0 else None,
-            "p90": float(ages.quantile(0.9)) if len(ages) > 0 else None
-        }
+            "p90": float(ages.quantile(0.9)) if len(ages) > 0 else None,
+        },
     )
+
 
 def calculate_coverage_stats(df: pd.DataFrame) -> CoverageStats:
     """
@@ -217,12 +232,12 @@ def calculate_coverage_stats(df: pd.DataFrame) -> CoverageStats:
     pairs. Coordinates within a run come from a single grid-generation
     pass, so exact equality is safe.
     """
-    point_cols = ['query_lat', 'query_lon']
+    point_cols = ["query_lat", "query_lon"]
     num_total_points = len(df[point_cols].drop_duplicates())
 
     # A grid point is covered if it holds >= 1 present pano (OK or NO_DATE):
     # a dateless pano is still imagery within reach (see PRESENT_STATUSES).
-    present_rows = df[df['status'].isin(PRESENT_STATUSES)]
+    present_rows = df[df["status"].isin(PRESENT_STATUSES)]
     num_points_with_panos = len(present_rows[point_cols].drop_duplicates())
     logger.debug(f"Grid points with panoramas: {num_points_with_panos}")
 
@@ -230,51 +245,65 @@ def calculate_coverage_stats(df: pd.DataFrame) -> CoverageStats:
     # overlap the covered points; whatever remains saw only errors
     # (REQUEST_DENIED, OVER_QUERY_LIMIT, ...)
     num_points_without_panos = len(
-        df.loc[df['status'] == 'ZERO_RESULTS', point_cols].drop_duplicates())
-    num_points_with_errors = (num_total_points - num_points_with_panos
-                              - num_points_without_panos)
+        df.loc[df["status"] == "ZERO_RESULTS", point_cols].drop_duplicates()
+    )
+    num_points_with_errors = num_total_points - num_points_with_panos - num_points_without_panos
 
-    successful_df_no_duplicates = present_rows.drop_duplicates(subset=['pano_id']).copy()
+    successful_df_no_duplicates = present_rows.drop_duplicates(subset=["pano_id"]).copy()
     num_unique_panos = len(successful_df_no_duplicates)
     logger.debug(f"Unique panoramas: {num_unique_panos}")
 
     distance_stats = None
     if num_unique_panos > 0:
-        distances = np.sqrt(
-            (successful_df_no_duplicates['query_lat'] - successful_df_no_duplicates['pano_lat'])**2 +
-            (successful_df_no_duplicates['query_lon'] - successful_df_no_duplicates['pano_lon'])**2
-        ) * 111000  # Approximate conversion to meters
-        
-        successful_df_no_duplicates.loc[:, 'distance_to_query'] = distances
-        logger.debug(f"Distance: {distances}")
-        logger.debug(f"Distance is NA: {successful_df_no_duplicates['distance_to_query'].isna().all()}")
-        logger.debug(f"Distance std: {successful_df_no_duplicates['distance_to_query'].std()}")
-    
-        
-        if not successful_df_no_duplicates['distance_to_query'].isna().all():
-
-            # If we have only one point, std will be NaN
-            std_val = successful_df_no_duplicates['distance_to_query'].std()
-            distance_stats = DistanceStats(
-                min_meters=float(successful_df_no_duplicates['distance_to_query'].min()),
-                max_meters=float(successful_df_no_duplicates['distance_to_query'].max()),
-                avg_meters=float(successful_df_no_duplicates['distance_to_query'].mean()),
-                median_meters=float(successful_df_no_duplicates['distance_to_query'].median()),
-                stdev_meters=0.0 if pd.isna(std_val) else float(std_val)  # Use 0.0 for single points
+        distances = (
+            np.sqrt(
+                (successful_df_no_duplicates["query_lat"] - successful_df_no_duplicates["pano_lat"])
+                ** 2
+                + (
+                    successful_df_no_duplicates["query_lon"]
+                    - successful_df_no_duplicates["pano_lon"]
+                )
+                ** 2
             )
-    
+            * 111000
+        )  # Approximate conversion to meters
+
+        successful_df_no_duplicates.loc[:, "distance_to_query"] = distances
+        logger.debug(f"Distance: {distances}")
+        logger.debug(
+            f"Distance is NA: {successful_df_no_duplicates['distance_to_query'].isna().all()}"
+        )
+        logger.debug(f"Distance std: {successful_df_no_duplicates['distance_to_query'].std()}")
+
+        if not successful_df_no_duplicates["distance_to_query"].isna().all():
+            # If we have only one point, std will be NaN
+            std_val = successful_df_no_duplicates["distance_to_query"].std()
+            distance_stats = DistanceStats(
+                min_meters=float(successful_df_no_duplicates["distance_to_query"].min()),
+                max_meters=float(successful_df_no_duplicates["distance_to_query"].max()),
+                avg_meters=float(successful_df_no_duplicates["distance_to_query"].mean()),
+                median_meters=float(successful_df_no_duplicates["distance_to_query"].median()),
+                stdev_meters=0.0
+                if pd.isna(std_val)
+                else float(std_val),  # Use 0.0 for single points
+            )
+
     return CoverageStats(
         num_points_with_panos=num_points_with_panos,
         num_points_with_unique_pano_ids=num_unique_panos,
         num_points_without_panos=num_points_without_panos,
         num_points_with_errors=num_points_with_errors,
-        coverage_rate=(num_points_with_panos / num_total_points) * 100 if num_total_points > 0 else 0,
-        pano_distance_stats=distance_stats
+        coverage_rate=(num_points_with_panos / num_total_points) * 100
+        if num_total_points > 0
+        else 0,
+        pano_distance_stats=distance_stats,
     )
+
 
 @dataclass
 class DuplicateStats:
     """Statistics about panorama duplications."""
+
     total_unique_panos: int
     total_pano_references: int
     duplicate_reference_count: int
@@ -282,21 +311,24 @@ class DuplicateStats:
     panos_with_multiple_refs: int
     average_references_per_pano: float
 
-    FIELD_LABELS: ClassVar[Dict[str, str]] = {
-        'total_unique_panos': 'Total Unique Panoramas',
-        'total_pano_references': 'Total References',
-        'duplicate_reference_count': 'Duplicate References',
-        'most_referenced_count': 'Most Referenced Count',
-        'panos_with_multiple_refs': 'Panoramas with Multiple Refs',
-        'average_references_per_pano': 'Average References per Pano'
+    FIELD_LABELS: ClassVar[dict[str, str]] = {
+        "total_unique_panos": "Total Unique Panoramas",
+        "total_pano_references": "Total References",
+        "duplicate_reference_count": "Duplicate References",
+        "most_referenced_count": "Most Referenced Count",
+        "panos_with_multiple_refs": "Panoramas with Multiple Refs",
+        "average_references_per_pano": "Average References per Pano",
     }
 
-    def to_rows(self) -> List[List[str]]:
+    def to_rows(self) -> list[list[str]]:
         """Convert stats to formatted rows for tabulation."""
         return [
-            [self.FIELD_LABELS[field], 
-             f"{getattr(self, field):.2f}" if field == 'average_references_per_pano' 
-             else str(getattr(self, field))]
+            [
+                self.FIELD_LABELS[field],
+                f"{getattr(self, field):.2f}"
+                if field == "average_references_per_pano"
+                else str(getattr(self, field)),
+            ]
             for field in self.FIELD_LABELS.keys()
         ]
 
@@ -307,24 +339,26 @@ class DuplicateStats:
             headers=["Metric", "Value"],
             tablefmt="simple",
             numalign="right",
-            stralign="left"
+            stralign="left",
         )
+
 
 @dataclass
 class YearlyDistribution:
     """Distribution of panoramas by year."""
-    counts: Dict[int, int]
 
-    def to_rows(self) -> List[List[str]]:
+    counts: dict[int, int]
+
+    def to_rows(self) -> list[list[str]]:
         """Convert distribution to formatted rows for tabulation."""
         total_panos = sum(self.counts.values())
         rows = []
-        
+
         for year in sorted(self.counts.keys()):
             count = self.counts[year]
             percentage = (count / total_panos) * 100
             rows.append([str(year), str(count), f"{percentage:.2f}%"])
-        
+
         # Add total row
         rows.append(["TOTAL", str(total_panos), "100.00%"])
         return rows
@@ -337,24 +371,26 @@ class YearlyDistribution:
             tablefmt="simple",
             floatfmt=".2f",
             numalign="right",
-            stralign="left"
+            stralign="left",
         )
+
 
 @dataclass
 class DailyDistribution:
     """Distribution of panoramas by day."""
-    counts: Dict[str, int]  # Maps ISO date strings (YYYY-MM-DD) to counts
 
-    def to_rows(self) -> List[List[str]]:
+    counts: dict[str, int]  # Maps ISO date strings (YYYY-MM-DD) to counts
+
+    def to_rows(self) -> list[list[str]]:
         """Convert distribution to formatted rows for tabulation."""
         total_panos = sum(self.counts.values())
         rows = []
-        
+
         for date in sorted(self.counts.keys()):
             count = self.counts[date]
             percentage = (count / total_panos) * 100
             rows.append([date, str(count), f"{percentage:.2f}%"])
-        
+
         # Add total row
         rows.append(["TOTAL", str(total_panos), "100.00%"])
         return rows
@@ -367,35 +403,31 @@ class DailyDistribution:
             tablefmt="simple",
             floatfmt=".2f",
             numalign="right",
-            stralign="left"
+            stralign="left",
         )
+
 
 @dataclass
 class PhotographerStats:
     """Statistics about photographer contributions."""
-    photographer_counts: Dict[str, int]  # Maps photographer name to unique pano count
+
+    photographer_counts: dict[str, int]  # Maps photographer name to unique pano count
     top_n: int = 5  # Number of top photographers to show
 
-    def to_rows(self) -> List[List[str]]:
+    def to_rows(self) -> list[list[str]]:
         """Convert stats to formatted rows for tabulation."""
         total_panos = sum(self.photographer_counts.values())
         rows = []
-        
+
         # Sort by count and take top N
         sorted_photographers = sorted(
-            self.photographer_counts.items(), 
-            key=lambda x: x[1], 
-            reverse=True
-        )[:self.top_n]
-        
+            self.photographer_counts.items(), key=lambda x: x[1], reverse=True
+        )[: self.top_n]
+
         for photographer, count in sorted_photographers:
             percentage = (count / total_panos) * 100
-            rows.append([
-                photographer,
-                f"{count:,}",
-                f"{percentage:.2f}%"
-            ])
-            
+            rows.append([photographer, f"{count:,}", f"{percentage:.2f}%"])
+
         return rows
 
     def format_table(self, title: str = "Top Photographers by Unique Panoramas") -> str:
@@ -406,12 +438,14 @@ class PhotographerStats:
             tablefmt="simple",
             floatfmt=".2f",
             numalign="right",
-            stralign="left"
+            stralign="left",
         )
+
 
 @dataclass
 class GSVAnalysisResults:
     """Complete set of GSV metadata analysis results."""
+
     duplicate_stats: DuplicateStats
     age_stats: AgeStats
     coverage_stats: CoverageStats
@@ -431,62 +465,63 @@ class GSVAnalysisResults:
         print(self.duplicate_stats.format_table())
 
         print(self.age_stats.format_table())
-        
+
         print("\nPhotographer Statistics")
         print(self.photographer_stats.format_table())
-        
+
         print("\nYearly and Daily Distributions")
         print(self.yearly_distribution.format_table())
         print(self.daily_distribution.format_table())
 
+
 def calculate_daily_distribution(df: pd.DataFrame) -> DailyDistribution:
     """
     Calculate distribution of panoramas by date (YYYY-MM-DD).
-    
+
     Args:
         df: DataFrame containing panorama data with capture_date column
-        
+
     Returns:
         DailyDistribution object containing date-wise counts
     """
     if len(df) == 0:
         return DailyDistribution(counts={})
-    
+
     # Convert capture_date to datetime if necessary
-    if not pd.api.types.is_datetime64_any_dtype(df['capture_date']):
-        df['capture_date'] = pd.to_datetime(df['capture_date'])
-    
+    if not pd.api.types.is_datetime64_any_dtype(df["capture_date"]):
+        df["capture_date"] = pd.to_datetime(df["capture_date"])
+
     # Use ISO format for dates (YYYY-MM-DD)
-    date_counts = df['capture_date'].apply(lambda x: x.date().isoformat()).value_counts().sort_index()
-    
-    # Convert counts to integers while maintaining ISO date strings as keys
-    return DailyDistribution(
-        counts={date: int(count) for date, count in date_counts.items()}
+    date_counts = (
+        df["capture_date"].apply(lambda x: x.date().isoformat()).value_counts().sort_index()
     )
+
+    # Convert counts to integers while maintaining ISO date strings as keys
+    return DailyDistribution(counts={date: int(count) for date, count in date_counts.items()})
+
 
 def calculate_photographer_stats(df: pd.DataFrame) -> PhotographerStats:
     """
     Calculate photographer contribution statistics.
-    
+
     Args:
         df: DataFrame containing GSV metadata with 'copyright_info' and 'pano_id' columns
-        
+
     Returns:
         PhotographerStats containing photographer contribution analysis
     """
     # Filter for present panoramas (OK or NO_DATE) and drop duplicates; a
     # dateless pano still carries its contributor/copyright attribution.
-    present_panos = df[df['status'].isin(PRESENT_STATUSES)].drop_duplicates(subset=['pano_id'])
+    present_panos = df[df["status"].isin(PRESENT_STATUSES)].drop_duplicates(subset=["pano_id"])
 
     # Count unique pano_ids per photographer
-    photographer_counts = present_panos['copyright_info'].value_counts().to_dict()
-    
+    photographer_counts = present_panos["copyright_info"].value_counts().to_dict()
+
     return PhotographerStats(photographer_counts=photographer_counts)
 
+
 def calculate_pano_stats(
-    df: pd.DataFrame, 
-    now: pd.Timestamp,
-    google_only: bool = False
+    df: pd.DataFrame, now: pd.Timestamp, google_only: bool = False
 ) -> GSVAnalysisResults:
     """
     Calculate comprehensive panorama statistics from a DataFrame.
@@ -506,21 +541,23 @@ def calculate_pano_stats(
         >>> results = calculate_pano_stats(df, now)
         >>> results.print_summary("Analysis Results")
     """
-    filtered_df = df[is_google_copyright(df['copyright_info'])] if google_only else df
+    filtered_df = df[is_google_copyright(df["copyright_info"])] if google_only else df
 
     # Present panoramas (OK or NO_DATE) count toward pano totals; date-based
     # stats below use only the dated (OK) subset.
-    present_panos = filtered_df[filtered_df['status'].isin(PRESENT_STATUSES)].copy()
+    present_panos = filtered_df[filtered_df["status"].isin(PRESENT_STATUSES)].copy()
 
     # Calculate duplicate statistics over every present pano
-    pano_id_counts = present_panos['pano_id'].value_counts()
+    pano_id_counts = present_panos["pano_id"].value_counts()
     duplicate_stats = DuplicateStats(
         total_unique_panos=len(pano_id_counts),
         total_pano_references=len(present_panos),
         duplicate_reference_count=len(present_panos) - len(pano_id_counts),
         most_referenced_count=int(pano_id_counts.max()) if not pano_id_counts.empty else 0,
         panos_with_multiple_refs=int((pano_id_counts > 1).sum()),
-        average_references_per_pano=float(len(present_panos) / len(pano_id_counts)) if len(pano_id_counts) > 0 else 0
+        average_references_per_pano=float(len(present_panos) / len(pano_id_counts))
+        if len(pano_id_counts) > 0
+        else 0,
     )
 
     # For most stats, we want to focus only on unique pano ids or we risk
@@ -528,7 +565,7 @@ def calculate_pano_stats(
     # from different query points
 
     # Age / capture-year / daily stats need a real date, so use dated panos only
-    dated_unique = filtered_df[filtered_df['status'] == 'OK'].drop_duplicates(subset=['pano_id'])
+    dated_unique = filtered_df[filtered_df["status"] == "OK"].drop_duplicates(subset=["pano_id"])
     age_stats = calculate_age_stats(dated_unique, now)
 
     # Coverage describes the sampled grid, not the copyright subset, so it
@@ -540,34 +577,33 @@ def calculate_pano_stats(
     yearly_dist = calculate_yearly_distribution(dated_unique)
     daily_dist = calculate_daily_distribution(dated_unique)
     photographer_stats = calculate_photographer_stats(present_panos)
-    
+
     return GSVAnalysisResults(
         duplicate_stats=duplicate_stats,
         age_stats=age_stats,
         coverage_stats=coverage_stats,
         yearly_distribution=yearly_dist,
         daily_distribution=daily_dist,
-        photographer_stats=photographer_stats
+        photographer_stats=photographer_stats,
     )
+
 
 def calculate_yearly_distribution(df: pd.DataFrame) -> YearlyDistribution:
     """Calculate distribution of panoramas by year."""
     if len(df) == 0:
         return YearlyDistribution(counts={})
-    
-    # Convert capture_date to datetime if necessary
-    if not pd.api.types.is_datetime64_any_dtype(df['capture_date']):
-        df['capture_date'] = pd.to_datetime(df['capture_date'])
-    
-    # Extract year and count occurrences
-    year_counts = df['capture_date'].dt.year.value_counts().sort_index()
-    
-    return YearlyDistribution(
-        counts={int(year): int(count) for year, count in year_counts.items()}
-    )
 
-def calculate_run_stats(df: pd.DataFrame, run_date,
-                        provider: str = 'gsv') -> Dict[str, Any]:
+    # Convert capture_date to datetime if necessary
+    if not pd.api.types.is_datetime64_any_dtype(df["capture_date"]):
+        df["capture_date"] = pd.to_datetime(df["capture_date"])
+
+    # Extract year and count occurrences
+    year_counts = df["capture_date"].dt.year.value_counts().sort_index()
+
+    return YearlyDistribution(counts={int(year): int(count) for year, count in year_counts.items()})
+
+
+def calculate_run_stats(df: pd.DataFrame, run_date, provider: str = "gsv") -> dict[str, Any]:
     """
     Compute the per-run summary stats stored in the runs catalog table.
 
@@ -589,47 +625,45 @@ def calculate_run_stats(df: pd.DataFrame, run_date,
     """
     now = pd.Timestamp(run_date)
 
-    status_ok = int((df['status'] == 'OK').sum())
-    status_no_date = int((df['status'] == 'NO_DATE').sum())
-    status_zero = int((df['status'] == 'ZERO_RESULTS').sum())
+    status_ok = int((df["status"] == "OK").sum())
+    status_no_date = int((df["status"] == "NO_DATE").sum())
+    status_zero = int((df["status"] == "ZERO_RESULTS").sum())
     status_other = int(len(df) - status_ok - status_no_date - status_zero)
 
     # Pano totals count every present pano (OK or NO_DATE); age stats use only
     # the dated subset, since NO_DATE panos carry no usable capture date.
-    present = df[df['status'].isin(PRESENT_STATUSES)]
-    unique = present.drop_duplicates(subset=['pano_id'])
+    present = df[df["status"].isin(PRESENT_STATUSES)]
+    unique = present.drop_duplicates(subset=["pano_id"])
     unique_google_panos = None
-    if provider == 'gsv' and not (len(unique) > 0
-                                  and unique['copyright_info'].isna().all()):
-        is_google = is_google_copyright(unique['copyright_info'])
+    if provider == "gsv" and not (len(unique) > 0 and unique["copyright_info"].isna().all()):
+        is_google = is_google_copyright(unique["copyright_info"])
         unique_google_panos = int(is_google.sum())
 
-    dated_unique = df[df['status'] == 'OK'].drop_duplicates(subset=['pano_id'])
+    dated_unique = df[df["status"] == "OK"].drop_duplicates(subset=["pano_id"])
     age_stats = calculate_age_stats(dated_unique.copy(), now)
     coverage = calculate_coverage_stats(df)
 
     return {
-        'total_points': len(df),
-        'status_ok': status_ok,
-        'status_no_date': status_no_date,
-        'status_zero_results': status_zero,
-        'status_other': status_other,
-        'unique_panos': len(unique),
-        'unique_google_panos': unique_google_panos,
-        'coverage_rate_pct': coverage.coverage_rate,
-        'oldest_capture_date': age_stats.oldest_pano_date,
-        'newest_capture_date': age_stats.newest_pano_date,
-        'median_pano_age_years': age_stats.median_pano_age_years,
+        "total_points": len(df),
+        "status_ok": status_ok,
+        "status_no_date": status_no_date,
+        "status_zero_results": status_zero,
+        "status_other": status_other,
+        "unique_panos": len(unique),
+        "unique_google_panos": unique_google_panos,
+        "coverage_rate_pct": coverage.coverage_rate,
+        "oldest_capture_date": age_stats.oldest_pano_date,
+        "newest_capture_date": age_stats.newest_pano_date,
+        "median_pano_age_years": age_stats.median_pano_age_years,
     }
 
 
 # Response statuses meaning the request itself was rejected
 # (credentials/quota), as opposed to "no imagery here" (ZERO_RESULTS)
-SYSTEMIC_FAILURE_STATUSES = ('REQUEST_DENIED', 'OVER_QUERY_LIMIT')
+SYSTEMIC_FAILURE_STATUSES = ("REQUEST_DENIED", "OVER_QUERY_LIMIT")
 
 
-def detect_systemic_failure(df: pd.DataFrame,
-                            threshold: float = 0.95) -> Optional[str]:
+def detect_systemic_failure(df: pd.DataFrame, threshold: float = 0.95) -> str | None:
     """
     Detect a run whose responses are dominated by credential/quota denials.
 
@@ -659,51 +693,53 @@ def detect_systemic_failure(df: pd.DataFrame,
     """
     if len(df) == 0:
         return None
-    counts = df['status'].value_counts()
+    counts = df["status"].value_counts()
     denied = int(sum(counts.get(s, 0) for s in SYSTEMIC_FAILURE_STATUSES))
     fraction = denied / len(df)
     if fraction < threshold:
         return None
-    breakdown = ", ".join(f"{s}={int(counts[s])}"
-                          for s in SYSTEMIC_FAILURE_STATUSES if s in counts)
-    return (f"{denied:,} of {len(df):,} responses ({fraction:.0%}) were "
-            f"denied ({breakdown}) — check the API credential/quota")
+    breakdown = ", ".join(f"{s}={int(counts[s])}" for s in SYSTEMIC_FAILURE_STATUSES if s in counts)
+    return (
+        f"{denied:,} of {len(df):,} responses ({fraction:.0%}) were "
+        f"denied ({breakdown}) — check the API credential/quota"
+    )
 
 
-def analyze_gsv_status(df: pd.DataFrame) -> Dict[str, Any]:
+def analyze_gsv_status(df: pd.DataFrame) -> dict[str, Any]:
     """
     Analyze GSV metadata status codes in a DataFrame.
-    
+
     Args:
         df: DataFrame containing GSV metadata
-        
+
     Returns:
         Dictionary containing status analysis including counts and percentages
-        
+
     Raises:
         ValueError: If no status column is found in the DataFrame
     """
     # Get the status column
-    status_cols = [col for col in df.columns if 'status' in col.lower()]
+    status_cols = [col for col in df.columns if "status" in col.lower()]
     if not status_cols:
         raise ValueError("No status column found in DataFrame")
     status_col = status_cols[0]
-    
+
     # Calculate status statistics
     status_counts = Counter(df[status_col])
     total_records = len(df)
-    
+
     return {
         "total_records": total_records,
         "status_counts": dict(status_counts),
         "status_percentages": {
-            status: (count/total_records * 100) 
-            for status, count in status_counts.items()
-        }
+            status: (count / total_records * 100) for status, count in status_counts.items()
+        },
     }
 
-def print_df_summary(df: pd.DataFrame, now: Optional[pd.Timestamp] = None,
-                     provider: str = 'gsv') -> None:
+
+def print_df_summary(
+    df: pd.DataFrame, now: pd.Timestamp | None = None, provider: str = "gsv"
+) -> None:
     """
     Print a comprehensive summary of download results.
 
@@ -722,7 +758,7 @@ def print_df_summary(df: pd.DataFrame, now: Optional[pd.Timestamp] = None,
     print("=" * 40)
     all_stats.print_summary()
 
-    if provider == 'gsv':
+    if provider == "gsv":
         google_stats = calculate_pano_stats(df, timestamp, google_only=True)
         print("\nGoogle Panoramas Only")
         print("=" * 40)

--- a/gsv_metadata_tracker/boundary_audit.py
+++ b/gsv_metadata_tracker/boundary_audit.py
@@ -18,7 +18,7 @@ flagging.
 import logging
 import math
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any
 
 from geopy.distance import geodesic
 
@@ -27,7 +27,7 @@ from .db import CityRow
 logger = logging.getLogger(__name__)
 
 # (south, north, west, east) in degrees — Nominatim boundingbox order
-BBox = Tuple[float, float, float, float]
+BBox = tuple[float, float, float, float]
 
 # Meters per degree of latitude / of longitude at the equator (WGS84 mean).
 # Used for the frozen-rectangle inverse and shoelace scaling; geodesic() is
@@ -39,50 +39,53 @@ _M_PER_DEG_LON_EQUATOR = 111_320.0
 @dataclass
 class OsmBoundary:
     """Parsed Nominatim result: identity, bbox, and polygon area if any."""
+
     display_name: str
-    osm_type: Optional[str]        # node / way / relation
-    place_class: Optional[str]     # e.g. 'boundary', 'place'
-    place_type: Optional[str]      # e.g. 'administrative', 'city'
+    osm_type: str | None  # node / way / relation
+    place_class: str | None  # e.g. 'boundary', 'place'
+    place_type: str | None  # e.g. 'administrative', 'city'
     lat: float
     lon: float
-    bbox: Optional[BBox]
-    geometry_type: Optional[str]   # Polygon / MultiPolygon / Point / ...
-    polygon_area_m2: Optional[float]
+    bbox: BBox | None
+    geometry_type: str | None  # Polygon / MultiPolygon / Point / ...
+    polygon_area_m2: float | None
 
 
 @dataclass
 class Thresholds:
     """Audit cutoffs; both raw ratios are reported so a reviewer can re-sort
     with different values without re-fetching."""
-    min_coverage: float = 0.75   # UNDER when frozen∩osm / osm bbox area < this
+
+    min_coverage: float = 0.75  # UNDER when frozen∩osm / osm bbox area < this
     over_area_ratio: float = 4.0  # OVER when frozen area / osm bbox area > this
 
 
 @dataclass
 class AuditResult:
     """One report row: verdict plus every metric behind it."""
+
     verdict: str  # OK | UNDER | OVER | WRONG_PLACE | NO_POLYGON |
     #               BBOX_SUSPECT | NOT_FOUND | NOT_FETCHED
-    osm_display_name: Optional[str] = None
-    osm_type: Optional[str] = None
-    place_class: Optional[str] = None
-    place_type: Optional[str] = None
-    geometry_type: Optional[str] = None
-    center_in_osm_bbox: Optional[bool] = None
-    center_dist_km: Optional[float] = None
-    osm_bbox_width_m: Optional[float] = None
-    osm_bbox_height_m: Optional[float] = None
-    osm_bbox_area_km2: Optional[float] = None
-    osm_polygon_area_km2: Optional[float] = None
-    bbox_coverage_frac: Optional[float] = None
-    over_area_ratio: Optional[float] = None
-    suggested_center_lat: Optional[float] = None
-    suggested_center_lon: Optional[float] = None
-    suggested_width_m: Optional[int] = None
-    suggested_height_m: Optional[int] = None
+    osm_display_name: str | None = None
+    osm_type: str | None = None
+    place_class: str | None = None
+    place_type: str | None = None
+    geometry_type: str | None = None
+    center_in_osm_bbox: bool | None = None
+    center_dist_km: float | None = None
+    osm_bbox_width_m: float | None = None
+    osm_bbox_height_m: float | None = None
+    osm_bbox_area_km2: float | None = None
+    osm_polygon_area_km2: float | None = None
+    bbox_coverage_frac: float | None = None
+    over_area_ratio: float | None = None
+    suggested_center_lat: float | None = None
+    suggested_center_lon: float | None = None
+    suggested_width_m: int | None = None
+    suggested_height_m: int | None = None
 
 
-def parse_osm_result(raw: Dict[str, Any]) -> OsmBoundary:
+def parse_osm_result(raw: dict[str, Any]) -> OsmBoundary:
     """
     Parse a raw Nominatim JSON result into an OsmBoundary.
 
@@ -90,31 +93,31 @@ def parse_osm_result(raw: Dict[str, Any]) -> OsmBoundary:
     [south, north, west, east] order, and both 'boundingbox' and 'geojson'
     may be absent.
     """
-    bbox: Optional[BBox] = None
-    raw_bbox = raw.get('boundingbox')
+    bbox: BBox | None = None
+    raw_bbox = raw.get("boundingbox")
     if raw_bbox is not None and len(raw_bbox) == 4:
         try:
             bbox = tuple(float(v) for v in raw_bbox)  # type: ignore[assignment]
         except (TypeError, ValueError):
             logger.warning(f"Unparseable boundingbox: {raw_bbox!r}")
 
-    geometry = raw.get('geojson')
-    geometry_type = geometry.get('type') if isinstance(geometry, dict) else None
+    geometry = raw.get("geojson")
+    geometry_type = geometry.get("type") if isinstance(geometry, dict) else None
 
     return OsmBoundary(
-        display_name=raw.get('display_name', ''),
-        osm_type=raw.get('osm_type'),
-        place_class=raw.get('class'),
-        place_type=raw.get('type'),
-        lat=float(raw['lat']),
-        lon=float(raw['lon']),
+        display_name=raw.get("display_name", ""),
+        osm_type=raw.get("osm_type"),
+        place_class=raw.get("class"),
+        place_type=raw.get("type"),
+        lat=float(raw["lat"]),
+        lon=float(raw["lon"]),
         bbox=bbox,
         geometry_type=geometry_type,
         polygon_area_m2=polygon_area_m2(geometry) if geometry else None,
     )
 
 
-def bbox_dims_m(bbox: BBox) -> Tuple[float, float]:
+def bbox_dims_m(bbox: BBox) -> tuple[float, float]:
     """
     (width_m, height_m) of a (south, north, west, east) bbox, measured
     geodesically — width along the middle latitude, matching
@@ -127,8 +130,9 @@ def bbox_dims_m(bbox: BBox) -> Tuple[float, float]:
     return width, height
 
 
-def frozen_rect_bounds(center_lat: float, center_lon: float,
-                       width_m: float, height_m: float) -> BBox:
+def frozen_rect_bounds(
+    center_lat: float, center_lon: float, width_m: float, height_m: float
+) -> BBox:
     """
     The frozen search rectangle as a (south, north, west, east) bbox —
     the inverse of the meters-from-degrees conversion, good to well under
@@ -137,8 +141,12 @@ def frozen_rect_bounds(center_lat: float, center_lon: float,
     half_h_deg = (height_m / 2) / _M_PER_DEG_LAT
     m_per_deg_lon = _M_PER_DEG_LON_EQUATOR * math.cos(math.radians(center_lat))
     half_w_deg = (width_m / 2) / m_per_deg_lon
-    return (center_lat - half_h_deg, center_lat + half_h_deg,
-            center_lon - half_w_deg, center_lon + half_w_deg)
+    return (
+        center_lat - half_h_deg,
+        center_lat + half_h_deg,
+        center_lon - half_w_deg,
+        center_lon + half_w_deg,
+    )
 
 
 def bbox_intersection_frac(rect: BBox, target: BBox) -> float:
@@ -160,7 +168,7 @@ def bbox_intersection_frac(rect: BBox, target: BBox) -> float:
     return (lat_overlap * lon_overlap) / (target_lat * target_lon)
 
 
-def _ring_area_m2(ring: List[List[float]]) -> float:
+def _ring_area_m2(ring: list[list[float]]) -> float:
     """
     Unsigned shoelace area of one GeoJSON ring ([lon, lat] pairs) in a
     local equirectangular frame anchored at the ring's mean latitude.
@@ -171,12 +179,12 @@ def _ring_area_m2(ring: List[List[float]]) -> float:
     kx = _M_PER_DEG_LON_EQUATOR * math.cos(math.radians(mean_lat))
     ky = _M_PER_DEG_LAT
     total = 0.0
-    for (lon1, lat1), (lon2, lat2) in zip(ring, ring[1:] + ring[:1]):
+    for (lon1, lat1), (lon2, lat2) in zip(ring, ring[1:] + ring[:1], strict=False):
         total += (lon1 * kx) * (lat2 * ky) - (lon2 * kx) * (lat1 * ky)
     return abs(total) / 2
 
 
-def polygon_area_m2(geometry: Optional[Dict[str, Any]]) -> Optional[float]:
+def polygon_area_m2(geometry: dict[str, Any] | None) -> float | None:
     """
     Area of a GeoJSON Polygon (exterior minus holes) or MultiPolygon
     (summed), in square meters. None for Point/LineString/anything else —
@@ -184,24 +192,25 @@ def polygon_area_m2(geometry: Optional[Dict[str, Any]]) -> Optional[float]:
     """
     if not isinstance(geometry, dict):
         return None
-    gtype = geometry.get('type')
-    if gtype == 'Polygon':
-        rings = geometry.get('coordinates', [])
+    gtype = geometry.get("type")
+    if gtype == "Polygon":
+        rings = geometry.get("coordinates", [])
         if not rings:
             return None
         area = _ring_area_m2(rings[0])
         for hole in rings[1:]:
             area -= _ring_area_m2(hole)
         return max(area, 0.0)
-    if gtype == 'MultiPolygon':
-        areas = [polygon_area_m2({'type': 'Polygon', 'coordinates': rings})
-                 for rings in geometry.get('coordinates', [])]
+    if gtype == "MultiPolygon":
+        areas = [
+            polygon_area_m2({"type": "Polygon", "coordinates": rings})
+            for rings in geometry.get("coordinates", [])
+        ]
         return sum(a for a in areas if a is not None) or None
     return None
 
 
-def _intersect(p1: List[float], p2: List[float], axis: int,
-               val: float) -> List[float]:
+def _intersect(p1: list[float], p2: list[float], axis: int, val: float) -> list[float]:
     """The point on segment p1->p2 where coordinate[axis] == val (linear)."""
     other = 1 - axis
     d = p2[axis] - p1[axis]
@@ -212,7 +221,7 @@ def _intersect(p1: List[float], p2: List[float], axis: int,
     return pt
 
 
-def _clip_ring_to_bbox(ring: List[List[float]], bbox: BBox) -> List[List[float]]:
+def _clip_ring_to_bbox(ring: list[list[float]], bbox: BBox) -> list[list[float]]:
     """
     Sutherland-Hodgman clip of a [lon, lat] ring against a (south, north,
     west, east) axis-aligned rectangle. Returns an open ring (no repeated
@@ -220,14 +229,13 @@ def _clip_ring_to_bbox(ring: List[List[float]], bbox: BBox) -> List[List[float]]
     """
     south, north, west, east = bbox
     # Drop an explicit closing vertex; the area/clip math treats rings as closed.
-    poly = (ring[:-1] if len(ring) > 1 and ring[0] == ring[-1] else list(ring))
+    poly = ring[:-1] if len(ring) > 1 and ring[0] == ring[-1] else list(ring)
     # (axis, threshold, keep_greater_equal): west, east, south, north edges.
-    edges = [(0, west, True), (0, east, False),
-             (1, south, True), (1, north, False)]
+    edges = [(0, west, True), (0, east, False), (1, south, True), (1, north, False)]
     for axis, val, keep_ge in edges:
         if not poly:
             break
-        clipped: List[List[float]] = []
+        clipped: list[list[float]] = []
         for i in range(len(poly)):
             cur, prev = poly[i], poly[i - 1]
             cur_in = cur[axis] >= val if keep_ge else cur[axis] <= val
@@ -242,26 +250,26 @@ def _clip_ring_to_bbox(ring: List[List[float]], bbox: BBox) -> List[List[float]]
     return poly
 
 
-def _clipped_polygon_area_m2(geometry: Dict[str, Any], bbox: BBox) -> float:
+def _clipped_polygon_area_m2(geometry: dict[str, Any], bbox: BBox) -> float:
     """Area (m²) of the part of a GeoJSON polygon inside `bbox`."""
-    gtype = geometry.get('type')
-    if gtype == 'Polygon':
-        rings = geometry.get('coordinates', [])
+    gtype = geometry.get("type")
+    if gtype == "Polygon":
+        rings = geometry.get("coordinates", [])
         if not rings:
             return 0.0
         area = _ring_area_m2(_clip_ring_to_bbox(rings[0], bbox))
         for hole in rings[1:]:
             area -= _ring_area_m2(_clip_ring_to_bbox(hole, bbox))
         return max(area, 0.0)
-    if gtype == 'MultiPolygon':
-        return sum(_clipped_polygon_area_m2({'type': 'Polygon',
-                                             'coordinates': rings}, bbox)
-                   for rings in geometry.get('coordinates', []))
+    if gtype == "MultiPolygon":
+        return sum(
+            _clipped_polygon_area_m2({"type": "Polygon", "coordinates": rings}, bbox)
+            for rings in geometry.get("coordinates", [])
+        )
     return 0.0
 
 
-def rect_polygon_coverage(geometry: Optional[Dict[str, Any]],
-                          bbox: Optional[BBox]) -> Optional[float]:
+def rect_polygon_coverage(geometry: dict[str, Any] | None, bbox: BBox | None) -> float | None:
     """
     Fraction of a GeoJSON boundary polygon's area that falls inside a
     (south, north, west, east) rectangle — "how much of the real city does
@@ -280,8 +288,13 @@ def rect_polygon_coverage(geometry: Optional[Dict[str, Any]],
     return max(0.0, min(1.0, inside / total))
 
 
-def classify(city: CityRow, osm: Optional[OsmBoundary],
-             thresholds: Thresholds = Thresholds()) -> AuditResult:
+# Module-level singleton so the default isn't a function call in the signature (B008).
+_DEFAULT_THRESHOLDS = Thresholds()
+
+
+def classify(
+    city: CityRow, osm: OsmBoundary | None, thresholds: Thresholds = _DEFAULT_THRESHOLDS
+) -> AuditResult:
     """
     Compare a city's frozen rectangle to its OSM boundary.
 
@@ -301,24 +314,24 @@ def classify(city: CityRow, osm: Optional[OsmBoundary],
       OK
     """
     if osm is None:
-        return AuditResult(verdict='NOT_FOUND')
+        return AuditResult(verdict="NOT_FOUND")
 
     result = AuditResult(
-        verdict='OK',
+        verdict="OK",
         osm_display_name=osm.display_name,
         osm_type=osm.osm_type,
         place_class=osm.place_class,
         place_type=osm.place_type,
         geometry_type=osm.geometry_type,
-        center_dist_km=geodesic((city.center_lat, city.center_lon),
-                                (osm.lat, osm.lon)).kilometers,
-        osm_polygon_area_km2=(osm.polygon_area_m2 / 1e6
-                              if osm.polygon_area_m2 is not None else None),
+        center_dist_km=geodesic((city.center_lat, city.center_lon), (osm.lat, osm.lon)).kilometers,
+        osm_polygon_area_km2=(
+            osm.polygon_area_m2 / 1e6 if osm.polygon_area_m2 is not None else None
+        ),
     )
 
     bbox = osm.bbox
     if bbox is None or bbox[2] > bbox[3] or (bbox[3] - bbox[2]) > 180:
-        result.verdict = 'BBOX_SUSPECT'
+        result.verdict = "BBOX_SUSPECT"
         return result
 
     south, north, west, east = bbox
@@ -330,23 +343,24 @@ def classify(city: CityRow, osm: Optional[OsmBoundary],
     result.suggested_center_lon = (west + east) / 2
     result.suggested_width_m = math.ceil(osm_w)
     result.suggested_height_m = math.ceil(osm_h)
-    result.center_in_osm_bbox = (south <= city.center_lat <= north
-                                 and west <= city.center_lon <= east)
+    result.center_in_osm_bbox = (
+        south <= city.center_lat <= north and west <= city.center_lon <= east
+    )
 
-    frozen_rect = frozen_rect_bounds(city.center_lat, city.center_lon,
-                                     city.grid_width_m, city.grid_height_m)
+    frozen_rect = frozen_rect_bounds(
+        city.center_lat, city.center_lon, city.grid_width_m, city.grid_height_m
+    )
     frozen_area_km2 = (city.grid_width_m * city.grid_height_m) / 1e6
     result.bbox_coverage_frac = bbox_intersection_frac(frozen_rect, bbox)
     if result.osm_bbox_area_km2 and result.osm_bbox_area_km2 > 0:
         result.over_area_ratio = frozen_area_km2 / result.osm_bbox_area_km2
 
     if not result.center_in_osm_bbox:
-        result.verdict = 'WRONG_PLACE'
-    elif osm.geometry_type not in ('Polygon', 'MultiPolygon'):
-        result.verdict = 'NO_POLYGON'
+        result.verdict = "WRONG_PLACE"
+    elif osm.geometry_type not in ("Polygon", "MultiPolygon"):
+        result.verdict = "NO_POLYGON"
     elif result.bbox_coverage_frac < thresholds.min_coverage:
-        result.verdict = 'UNDER'
-    elif (result.over_area_ratio is not None
-          and result.over_area_ratio > thresholds.over_area_ratio):
-        result.verdict = 'OVER'
+        result.verdict = "UNDER"
+    elif result.over_area_ratio is not None and result.over_area_ratio > thresholds.over_area_ratio:
+        result.verdict = "OVER"
     return result

--- a/gsv_metadata_tracker/cli.py
+++ b/gsv_metadata_tracker/cli.py
@@ -25,31 +25,31 @@ Concurrent API requests are controlled by two key parameters:
 """
 
 import argparse
-import sys
+import asyncio
 import logging
 import os
-import asyncio
-from datetime import date, datetime, timezone
+import sys
+from datetime import UTC, date, datetime
+
 from dotenv import load_dotenv
 
-from . import db
-from .analysis import print_df_summary, calculate_run_stats, detect_systemic_failure
-from .diff import compute_run_diff, generate_diff_filename, write_diff_detail
-from .fileutils import load_city_csv_file
-from .json_summarizer import generate_city_metadata_summary_as_json, generate_aggregate_v2
-from .naming import generate_run_filename, same_grid_geometry, sanitize_city_query_str
-from .paths import get_default_data_dir, get_default_vis_dir
-
 from . import (
-    load_config,
-    get_city_location_data,
-    get_search_dimensions,
     create_visualization_map,
+    db,
     display_search_area,
     download_gsv_metadata_async,
     download_mapillary_metadata_async,
-    open_in_browser
+    get_city_location_data,
+    get_search_dimensions,
+    load_config,
+    open_in_browser,
 )
+from .analysis import calculate_run_stats, detect_systemic_failure, print_df_summary
+from .diff import compute_run_diff, generate_diff_filename, write_diff_detail
+from .fileutils import load_city_csv_file
+from .json_summarizer import generate_aggregate_v2, generate_city_metadata_summary_as_json
+from .naming import generate_run_filename, same_grid_geometry, sanitize_city_query_str
+from .paths import get_default_data_dir, get_default_vis_dir
 
 logger = logging.getLogger(__name__)
 
@@ -87,7 +87,8 @@ def _cap_dimensions(grid_width, grid_height, city):
         logger.warning(
             f"Derived grid for '{city}' is {grid_width:.0f}x{grid_height:.0f}m; "
             f"clamping to {capped_w:.0f}x{capped_h:.0f}m (the OSM boundary is far "
-            f"larger than a typical city sample). Use --width/--height to override.")
+            f"larger than a typical city sample). Use --width/--height to override."
+        )
     return capped_w, capped_h
 
 
@@ -111,154 +112,140 @@ def parse_args():
         argparse.Namespace: Parsed command line arguments
     """
     parser = argparse.ArgumentParser(
-        description='GSV Metadata Tracker',
-        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+        description="GSV Metadata Tracker", formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+
+    parser.add_argument("city", help="City name to analyze")
+
+    parser.add_argument(
+        "--provider",
+        choices=["both", "gsv", "mapillary"],
+        default="both",
+        help="Imagery provider(s) to collect. The default collects GSV then "
+        "Mapillary back-to-back with the same run date so the two "
+        "series stay in sync. Each provider keeps its own independent "
+        "run series (dated files, diffs, skip policy) on the same "
+        "frozen city grid.",
     )
 
     parser.add_argument(
-        'city',
-        help='City name to analyze'
-    )
-
-    parser.add_argument(
-        '--provider',
-        choices=['both', 'gsv', 'mapillary'],
-        default='both',
-        help='Imagery provider(s) to collect. The default collects GSV then '
-             'Mapillary back-to-back with the same run date so the two '
-             'series stay in sync. Each provider keeps its own independent '
-             'run series (dated files, diffs, skip policy) on the same '
-             'frozen city grid.'
-    )
-
-    parser.add_argument(
-        '--download-dir',
+        "--download-dir",
         type=str,
-        help='Dir to save downloaded data (defaults to ./data)',
-        default=get_default_data_dir()
+        help="Dir to save downloaded data (defaults to ./data)",
+        default=get_default_data_dir(),
     )
 
     parser.add_argument(
-        '--width',
+        "--width",
         type=float,
         default=None,
-        help='Search grid width in meters. Only used when the city is not '
-             'yet registered; registered cities reuse frozen geometry. '
-             '(Default if inference fails: 1000m)'
+        help="Search grid width in meters. Only used when the city is not "
+        "yet registered; registered cities reuse frozen geometry. "
+        "(Default if inference fails: 1000m)",
     )
 
     parser.add_argument(
-        '--height',
+        "--height", type=float, default=None, help="Search grid height in meters. See --width."
+    )
+
+    parser.add_argument(
+        "--lat",
         type=float,
         default=None,
-        help='Search grid height in meters. See --width.'
+        help="Latitude of city center. Must be used with --lng. Only used "
+        "when the city is not yet registered.",
     )
 
     parser.add_argument(
-        '--lat',
-        type=float,
-        default=None,
-        help='Latitude of city center. Must be used with --lng. Only used '
-             'when the city is not yet registered.'
+        "--lng", type=float, default=None, help="Longitude of city center. Must be used with --lat."
     )
 
     parser.add_argument(
-        '--lng',
-        type=float,
-        default=None,
-        help='Longitude of city center. Must be used with --lat.'
-    )
-
-    parser.add_argument(
-        '--step',
+        "--step",
         type=float,
         default=20,
-        help='Step size in meters between sample points in the grid '
-             '(only used when the city is not yet registered)'
+        help="Step size in meters between sample points in the grid "
+        "(only used when the city is not yet registered)",
     )
 
     # Temporal tracking / run policy
-    run_group = parser.add_argument_group('Run Policy')
+    run_group = parser.add_argument_group("Run Policy")
     run_group.add_argument(
-        '--run-date',
+        "--run-date",
         type=date.fromisoformat,
         default=None,
-        metavar='YYYY-MM-DD',
-        help='Date recorded for this run (default: today, UTC). Embedded in '
-             'the output filename.'
+        metavar="YYYY-MM-DD",
+        help="Date recorded for this run (default: today, UTC). Embedded in the output filename.",
     )
     run_group.add_argument(
-        '--force',
-        action='store_true',
-        help='Collect even if a recent run exists'
+        "--force", action="store_true", help="Collect even if a recent run exists"
     )
     run_group.add_argument(
-        '--min-days-since-last-run',
+        "--min-days-since-last-run",
         type=int,
         default=80,
-        help='Skip (exit 0) if the latest run is newer than this many days'
+        help="Skip (exit 0) if the latest run is newer than this many days",
     )
     run_group.add_argument(
-        '--db-path',
+        "--db-path",
         type=str,
         default=None,
-        help='Path to the run catalog database (default: {download-dir}/gsv_tracker.db)'
+        help="Path to the run catalog database (default: {download-dir}/gsv_tracker.db)",
     )
     run_group.add_argument(
-        '--no-publish-json',
-        action='store_true',
-        help='Skip regenerating the aggregate cities.json.gz (the per-run '
-             'JSON is always written). Useful in batch/scheduler contexts '
-             'that regenerate the aggregate once at the end.'
+        "--no-publish-json",
+        action="store_true",
+        help="Skip regenerating the aggregate cities.json.gz (the per-run "
+        "JSON is always written). Useful in batch/scheduler contexts "
+        "that regenerate the aggregate once at the end.",
     )
 
     # Parameters controlling concurrent processing
-    concurrency_group = parser.add_argument_group('Concurrency Control')
+    concurrency_group = parser.add_argument_group("Concurrency Control")
     concurrency_group.add_argument(
-        '--batch-size',
+        "--batch-size",
         type=int,
         default=100,
-        help='''Number of requests to prepare and queue at once.
+        help="""Number of requests to prepare and queue at once.
              Should be >= connection-limit. Higher values use more memory
-             but can be more efficient. API limit is 500/second.'''
+             but can be more efficient. API limit is 500/second.""",
     )
 
     concurrency_group.add_argument(
-        '--connection-limit',
+        "--connection-limit",
         type=int,
         default=50,
-        help='''Maximum number of concurrent connections to the API.
+        help="""Maximum number of concurrent connections to the API.
              Controls how many requests are actually in-flight at once.
              Should be <= batch-size. Conservative values prevent overwhelming
-             the network or API.'''
+             the network or API.""",
     )
 
     parser.add_argument(
-        '--timeout',
+        "--timeout",
         type=float,
         default=30.0,
-        help='Timeout in seconds for each individual API request'
+        help="Timeout in seconds for each individual API request",
     )
 
     parser.add_argument(
-        '--check-boundary', '--check-size',
-        action='store_true',
-        help='Generate visualization of search area without downloading data. '
-            'Useful for verifying the area before starting a download.'
+        "--check-boundary",
+        "--check-size",
+        action="store_true",
+        help="Generate visualization of search area without downloading data. "
+        "Useful for verifying the area before starting a download.",
     )
 
     parser.add_argument(
-        '--no-visual',
-        action='store_true',
-        help='Skip generating visualizations of the results'
+        "--no-visual", action="store_true", help="Skip generating visualizations of the results"
     )
 
     parser.add_argument(
-        '--log-level',
+        "--log-level",
         type=str,
-        default='WARNING',
-        choices=['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'],
-        help='Set the logging level for output messages'
+        default="WARNING",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
+        help="Set the logging level for output messages",
     )
 
     args = parser.parse_args()
@@ -289,8 +276,11 @@ def _resolve_geometry(conn, args):
     """
     city_row = db.resolve_city(conn, args.city)
     if city_row is not None:
-        overrides = [o for o, v in (('--lat/--lng', args.lat),
-                                    ('--width/--height', args.width)) if v is not None]
+        overrides = [
+            o
+            for o, v in (("--lat/--lng", args.lat), ("--width/--height", args.width))
+            if v is not None
+        ]
         if overrides:
             logger.warning(
                 f"{' and '.join(overrides)} ignored: '{args.city}' is already "
@@ -298,7 +288,8 @@ def _resolve_geometry(conn, args):
                 f"(center {city_row.center_lat:.5f},{city_row.center_lon:.5f}, "
                 f"{city_row.grid_width_m}x{city_row.grid_height_m}m, "
                 f"step {city_row.step_m}m). Changing geometry would break "
-                f"run-to-run diffs.")
+                f"run-to-run diffs."
+            )
         return city_row, False
 
     # Unknown city: geocode once and register with frozen geometry
@@ -310,8 +301,10 @@ def _resolve_geometry(conn, args):
     elif city_loc_data:
         center_lat, center_lng = _resolve_center(city_loc_data)
     else:
-        logger.error(f"Could not find coordinates for {args.city}. "
-                     f"Use --lat and --lng to provide them manually.")
+        logger.error(
+            f"Could not find coordinates for {args.city}. "
+            f"Use --lat and --lng to provide them manually."
+        )
         sys.exit(1)
 
     if args.width is not None:
@@ -321,7 +314,7 @@ def _resolve_geometry(conn, args):
         grid_width, grid_height = get_search_dimensions(args.city, 1000, 1000)
         grid_width, grid_height = _cap_dimensions(grid_width, grid_height, args.city)
 
-    city_name = city_loc_data.city if city_loc_data else args.city.split(',')[0].strip()
+    city_name = city_loc_data.city if city_loc_data else args.city.split(",")[0].strip()
     state_name = city_loc_data.state if city_loc_data else None
     state_code = city_loc_data.state_code if city_loc_data else None
     country_name = city_loc_data.country if city_loc_data else None
@@ -351,8 +344,9 @@ def _resolve_geometry(conn, args):
     return db.resolve_city(conn, city_id), True
 
 
-def _compute_and_record_diff(conn, city_row, prev_run, run_id, run_date,
-                             df_new, download_dir, provider='gsv'):
+def _compute_and_record_diff(
+    conn, city_row, prev_run, run_id, run_date, df_new, download_dir, provider="gsv"
+):
     """
     Diff the new run against the previous one of the same provider, persist
     the summary row (and detail csv.gz when there are changes), and return
@@ -369,8 +363,8 @@ def _compute_and_record_diff(conn, city_row, prev_run, run_id, run_date,
     detail_filename = None
     if diff.has_changes:
         detail_filename = generate_diff_filename(
-            city_row.city_id, prev_run.run_date, run_date.isoformat(),
-            provider=provider)
+            city_row.city_id, prev_run.run_date, run_date.isoformat(), provider=provider
+        )
         write_diff_detail(diff, os.path.join(download_dir, detail_filename))
 
     db.record_diff(
@@ -422,17 +416,17 @@ async def async_main():
 
     logging.basicConfig(
         level=getattr(logging, args.log_level.upper()),
-        format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
-        datefmt='%Y-%m-%d %H:%M:%S'
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
     )
 
     os.makedirs(args.download_dir, exist_ok=True)
     logging.info(f"Using download directory: {args.download_dir}")
 
-    run_date = args.run_date or datetime.now(timezone.utc).date()
+    run_date = args.run_date or datetime.now(UTC).date()
     db_path = args.db_path or db.get_default_db_path(args.download_dir)
 
-    providers = ['gsv', 'mapillary'] if args.provider == 'both' else [args.provider]
+    providers = ["gsv", "mapillary"] if args.provider == "both" else [args.provider]
 
     try:
         # Fail fast: require every requested provider's credential before
@@ -450,17 +444,20 @@ async def async_main():
         city_row, newly_registered = _resolve_geometry(conn, args)
 
         print(f"City: {city_row.display_name} ({city_row.city_id})")
-        print(f"Grid: {city_row.grid_width_m}m x {city_row.grid_height_m}m, "
-              f"step {city_row.step_m}m, centered at "
-              f"{city_row.center_lat:.5f}, {city_row.center_lon:.5f}")
+        print(
+            f"Grid: {city_row.grid_width_m}m x {city_row.grid_height_m}m, "
+            f"step {city_row.step_m}m, centered at "
+            f"{city_row.center_lat:.5f}, {city_row.center_lon:.5f}"
+        )
 
         # Collect each provider in turn (same run_date, so series pair up).
         # One provider failing must not prevent the other from collecting.
         failed = []
         for provider in providers:
             try:
-                await _collect_one_run(conn, args, city_row, run_date,
-                                       provider, configs[provider], vis_path)
+                await _collect_one_run(
+                    conn, args, city_row, run_date, provider, configs[provider], vis_path
+                )
             except Exception as e:
                 logging.exception(f"{provider} collection failed: {e}")
                 failed.append(provider)
@@ -478,8 +475,7 @@ async def async_main():
         sys.exit(1)
 
 
-async def _collect_one_run(conn, args, city_row, run_date, provider, config,
-                           vis_path) -> None:
+async def _collect_one_run(conn, args, city_row, run_date, provider, config, vis_path) -> None:
     """
     Collect, catalog, diff, and summarize one (city, provider) run.
     Returns silently when the skip policy applies; raises on failure.
@@ -490,26 +486,35 @@ async def _collect_one_run(conn, args, city_row, run_date, provider, config,
     if latest is not None:
         days_since = (run_date - date.fromisoformat(latest.run_date)).days
         if latest.run_date == run_date.isoformat():
-            print(f"A {provider} run already exists for {city_row.city_id} "
-                  f"on {run_date} ({latest.csv_filename}); nothing to do. "
-                  f"Use --run-date to record a different date.")
+            print(
+                f"A {provider} run already exists for {city_row.city_id} "
+                f"on {run_date} ({latest.csv_filename}); nothing to do. "
+                f"Use --run-date to record a different date."
+            )
             return
         if not args.force and days_since < args.min_days_since_last_run:
-            print(f"SKIP: latest {provider} run for {city_row.city_id} is "
-                  f"{days_since} days old ({latest.run_date}), newer than "
-                  f"--min-days-since-last-run={args.min_days_since_last_run}. "
-                  f"Use --force to collect anyway.")
+            print(
+                f"SKIP: latest {provider} run for {city_row.city_id} is "
+                f"{days_since} days old ({latest.run_date}), newer than "
+                f"--min-days-since-last-run={args.min_days_since_last_run}. "
+                f"Use --force to collect anyway."
+            )
             return
 
     # Dated, immutable output file for this run
     run_base = generate_run_filename(
-        city_row.city_id, city_row.grid_width_m, city_row.grid_height_m,
-        city_row.step_m, run_date, provider=provider)
+        city_row.city_id,
+        city_row.grid_width_m,
+        city_row.grid_height_m,
+        city_row.step_m,
+        run_date,
+        provider=provider,
+    )
     output_csv_gz_path = os.path.join(args.download_dir, f"{run_base}.csv.gz")
 
     logging.info(f"Collecting {provider} run {run_date} for {city_row.city_id}")
 
-    if provider == 'mapillary':
+    if provider == "mapillary":
         dict_results = await download_mapillary_metadata_async(
             city_name=city_row.display_name,
             center_lat=city_row.center_lat,
@@ -517,13 +522,14 @@ async def _collect_one_run(conn, args, city_row, run_date, provider, config,
             grid_width=city_row.grid_width_m,
             grid_height=city_row.grid_height_m,
             step_length=city_row.step_m,
-            access_token=config['access_token'],
+            access_token=config["access_token"],
             output_csv_gz_path=output_csv_gz_path,
-            request_timeout=args.timeout
+            request_timeout=args.timeout,
         )
     else:
-        logging.info(f"Using batch_size={args.batch_size}, "
-                     f"connection_limit={args.connection_limit}")
+        logging.info(
+            f"Using batch_size={args.batch_size}, connection_limit={args.connection_limit}"
+        )
         dict_results = await download_gsv_metadata_async(
             city_name=city_row.display_name,
             center_lat=city_row.center_lat,
@@ -531,18 +537,17 @@ async def _collect_one_run(conn, args, city_row, run_date, provider, config,
             grid_width=city_row.grid_width_m,
             grid_height=city_row.grid_height_m,
             step_length=city_row.step_m,
-            api_key=config['api_key'],
+            api_key=config["api_key"],
             output_csv_gz_path=output_csv_gz_path,
             batch_size=args.batch_size,
             connection_limit=args.connection_limit,
-            request_timeout=args.timeout
+            request_timeout=args.timeout,
         )
     df = dict_results["df"]
 
     # Record API usage in the daily per-provider budget ledger (the
     # requests were spent even if the run is rejected below)
-    db.add_api_usage(conn, run_date, dict_results["api_requests"],
-                     provider=provider)
+    db.add_api_usage(conn, run_date, dict_results["api_requests"], provider=provider)
 
     # Refuse to catalog a run dominated by credential/quota denials: it
     # says nothing about the city, and once registered it would become the
@@ -554,7 +559,8 @@ async def _collect_one_run(conn, args, city_row, run_date, provider, config,
         os.replace(output_csv_gz_path, rejected_path)
         raise RuntimeError(
             f"{provider} run rejected, not cataloged: {failure_reason}. "
-            f"Raw responses kept at {rejected_path}")
+            f"Raw responses kept at {rejected_path}"
+        )
 
     print(f"\nDownload Summary for {city_row.display_name} [{provider}]")
     print("=" * 50)
@@ -566,8 +572,9 @@ async def _collect_one_run(conn, args, city_row, run_date, provider, config,
     started = dict_results.get("started_at")
     finished = dict_results.get("finished_at")
     if started and finished:
-        duration = (datetime.fromisoformat(finished)
-                    - datetime.fromisoformat(started)).total_seconds()
+        duration = (
+            datetime.fromisoformat(finished) - datetime.fromisoformat(started)
+        ).total_seconds()
     run_id = db.register_run(
         conn,
         city_id=city_row.city_id,
@@ -587,38 +594,41 @@ async def _collect_one_run(conn, args, city_row, run_date, provider, config,
     # the filename; a cross-geometry diff would compare different sampled
     # areas and produce meaningless added/removed counts.
     change_block = None
-    prev_run = db.get_previous_run(conn, city_row.city_id, run_date,
-                                   provider=provider)
+    prev_run = db.get_previous_run(conn, city_row.city_id, run_date, provider=provider)
     if prev_run is not None:
         new_csv_filename = os.path.basename(output_csv_gz_path)
         if same_grid_geometry(prev_run.csv_filename, new_csv_filename):
             change_block = _compute_and_record_diff(
-                conn, city_row, prev_run, run_id, run_date, df,
-                args.download_dir, provider=provider)
+                conn, city_row, prev_run, run_id, run_date, df, args.download_dir, provider=provider
+            )
         else:
             logger.warning(
                 f"Skipping diff for {city_row.city_id} [{provider}]: previous "
                 f"run {prev_run.csv_filename} has different grid geometry than "
                 f"{new_csv_filename}; diffs resume once two same-geometry runs "
-                f"exist")
+                f"exist"
+            )
 
     # Per-run summary JSON (schema v2, ages pinned to run_date)
     json_path = generate_city_metadata_summary_as_json(
-        output_csv_gz_path, df,
+        output_csv_gz_path,
+        df,
         city_row.city_name,
         city_row.state_name,
         city_row.country_name,
-        city_row.grid_width_m, city_row.grid_height_m, city_row.step_m,
+        city_row.grid_width_m,
+        city_row.grid_height_m,
+        city_row.step_m,
         force_recreate_file=True,
         run_date=run_date,
         change_from_previous_run=change_block,
-        provider=provider)
+        provider=provider,
+    )
     db.update_run_json_filename(conn, run_id, os.path.basename(json_path))
 
     if not args.no_visual:
         map_path = os.path.join(vis_path, f"{run_base}.html")
-        map_obj = create_visualization_map(df, city_row.display_name,
-                                           provider=provider)
+        map_obj = create_visualization_map(df, city_row.display_name, provider=provider)
         print(f"Saving map visualization to {map_path}")
         map_obj.save(map_path)
         logging.info(f"Map visualization saved to {map_path}")
@@ -638,14 +648,17 @@ def _check_boundary(conn, args, vis_path: str) -> int:
 
     city_row = db.resolve_city(conn, args.city)
     if city_row is not None:
-        overrides = [o for o, v in (('--lat/--lng', args.lat),
-                                    ('--width/--height', args.width)) if v is not None]
+        overrides = [
+            o
+            for o, v in (("--lat/--lng", args.lat), ("--width/--height", args.width))
+            if v is not None
+        ]
         if overrides:
             logger.warning(
                 f"{' and '.join(overrides)} ignored: '{args.city}' is already "
-                f"registered as {city_row.city_id} with frozen grid geometry")
-        print(f"'{args.city}' is registered as {city_row.city_id}; "
-              f"previewing its frozen geometry")
+                f"registered as {city_row.city_id} with frozen grid geometry"
+            )
+        print(f"'{args.city}' is registered as {city_row.city_id}; previewing its frozen geometry")
         city_id = city_row.city_id
         center_lat, center_lng = city_row.center_lat, city_row.center_lon
         grid_width, grid_height = city_row.grid_width_m, city_row.grid_height_m
@@ -657,8 +670,10 @@ def _check_boundary(conn, args, vis_path: str) -> int:
         elif city_loc_data:
             center_lat, center_lng = _resolve_center(city_loc_data)
         else:
-            logging.error(f"Could not find coordinates for {args.city}. "
-                          f"Use --lat and --lng to provide them manually.")
+            logging.error(
+                f"Could not find coordinates for {args.city}. "
+                f"Use --lat and --lng to provide them manually."
+            )
             return 1
 
         if args.width is not None:
@@ -671,8 +686,9 @@ def _check_boundary(conn, args, vis_path: str) -> int:
         # Same canonical id register_city would derive, so the preview
         # filename matches the files an eventual run will produce
         if city_loc_data:
-            city_id = db.derive_city_id(city_loc_data.city, city_loc_data.state,
-                                        city_loc_data.country)
+            city_id = db.derive_city_id(
+                city_loc_data.city, city_loc_data.state, city_loc_data.country
+            )
         else:
             city_id = db.derive_city_id(args.city, None, None)
 
@@ -682,7 +698,8 @@ def _check_boundary(conn, args, vis_path: str) -> int:
     boundary_vis_full_path = os.path.join(vis_path, f"{base_name}_search_boundary.html")
 
     search_area_map = display_search_area(
-        args.city, center_lat, center_lng, grid_width, grid_height, args.step)
+        args.city, center_lat, center_lng, grid_width, grid_height, args.step
+    )
     search_area_map.save(boundary_vis_full_path)
 
     print(f"\nSearch area preview saved to: {boundary_vis_full_path}")
@@ -692,7 +709,9 @@ def _check_boundary(conn, args, vis_path: str) -> int:
     success, error_msg = open_in_browser(boundary_vis_full_path)
     if not success:
         logging.warning(f"Could not automatically open visualization: {error_msg}")
-        print(f"Please open {boundary_vis_full_path} in your web browser to view the visualization.")
+        print(
+            f"Please open {boundary_vis_full_path} in your web browser to view the visualization."
+        )
 
     return 0
 
@@ -712,7 +731,7 @@ def main():
     # 1. ProactorEventLoop (default): Good for subprocess/pipes but can have issues with some async operations
     # 2. SelectorEventLoop: More compatible with networking operations like what we're doing
     # So, on Windows, we explicitly set the event loop to use SelectorEventLoop
-    if sys.platform.startswith('win'):
+    if sys.platform.startswith("win"):
         # Override default Windows event loop policy to ensure compatibility
         # with aiohttp's async networking operations
         asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
@@ -726,5 +745,6 @@ def main():
         logging.exception(f"Fatal error: {str(e)}")
         sys.exit(1)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()

--- a/gsv_metadata_tracker/config.py
+++ b/gsv_metadata_tracker/config.py
@@ -1,26 +1,27 @@
-import os
 import logging
+import os
+from typing import Any
+
 import numpy as np
 import pandas as pd
-from typing import Dict, Any
-from .paths import get_default_data_dir
 
 logger = logging.getLogger(__name__)
 
 # Standard metadata schema for GSV download files
 METADATA_DTYPES = {
-    'query_lat': np.float64,
-    'query_lon': np.float64,
-    'query_timestamp': str,            # initially read as a str; stored in (ISO 8601 with timezone) 
-    'pano_lat': pd.Float64Dtype(),     # nullable float
-    'pano_lon': pd.Float64Dtype(),     # nullable float
-    'pano_id': pd.StringDtype(),       # nullable string
-    'capture_date': str,               # initially read as a str; stored in ISO 8601 format (YYYY-MM-DD)
-    'copyright_info': pd.StringDtype(), # nullable string
-    'status': str # status is never null
+    "query_lat": np.float64,
+    "query_lon": np.float64,
+    "query_timestamp": str,  # initially read as a str; stored in (ISO 8601 with timezone)
+    "pano_lat": pd.Float64Dtype(),  # nullable float
+    "pano_lon": pd.Float64Dtype(),  # nullable float
+    "pano_id": pd.StringDtype(),  # nullable string
+    "capture_date": str,  # initially read as a str; stored in ISO 8601 format (YYYY-MM-DD)
+    "copyright_info": pd.StringDtype(),  # nullable string
+    "status": str,  # status is never null
 }
 
-def load_config(provider: str = 'gsv') -> Dict[str, Any]:
+
+def load_config(provider: str = "gsv") -> dict[str, Any]:
     """
     Load the API credential for the given provider from the environment.
 
@@ -28,11 +29,11 @@ def load_config(provider: str = 'gsv') -> Dict[str, Any]:
     Only the requested provider's credential is required, so a machine can
     run one provider without the other's key.
     """
-    if provider == 'gsv':
+    if provider == "gsv":
         config = {
-            'api_key': os.environ.get('GMAPS_API_KEY'),
+            "api_key": os.environ.get("GMAPS_API_KEY"),
         }
-        if not config['api_key']:
+        if not config["api_key"]:
             raise ValueError(
                 "GMAPS_API_KEY not found in environment variables.\n\n"
                 "Option 1: Create a .env file in your project root:\n"
@@ -50,11 +51,11 @@ def load_config(provider: str = 'gsv') -> Dict[str, Any]:
             )
         return config
 
-    if provider == 'mapillary':
+    if provider == "mapillary":
         config = {
-            'access_token': os.environ.get('MAPILLARY_ACCESS_TOKEN'),
+            "access_token": os.environ.get("MAPILLARY_ACCESS_TOKEN"),
         }
-        if not config['access_token']:
+        if not config["access_token"]:
             raise ValueError(
                 "MAPILLARY_ACCESS_TOKEN not found in environment variables.\n\n"
                 "Option 1: Add it to the .env file in your project root:\n"

--- a/gsv_metadata_tracker/db.py
+++ b/gsv_metadata_tracker/db.py
@@ -21,8 +21,7 @@ import logging
 import os
 import sqlite3
 from dataclasses import dataclass
-from datetime import date, datetime, timezone
-from typing import List, Optional
+from datetime import UTC, date, datetime
 
 from .naming import sanitize_city_query_str
 
@@ -229,13 +228,14 @@ ALTER TABLE runs ADD COLUMN status_no_date INTEGER;
 @dataclass
 class CityRow:
     """A row from the cities table."""
+
     city_id: str
     display_name: str
     city_name: str
-    state_name: Optional[str]
-    state_code: Optional[str]
-    country_name: Optional[str]
-    country_code: Optional[str]
+    state_name: str | None
+    state_code: str | None
+    country_name: str | None
+    country_code: str | None
     center_lat: float
     center_lon: float
     grid_width_m: int
@@ -243,39 +243,40 @@ class CityRow:
     step_m: int
     created_at: str
     enabled: bool
-    notes: Optional[str]
+    notes: str | None
 
 
 @dataclass
 class RunRow:
     """A row from the runs table."""
+
     run_id: int
     city_id: str
     provider: str
     run_date: str
     csv_filename: str
-    json_filename: Optional[str]
+    json_filename: str | None
     is_baseline: bool
-    started_at: Optional[str]
-    finished_at: Optional[str]
-    duration_seconds: Optional[float]
-    total_points: Optional[int]
-    status_ok: Optional[int]
-    status_no_date: Optional[int]
-    status_zero_results: Optional[int]
-    status_other: Optional[int]
-    unique_panos: Optional[int]
-    unique_google_panos: Optional[int]
-    coverage_rate_pct: Optional[float]
-    oldest_capture_date: Optional[str]
-    newest_capture_date: Optional[str]
-    median_pano_age_years: Optional[float]
-    api_requests: Optional[int]
+    started_at: str | None
+    finished_at: str | None
+    duration_seconds: float | None
+    total_points: int | None
+    status_ok: int | None
+    status_no_date: int | None
+    status_zero_results: int | None
+    status_other: int | None
+    unique_panos: int | None
+    unique_google_panos: int | None
+    coverage_rate_pct: float | None
+    oldest_capture_date: str | None
+    newest_capture_date: str | None
+    median_pano_age_years: float | None
+    api_requests: int | None
 
 
 def utc_now_iso() -> str:
     """Current UTC time as an ISO 8601 string."""
-    return datetime.now(timezone.utc).isoformat()
+    return datetime.now(UTC).isoformat()
 
 
 def get_default_db_path(data_dir: str) -> str:
@@ -304,7 +305,8 @@ def init_schema(conn: sqlite3.Connection) -> None:
     if user_version > SCHEMA_VERSION:
         raise RuntimeError(
             f"Database schema version {user_version} is newer than this code "
-            f"supports ({SCHEMA_VERSION}). Update the code before proceeding.")
+            f"supports ({SCHEMA_VERSION}). Update the code before proceeding."
+        )
     if user_version == 1:
         _migrate_v1_to_v2(conn)
         user_version = 2
@@ -332,8 +334,7 @@ def _migrate_v1_to_v2(conn: sqlite3.Connection) -> None:
         conn.executescript(_MIGRATE_V1_TO_V2)
         violations = conn.execute("PRAGMA foreign_key_check").fetchall()
         if violations:
-            raise RuntimeError(
-                f"Schema migration produced foreign key violations: {violations}")
+            raise RuntimeError(f"Schema migration produced foreign key violations: {violations}")
         conn.commit()
     finally:
         conn.execute("PRAGMA foreign_keys=ON")
@@ -347,15 +348,14 @@ def _migrate_v3_to_v4(conn: sqlite3.Connection) -> None:
     column) can still be stamped forward through this step.
     """
     cols = {r[1] for r in conn.execute("PRAGMA table_info(runs)").fetchall()}
-    if 'status_no_date' in cols:
+    if "status_no_date" in cols:
         return
     logger.info("Migrating catalog schema v3 -> v4 (adding runs.status_no_date)")
     conn.executescript(_MIGRATE_V3_TO_V4)
     conn.commit()
 
 
-def derive_city_id(city_name: str, state_name: Optional[str],
-                   country_name: Optional[str]) -> str:
+def derive_city_id(city_name: str, state_name: str | None, country_name: str | None) -> str:
     """
     Canonical city id: the sanitized slug of the full (never abbreviated)
     location names, e.g. 'albany--new-york--united-states'. Derived once at
@@ -365,18 +365,21 @@ def derive_city_id(city_name: str, state_name: Optional[str],
     return sanitize_city_query_str(", ".join(components))
 
 
-def register_city(conn: sqlite3.Connection, *,
-                  city_name: str,
-                  state_name: Optional[str],
-                  state_code: Optional[str],
-                  country_name: Optional[str],
-                  country_code: Optional[str],
-                  center_lat: float,
-                  center_lon: float,
-                  grid_width_m: float,
-                  grid_height_m: float,
-                  step_m: float,
-                  notes: Optional[str] = None) -> str:
+def register_city(
+    conn: sqlite3.Connection,
+    *,
+    city_name: str,
+    state_name: str | None,
+    state_code: str | None,
+    country_name: str | None,
+    country_code: str | None,
+    center_lat: float,
+    center_lon: float,
+    grid_width_m: float,
+    grid_height_m: float,
+    step_m: float,
+    notes: str | None = None,
+) -> str:
     """
     Register a city with its frozen grid geometry. Idempotent: if the city
     already exists, the existing row wins (geometry is never overwritten).
@@ -391,20 +394,36 @@ def register_city(conn: sqlite3.Connection, *,
             country_name, country_code, center_lat, center_lon,
             grid_width_m, grid_height_m, step_m, created_at)
            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
-        (city_id, ", ".join(display_parts), city_name, state_name, state_code,
-         country_name, country_code, center_lat, center_lon,
-         int(grid_width_m), int(grid_height_m), int(step_m), utc_now_iso()))
+        (
+            city_id,
+            ", ".join(display_parts),
+            city_name,
+            state_name,
+            state_code,
+            country_name,
+            country_code,
+            center_lat,
+            center_lon,
+            int(grid_width_m),
+            int(grid_height_m),
+            int(step_m),
+            utc_now_iso(),
+        ),
+    )
     conn.commit()
     return city_id
 
 
-def update_city_geometry(conn: sqlite3.Connection, *,
-                         city_id: str,
-                         center_lat: float,
-                         center_lon: float,
-                         grid_width_m: float,
-                         grid_height_m: float,
-                         notes: Optional[str] = None) -> None:
+def update_city_geometry(
+    conn: sqlite3.Connection,
+    *,
+    city_id: str,
+    center_lat: float,
+    center_lon: float,
+    grid_width_m: float,
+    grid_height_m: float,
+    notes: str | None = None,
+) -> None:
     """
     Overwrite a city's frozen grid geometry (center + dimensions).
 
@@ -418,9 +437,8 @@ def update_city_geometry(conn: sqlite3.Connection, *,
     notes so the correction leaves an audit trail on the row.
     """
     if notes:
-        existing = conn.execute(
-            "SELECT notes FROM cities WHERE city_id = ?", (city_id,)).fetchone()
-        prior = existing['notes'] if existing and existing['notes'] else None
+        existing = conn.execute("SELECT notes FROM cities WHERE city_id = ?", (city_id,)).fetchone()
+        prior = existing["notes"] if existing and existing["notes"] else None
         notes = f"{prior}\n{notes}" if prior else notes
 
     cur = conn.execute(
@@ -429,8 +447,8 @@ def update_city_geometry(conn: sqlite3.Connection, *,
                grid_width_m = ?, grid_height_m = ?,
                notes = COALESCE(?, notes)
            WHERE city_id = ?""",
-        (center_lat, center_lon, int(grid_width_m), int(grid_height_m),
-         notes, city_id))
+        (center_lat, center_lon, int(grid_width_m), int(grid_height_m), notes, city_id),
+    )
     if cur.rowcount == 0:
         raise KeyError(f"Cannot update geometry: unknown city_id '{city_id}'")
     conn.commit()
@@ -440,11 +458,12 @@ def add_alias(conn: sqlite3.Connection, alias_slug: str, city_id: str) -> None:
     """Map a legacy filename slug (e.g. 'albany--ny') to a canonical city."""
     conn.execute(
         "INSERT OR IGNORE INTO city_aliases (alias_slug, city_id) VALUES (?, ?)",
-        (alias_slug, city_id))
+        (alias_slug, city_id),
+    )
     conn.commit()
 
 
-def resolve_city(conn: sqlite3.Connection, query: str) -> Optional[CityRow]:
+def resolve_city(conn: sqlite3.Connection, query: str) -> CityRow | None:
     """
     Resolve a city query string or slug to its catalog row.
 
@@ -452,46 +471,50 @@ def resolve_city(conn: sqlite3.Connection, query: str) -> Optional[CityRow]:
     match, then a display_name match (case-insensitive).
     """
     slug = sanitize_city_query_str(query)
-    row = conn.execute(
-        "SELECT * FROM cities WHERE city_id = ?", (slug,)).fetchone()
+    row = conn.execute("SELECT * FROM cities WHERE city_id = ?", (slug,)).fetchone()
     if row is None:
         row = conn.execute(
             """SELECT c.* FROM cities c
                JOIN city_aliases a ON a.city_id = c.city_id
-               WHERE a.alias_slug = ?""", (slug,)).fetchone()
+               WHERE a.alias_slug = ?""",
+            (slug,),
+        ).fetchone()
     if row is None:
         row = conn.execute(
-            "SELECT * FROM cities WHERE lower(display_name) = lower(?)",
-            (query.strip(),)).fetchone()
+            "SELECT * FROM cities WHERE lower(display_name) = lower(?)", (query.strip(),)
+        ).fetchone()
     if row is None:
         return None
     d = dict(row)
-    d['enabled'] = bool(d['enabled'])
+    d["enabled"] = bool(d["enabled"])
     return CityRow(**d)
 
 
-def register_run(conn: sqlite3.Connection, *,
-                 city_id: str,
-                 run_date: date,
-                 csv_filename: str,
-                 provider: str = 'gsv',
-                 json_filename: Optional[str] = None,
-                 is_baseline: bool = False,
-                 started_at: Optional[str] = None,
-                 finished_at: Optional[str] = None,
-                 duration_seconds: Optional[float] = None,
-                 total_points: Optional[int] = None,
-                 status_ok: Optional[int] = None,
-                 status_no_date: Optional[int] = None,
-                 status_zero_results: Optional[int] = None,
-                 status_other: Optional[int] = None,
-                 unique_panos: Optional[int] = None,
-                 unique_google_panos: Optional[int] = None,
-                 coverage_rate_pct: Optional[float] = None,
-                 oldest_capture_date: Optional[str] = None,
-                 newest_capture_date: Optional[str] = None,
-                 median_pano_age_years: Optional[float] = None,
-                 api_requests: Optional[int] = None) -> int:
+def register_run(
+    conn: sqlite3.Connection,
+    *,
+    city_id: str,
+    run_date: date,
+    csv_filename: str,
+    provider: str = "gsv",
+    json_filename: str | None = None,
+    is_baseline: bool = False,
+    started_at: str | None = None,
+    finished_at: str | None = None,
+    duration_seconds: float | None = None,
+    total_points: int | None = None,
+    status_ok: int | None = None,
+    status_no_date: int | None = None,
+    status_zero_results: int | None = None,
+    status_other: int | None = None,
+    unique_panos: int | None = None,
+    unique_google_panos: int | None = None,
+    coverage_rate_pct: float | None = None,
+    oldest_capture_date: str | None = None,
+    newest_capture_date: str | None = None,
+    median_pano_age_years: float | None = None,
+    api_requests: int | None = None,
+) -> int:
     """
     Register a completed collection run. Raises sqlite3.IntegrityError if a
     run already exists for (city_id, provider, run_date) or the csv_filename
@@ -508,72 +531,90 @@ def register_run(conn: sqlite3.Connection, *,
             oldest_capture_date, newest_capture_date, median_pano_age_years,
             api_requests)
            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
-        (city_id, provider, run_date.isoformat(), csv_filename, json_filename,
-         int(is_baseline), started_at, finished_at, duration_seconds,
-         total_points, status_ok, status_no_date, status_zero_results,
-         status_other, unique_panos, unique_google_panos, coverage_rate_pct,
-         oldest_capture_date, newest_capture_date, median_pano_age_years,
-         api_requests))
+        (
+            city_id,
+            provider,
+            run_date.isoformat(),
+            csv_filename,
+            json_filename,
+            int(is_baseline),
+            started_at,
+            finished_at,
+            duration_seconds,
+            total_points,
+            status_ok,
+            status_no_date,
+            status_zero_results,
+            status_other,
+            unique_panos,
+            unique_google_panos,
+            coverage_rate_pct,
+            oldest_capture_date,
+            newest_capture_date,
+            median_pano_age_years,
+            api_requests,
+        ),
+    )
     conn.commit()
     return cur.lastrowid
 
 
-def update_run_json_filename(conn: sqlite3.Connection, run_id: int,
-                             json_filename: str) -> None:
+def update_run_json_filename(conn: sqlite3.Connection, run_id: int, json_filename: str) -> None:
     """Record the per-run summary JSON filename after it is generated."""
-    conn.execute("UPDATE runs SET json_filename = ? WHERE run_id = ?",
-                 (json_filename, run_id))
+    conn.execute("UPDATE runs SET json_filename = ? WHERE run_id = ?", (json_filename, run_id))
     conn.commit()
 
 
 def _row_to_run(row: sqlite3.Row) -> RunRow:
     d = dict(row)
-    d['is_baseline'] = bool(d['is_baseline'])
+    d["is_baseline"] = bool(d["is_baseline"])
     return RunRow(**d)
 
 
-def get_latest_run(conn: sqlite3.Connection, city_id: str,
-                   provider: str = 'gsv') -> Optional[RunRow]:
+def get_latest_run(conn: sqlite3.Connection, city_id: str, provider: str = "gsv") -> RunRow | None:
     """Most recent run for a (city, provider) by run_date, or None."""
     row = conn.execute(
         """SELECT * FROM runs WHERE city_id = ? AND provider = ?
            ORDER BY run_date DESC LIMIT 1""",
-        (city_id, provider)).fetchone()
+        (city_id, provider),
+    ).fetchone()
     return _row_to_run(row) if row else None
 
 
-def get_previous_run(conn: sqlite3.Connection, city_id: str,
-                     before_date: date,
-                     provider: str = 'gsv') -> Optional[RunRow]:
+def get_previous_run(
+    conn: sqlite3.Connection, city_id: str, before_date: date, provider: str = "gsv"
+) -> RunRow | None:
     """Most recent run strictly before the given date, or None."""
     row = conn.execute(
         """SELECT * FROM runs WHERE city_id = ? AND provider = ?
            AND run_date < ?
            ORDER BY run_date DESC LIMIT 1""",
-        (city_id, provider, before_date.isoformat())).fetchone()
+        (city_id, provider, before_date.isoformat()),
+    ).fetchone()
     return _row_to_run(row) if row else None
 
 
-def get_runs_for_city(conn: sqlite3.Connection, city_id: str,
-                      provider: Optional[str] = 'gsv') -> List[RunRow]:
+def get_runs_for_city(
+    conn: sqlite3.Connection, city_id: str, provider: str | None = "gsv"
+) -> list[RunRow]:
     """
     Runs for a city, oldest first. provider=None returns runs for all
     providers (used by the aggregate builder, which groups them itself).
     """
     if provider is None:
         rows = conn.execute(
-            "SELECT * FROM runs WHERE city_id = ? ORDER BY run_date ASC",
-            (city_id,)).fetchall()
+            "SELECT * FROM runs WHERE city_id = ? ORDER BY run_date ASC", (city_id,)
+        ).fetchall()
     else:
         rows = conn.execute(
             """SELECT * FROM runs WHERE city_id = ? AND provider = ?
                ORDER BY run_date ASC""",
-            (city_id, provider)).fetchall()
+            (city_id, provider),
+        ).fetchall()
     return [_row_to_run(r) for r in rows]
 
 
-def get_all_cities(conn: sqlite3.Connection,
-                   enabled_only: bool = False) -> List[CityRow]:
+def get_all_cities(conn: sqlite3.Connection, enabled_only: bool = False) -> list[CityRow]:
     """All registered cities, ordered by city_id."""
     sql = "SELECT * FROM cities"
     if enabled_only:
@@ -582,24 +623,27 @@ def get_all_cities(conn: sqlite3.Connection,
     out = []
     for row in conn.execute(sql).fetchall():
         d = dict(row)
-        d['enabled'] = bool(d['enabled'])
+        d["enabled"] = bool(d["enabled"])
         out.append(CityRow(**d))
     return out
 
 
-def record_diff(conn: sqlite3.Connection, *,
-                city_id: str,
-                from_run_id: int,
-                to_run_id: int,
-                grid_aligned: bool,
-                panos_added: int,
-                panos_removed: int,
-                panos_persisted: int,
-                capture_date_changed: int,
-                points_gained_coverage: Optional[int],
-                points_lost_coverage: Optional[int],
-                coverage_delta_pct: Optional[float],
-                detail_filename: Optional[str]) -> int:
+def record_diff(
+    conn: sqlite3.Connection,
+    *,
+    city_id: str,
+    from_run_id: int,
+    to_run_id: int,
+    grid_aligned: bool,
+    panos_added: int,
+    panos_removed: int,
+    panos_persisted: int,
+    capture_date_changed: int,
+    points_gained_coverage: int | None,
+    points_lost_coverage: int | None,
+    coverage_delta_pct: float | None,
+    detail_filename: str | None,
+) -> int:
     """Store a run-to-run diff summary. Idempotent on (from_run, to_run)."""
     cur = conn.execute(
         """INSERT OR REPLACE INTO run_diffs
@@ -608,35 +652,49 @@ def record_diff(conn: sqlite3.Connection, *,
             points_gained_coverage, points_lost_coverage, coverage_delta_pct,
             detail_filename, computed_at)
            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
-        (city_id, from_run_id, to_run_id, int(grid_aligned),
-         panos_added, panos_removed, panos_persisted, capture_date_changed,
-         points_gained_coverage, points_lost_coverage, coverage_delta_pct,
-         detail_filename, utc_now_iso()))
+        (
+            city_id,
+            from_run_id,
+            to_run_id,
+            int(grid_aligned),
+            panos_added,
+            panos_removed,
+            panos_persisted,
+            capture_date_changed,
+            points_gained_coverage,
+            points_lost_coverage,
+            coverage_delta_pct,
+            detail_filename,
+            utc_now_iso(),
+        ),
+    )
     conn.commit()
     return cur.lastrowid
 
 
-def get_diff_for_run(conn: sqlite3.Connection,
-                     to_run_id: int) -> Optional[sqlite3.Row]:
+def get_diff_for_run(conn: sqlite3.Connection, to_run_id: int) -> sqlite3.Row | None:
     """The diff whose 'to' side is the given run, or None."""
-    return conn.execute(
-        "SELECT * FROM run_diffs WHERE to_run_id = ?", (to_run_id,)).fetchone()
+    return conn.execute("SELECT * FROM run_diffs WHERE to_run_id = ?", (to_run_id,)).fetchone()
 
 
 # ── Historical-dates harvests (issue #2) ───────────────────────────────────
 
-def register_history_harvest(conn: sqlite3.Connection, *,
-                             city_id: str,
-                             harvest_date: date,
-                             csv_filename: str,
-                             provider: str = 'gsv',
-                             grid_points_queried: Optional[int] = None,
-                             unique_panos: Optional[int] = None,
-                             oldest_capture_date: Optional[str] = None,
-                             newest_capture_date: Optional[str] = None,
-                             api_requests: Optional[int] = None,
-                             started_at: Optional[str] = None,
-                             finished_at: Optional[str] = None) -> int:
+
+def register_history_harvest(
+    conn: sqlite3.Connection,
+    *,
+    city_id: str,
+    harvest_date: date,
+    csv_filename: str,
+    provider: str = "gsv",
+    grid_points_queried: int | None = None,
+    unique_panos: int | None = None,
+    oldest_capture_date: str | None = None,
+    newest_capture_date: str | None = None,
+    api_requests: int | None = None,
+    started_at: str | None = None,
+    finished_at: str | None = None,
+) -> int:
     """
     Catalog a completed historical-dates harvest. Idempotent on the filename
     and on (city_id, provider, harvest_date): re-harvesting the same city on the
@@ -645,7 +703,7 @@ def register_history_harvest(conn: sqlite3.Connection, *,
 
     Returns the harvest_id.
     """
-    cur = conn.execute(
+    conn.execute(
         """INSERT INTO history_harvests
            (city_id, provider, harvest_date, csv_filename, grid_points_queried,
             unique_panos, oldest_capture_date, newest_capture_date,
@@ -660,63 +718,80 @@ def register_history_harvest(conn: sqlite3.Connection, *,
              api_requests = excluded.api_requests,
              started_at = excluded.started_at,
              finished_at = excluded.finished_at""",
-        (city_id, provider, harvest_date.isoformat(), csv_filename,
-         grid_points_queried, unique_panos, oldest_capture_date,
-         newest_capture_date, api_requests, started_at, finished_at))
+        (
+            city_id,
+            provider,
+            harvest_date.isoformat(),
+            csv_filename,
+            grid_points_queried,
+            unique_panos,
+            oldest_capture_date,
+            newest_capture_date,
+            api_requests,
+            started_at,
+            finished_at,
+        ),
+    )
     conn.commit()
     row = conn.execute(
         """SELECT harvest_id FROM history_harvests
            WHERE city_id = ? AND provider = ? AND harvest_date = ?""",
-        (city_id, provider, harvest_date.isoformat())).fetchone()
-    return row['harvest_id']
+        (city_id, provider, harvest_date.isoformat()),
+    ).fetchone()
+    return row["harvest_id"]
 
 
-def get_latest_history_harvest(conn: sqlite3.Connection, city_id: str,
-                               provider: str = 'gsv') -> Optional[sqlite3.Row]:
+def get_latest_history_harvest(
+    conn: sqlite3.Connection, city_id: str, provider: str = "gsv"
+) -> sqlite3.Row | None:
     """Most recent history harvest for a (city, provider), or None."""
     return conn.execute(
         """SELECT * FROM history_harvests
            WHERE city_id = ? AND provider = ?
            ORDER BY harvest_date DESC LIMIT 1""",
-        (city_id, provider)).fetchone()
+        (city_id, provider),
+    ).fetchone()
 
 
 # ── API budget ledger ──────────────────────────────────────────────────────
 
-def add_api_usage(conn: sqlite3.Connection, usage_date: date, n: int,
-                  provider: str = 'gsv') -> None:
+
+def add_api_usage(
+    conn: sqlite3.Connection, usage_date: date, n: int, provider: str = "gsv"
+) -> None:
     """Add n requests to the given (date, provider) ledger row."""
     conn.execute(
         """INSERT INTO api_usage (usage_date, provider, requests)
            VALUES (?, ?, ?)
            ON CONFLICT(usage_date, provider)
            DO UPDATE SET requests = requests + ?""",
-        (usage_date.isoformat(), provider, n, n))
+        (usage_date.isoformat(), provider, n, n),
+    )
     conn.commit()
 
 
-def get_api_usage(conn: sqlite3.Connection, usage_date: date,
-                  provider: str = 'gsv') -> int:
+def get_api_usage(conn: sqlite3.Connection, usage_date: date, provider: str = "gsv") -> int:
     """Requests recorded for the given (date, provider) (0 if none)."""
     row = conn.execute(
         "SELECT requests FROM api_usage WHERE usage_date = ? AND provider = ?",
-        (usage_date.isoformat(), provider)).fetchone()
+        (usage_date.isoformat(), provider),
+    ).fetchone()
     return row[0] if row else 0
 
 
 # ── Scheduler state ────────────────────────────────────────────────────────
+
 
 def compute_day_of_cycle(city_id: str, cycle_days: int) -> int:
     """
     Stable stagger assignment: hash the city_id onto a day of the cycle.
     Deterministic across machines and runs.
     """
-    digest = hashlib.sha256(city_id.encode('utf-8')).hexdigest()
+    digest = hashlib.sha256(city_id.encode("utf-8")).hexdigest()
     return int(digest, 16) % cycle_days
 
 
-def assign_schedule(conn: sqlite3.Connection, cycle_days: int,
-                    providers: tuple = ('gsv',)) -> int:
+def assign_schedule(conn: sqlite3.Connection, cycle_days: int, providers: tuple = ("gsv",)) -> int:
     """
     Ensure every enabled city has a schedule_state row per provider with its
     day_of_cycle. The day is hashed from city_id alone, so all providers of
@@ -734,14 +809,21 @@ def assign_schedule(conn: sqlite3.Connection, cycle_days: int,
                    VALUES (?, ?, ?)
                    ON CONFLICT(city_id, provider)
                    DO UPDATE SET day_of_cycle = ?""",
-                (city.city_id, provider, day, day))
+                (city.city_id, provider, day, day),
+            )
     conn.commit()
     return len(cities)
 
 
-def get_due_cities(conn: sqlite3.Connection, *, today: date, cycle_days: int,
-                   grace_days: int, max_consecutive_failures: int,
-                   provider: str = 'gsv') -> List[CityRow]:
+def get_due_cities(
+    conn: sqlite3.Connection,
+    *,
+    today: date,
+    cycle_days: int,
+    grace_days: int,
+    max_consecutive_failures: int,
+    provider: str = "gsv",
+) -> list[CityRow]:
     """
     Cities due for collection today for the given provider, ordered
     stalest-first so backlog self-heals after outages.
@@ -761,20 +843,24 @@ def get_due_cities(conn: sqlite3.Connection, *, today: date, cycle_days: int,
              AND (s.last_success_at IS NULL
                   OR julianday(?) - julianday(s.last_success_at) >= ?)
            ORDER BY s.last_success_at ASC NULLS FIRST, c.city_id ASC""",
-        (provider, max_consecutive_failures, today.isoformat(),
-         threshold)).fetchall()
+        (provider, max_consecutive_failures, today.isoformat(), threshold),
+    ).fetchall()
     out = []
     for row in rows:
-        d = {k: row[k] for k in row.keys()
-             if k not in ('last_success_at', 'consecutive_failures')}
-        d['enabled'] = bool(d['enabled'])
+        d = {k: row[k] for k in row.keys() if k not in ("last_success_at", "consecutive_failures")}
+        d["enabled"] = bool(d["enabled"])
         out.append(CityRow(**d))
     return out
 
 
-def record_attempt(conn: sqlite3.Connection, city_id: str, *,
-                   success: bool, error: Optional[str] = None,
-                   provider: str = 'gsv') -> None:
+def record_attempt(
+    conn: sqlite3.Connection,
+    city_id: str,
+    *,
+    success: bool,
+    error: str | None = None,
+    provider: str = "gsv",
+) -> None:
     """Update schedule_state after a collection attempt."""
     now = utc_now_iso()
     if success:
@@ -786,7 +872,8 @@ def record_attempt(conn: sqlite3.Connection, city_id: str, *,
                ON CONFLICT(city_id, provider) DO UPDATE SET
                  last_attempt_at = ?, last_success_at = ?,
                  consecutive_failures = 0, last_error = NULL""",
-            (city_id, provider, now, now, now, now))
+            (city_id, provider, now, now, now, now),
+        )
     else:
         conn.execute(
             """INSERT INTO schedule_state
@@ -797,5 +884,6 @@ def record_attempt(conn: sqlite3.Connection, city_id: str, *,
                  last_attempt_at = ?,
                  consecutive_failures = consecutive_failures + 1,
                  last_error = ?""",
-            (city_id, provider, now, error, now, error))
+            (city_id, provider, now, error, now, error),
+        )
     conn.commit()

--- a/gsv_metadata_tracker/diff.py
+++ b/gsv_metadata_tracker/diff.py
@@ -16,7 +16,6 @@ baseline may not (geocoder drift), in which case grid-point stats are None.
 import gzip
 import logging
 from dataclasses import dataclass, field
-from typing import Optional
 
 import pandas as pd
 
@@ -32,32 +31,32 @@ _COORD_DECIMALS = 6
 @dataclass
 class RunDiff:
     """Summary (and detail rows) of changes between two runs of a city."""
+
     panos_added: int
     panos_removed: int
     panos_persisted: int
     capture_date_changed: int
     grid_aligned: bool
-    points_gained_coverage: Optional[int]
-    points_lost_coverage: Optional[int]
-    coverage_delta_pct: Optional[float]
+    points_gained_coverage: int | None
+    points_lost_coverage: int | None
+    coverage_delta_pct: float | None
     # Long-form detail rows: change_type, pano_id, pano_lat, pano_lon,
     # old_capture_date, new_capture_date
     detail: pd.DataFrame = field(repr=False, default=None)
 
     @property
     def has_changes(self) -> bool:
-        return (self.panos_added + self.panos_removed +
-                self.capture_date_changed) > 0
+        return (self.panos_added + self.panos_removed + self.capture_date_changed) > 0
 
 
 def _unique_ok_panos(df: pd.DataFrame) -> pd.DataFrame:
     """OK rows deduplicated on pano_id, keeping the newest capture_date."""
-    ok = df[df['status'] == 'OK'].copy()
-    ok = ok.sort_values('capture_date', na_position='first')
-    return ok.drop_duplicates(subset=['pano_id'], keep='last')
+    ok = df[df["status"] == "OK"].copy()
+    ok = ok.sort_values("capture_date", na_position="first")
+    return ok.drop_duplicates(subset=["pano_id"], keep="last")
 
 
-def _capture_date_str(value) -> Optional[str]:
+def _capture_date_str(value) -> str | None:
     """capture_date as 'YYYY-MM-DD' or None (handles NaT and raw strings)."""
     if pd.isna(value):
         return None
@@ -67,10 +66,12 @@ def _capture_date_str(value) -> Optional[str]:
 
 
 def _grid_keys(df: pd.DataFrame) -> pd.Index:
-    return pd.MultiIndex.from_arrays([
-        df['query_lat'].round(_COORD_DECIMALS),
-        df['query_lon'].round(_COORD_DECIMALS),
-    ])
+    return pd.MultiIndex.from_arrays(
+        [
+            df["query_lat"].round(_COORD_DECIMALS),
+            df["query_lon"].round(_COORD_DECIMALS),
+        ]
+    )
 
 
 def compute_run_diff(df_old: pd.DataFrame, df_new: pd.DataFrame) -> RunDiff:
@@ -86,8 +87,8 @@ def compute_run_diff(df_old: pd.DataFrame, df_new: pd.DataFrame) -> RunDiff:
         (None when the grids don't align), and a detail DataFrame with one
         row per changed pano.
     """
-    old_panos = _unique_ok_panos(df_old).set_index('pano_id')
-    new_panos = _unique_ok_panos(df_new).set_index('pano_id')
+    old_panos = _unique_ok_panos(df_old).set_index("pano_id")
+    new_panos = _unique_ok_panos(df_new).set_index("pano_id")
 
     old_ids = set(old_panos.index)
     new_ids = set(new_panos.index)
@@ -99,60 +100,72 @@ def compute_run_diff(df_old: pd.DataFrame, df_new: pd.DataFrame) -> RunDiff:
     detail_rows = []
     for pano_id in added_ids:
         row = new_panos.loc[pano_id]
-        detail_rows.append({
-            'change_type': 'pano_added',
-            'pano_id': pano_id,
-            'pano_lat': row['pano_lat'],
-            'pano_lon': row['pano_lon'],
-            'old_capture_date': None,
-            'new_capture_date': _capture_date_str(row['capture_date']),
-        })
+        detail_rows.append(
+            {
+                "change_type": "pano_added",
+                "pano_id": pano_id,
+                "pano_lat": row["pano_lat"],
+                "pano_lon": row["pano_lon"],
+                "old_capture_date": None,
+                "new_capture_date": _capture_date_str(row["capture_date"]),
+            }
+        )
     for pano_id in removed_ids:
         row = old_panos.loc[pano_id]
-        detail_rows.append({
-            'change_type': 'pano_removed',
-            'pano_id': pano_id,
-            'pano_lat': row['pano_lat'],
-            'pano_lon': row['pano_lon'],
-            'old_capture_date': _capture_date_str(row['capture_date']),
-            'new_capture_date': None,
-        })
+        detail_rows.append(
+            {
+                "change_type": "pano_removed",
+                "pano_id": pano_id,
+                "pano_lat": row["pano_lat"],
+                "pano_lon": row["pano_lon"],
+                "old_capture_date": _capture_date_str(row["capture_date"]),
+                "new_capture_date": None,
+            }
+        )
 
     capture_date_changed = 0
     for pano_id in persisted_ids:
-        old_date = _capture_date_str(old_panos.loc[pano_id, 'capture_date'])
-        new_date = _capture_date_str(new_panos.loc[pano_id, 'capture_date'])
+        old_date = _capture_date_str(old_panos.loc[pano_id, "capture_date"])
+        new_date = _capture_date_str(new_panos.loc[pano_id, "capture_date"])
         if old_date != new_date:
             capture_date_changed += 1
             row = new_panos.loc[pano_id]
-            detail_rows.append({
-                'change_type': 'capture_date_changed',
-                'pano_id': pano_id,
-                'pano_lat': row['pano_lat'],
-                'pano_lon': row['pano_lon'],
-                'old_capture_date': old_date,
-                'new_capture_date': new_date,
-            })
+            detail_rows.append(
+                {
+                    "change_type": "capture_date_changed",
+                    "pano_id": pano_id,
+                    "pano_lat": row["pano_lat"],
+                    "pano_lon": row["pano_lon"],
+                    "old_capture_date": old_date,
+                    "new_capture_date": new_date,
+                }
+            )
 
     detail = pd.DataFrame(
         detail_rows,
-        columns=['change_type', 'pano_id', 'pano_lat', 'pano_lon',
-                 'old_capture_date', 'new_capture_date'])
+        columns=[
+            "change_type",
+            "pano_id",
+            "pano_lat",
+            "pano_lon",
+            "old_capture_date",
+            "new_capture_date",
+        ],
+    )
 
     # Grid-point coverage transitions, only when both runs sampled the
     # exact same grid points
     old_keys = _grid_keys(df_old)
     new_keys = _grid_keys(df_new)
-    grid_aligned = (len(old_keys) == len(new_keys)
-                    and set(old_keys) == set(new_keys))
+    grid_aligned = len(old_keys) == len(new_keys) and set(old_keys) == set(new_keys)
 
     points_gained = points_lost = coverage_delta = None
     if grid_aligned:
-        old_status = pd.Series(df_old['status'].values, index=old_keys)
-        new_status = pd.Series(df_new['status'].values, index=new_keys)
+        old_status = pd.Series(df_old["status"].values, index=old_keys)
+        new_status = pd.Series(df_new["status"].values, index=new_keys)
         # Duplicated grid keys shouldn't happen; guard so align() can't explode
-        old_status = old_status[~old_status.index.duplicated(keep='first')]
-        new_status = new_status[~new_status.index.duplicated(keep='first')]
+        old_status = old_status[~old_status.index.duplicated(keep="first")]
+        new_status = new_status[~new_status.index.duplicated(keep="first")]
         new_status = new_status.reindex(old_status.index)
 
         # A point is covered if it holds present imagery (OK or NO_DATE),
@@ -168,7 +181,8 @@ def compute_run_diff(df_old: pd.DataFrame, df_new: pd.DataFrame) -> RunDiff:
         logger.warning(
             "Query grids do not align between runs "
             f"({len(set(old_keys))} vs {len(set(new_keys))} unique points); "
-            "skipping grid-point coverage transitions")
+            "skipping grid-point coverage transitions"
+        )
 
     return RunDiff(
         panos_added=len(added_ids),
@@ -183,8 +197,9 @@ def compute_run_diff(df_old: pd.DataFrame, df_new: pd.DataFrame) -> RunDiff:
     )
 
 
-def generate_diff_filename(city_id: str, from_date: str, to_date: str,
-                           provider: str = 'gsv') -> str:
+def generate_diff_filename(
+    city_id: str, from_date: str, to_date: str, provider: str = "gsv"
+) -> str:
     """
     Basename for a published diff detail file.
 
@@ -192,12 +207,12 @@ def generate_diff_filename(city_id: str, from_date: str, to_date: str,
     other providers get a token after '_diff':
     ``{city_id}_diff_mapillary_{from}_to_{to}.csv.gz``.
     """
-    provider_token = '' if provider == 'gsv' else f"{provider}_"
+    provider_token = "" if provider == "gsv" else f"{provider}_"
     return f"{city_id}_diff_{provider_token}{from_date}_to_{to_date}.csv.gz"
 
 
 def write_diff_detail(diff: RunDiff, output_path: str) -> None:
     """Write the diff's detail rows as a gzipped CSV."""
-    with gzip.open(output_path, 'wt', encoding='utf-8', newline='') as f:
+    with gzip.open(output_path, "wt", encoding="utf-8", newline="") as f:
         diff.detail.to_csv(f, index=False)
     logger.info(f"Wrote diff detail ({len(diff.detail)} rows) to {output_path}")

--- a/gsv_metadata_tracker/download_async.py
+++ b/gsv_metadata_tracker/download_async.py
@@ -1,23 +1,25 @@
-import pandas as pd
-import time
-from datetime import datetime, timezone
-import logging
-from typing import Dict, Any, List, Tuple, Optional
-from tqdm import tqdm
-import geopy.distance
-import os
-import gzip
-import shutil
 import asyncio
-import aiohttp
-from filelock import FileLock
+import gzip
+import logging
+import os
+import shutil
+import time
+from datetime import UTC, datetime
 from pathlib import Path
-import backoff
+from typing import Any
 
-from .fileutils import load_city_csv_file
+import aiohttp
+import backoff
+import geopy.distance
+import pandas as pd
+from filelock import FileLock
+from tqdm import tqdm
+
 from .config import METADATA_DTYPES
+from .fileutils import load_city_csv_file
 
 logger = logging.getLogger(__name__)
+
 
 def create_helpful_permission_error(path: str) -> str:
     """Create a helpful error message for permission issues."""
@@ -35,36 +37,36 @@ def create_helpful_permission_error(path: str) -> str:
         f"  python gsv_tracker.py CITY_NAME --download-dir NEW_DIRECTORY\n"
     )
 
+
 class DownloadError(Exception):
     """Custom exception for download-related errors."""
+
     pass
 
+
 @backoff.on_exception(
-    backoff.expo,
-    (asyncio.TimeoutError, aiohttp.ClientError),
-    max_tries=3,
-    max_time=60
+    backoff.expo, (asyncio.TimeoutError, aiohttp.ClientError), max_tries=3, max_time=60
 )
 async def fetch_gsv_pano_metadata_async(
     lat: float,
     lon: float,
     api_key: str,
     session: aiohttp.ClientSession,
-    timeout: aiohttp.ClientTimeout
-) -> Dict[str, Any]:
+    timeout: aiohttp.ClientTimeout,
+) -> dict[str, Any]:
     """
     Get the closest pano data from Google Street View API using aiohttp with retry logic.
-    
+
     Args:
         lat: Latitude coordinate
         lon: Longitude coordinate
         api_key: Google Street View API key
         session: aiohttp ClientSession for making requests
         timeout: Request timeout settings
-    
+
     Returns:
         Dict containing the API response
-    
+
     Raises:
         DownloadError: If the request fails or returns invalid data after all retries
     """
@@ -74,33 +76,31 @@ async def fetch_gsv_pano_metadata_async(
             if response.status != 200:
                 raise DownloadError(f"HTTP {response.status}: {await response.text()}")
             return await response.json()
-    except (asyncio.TimeoutError, aiohttp.ClientError) as e:
+    except (TimeoutError, aiohttp.ClientError) as e:
         logger.warning(f"Attempt failed for coordinates {lat},{lon}: {str(e)}, retrying...")
         raise  # Let backoff handle the retry
     except Exception as e:
-        raise DownloadError(f"Error fetching data for coordinates {lat},{lon}: {str(e)}")
+        raise DownloadError(f"Error fetching data for coordinates {lat},{lon}: {str(e)}") from e
+
 
 def generate_grid_points(
-    origin: geopy.Point,
-    width_steps: int,
-    height_steps: int,
-    step_length: float
-) -> List[Tuple[float, float, int, int]]:
+    origin: geopy.Point, width_steps: int, height_steps: int, step_length: float
+) -> list[tuple[float, float, int, int]]:
     """
     Generate all grid points for the search area with progress bar.
-    
+
     Args:
         origin: Center point of the grid
         width_steps: Number of steps in width direction
         height_steps: Number of steps in height direction
         step_length: Distance between points in meters
-    
+
     Returns:
         List of tuples containing (latitude, longitude, i, j) for each point
     """
     points = []
     total_points = (width_steps + 1) * (height_steps + 1)
-    
+
     with tqdm(total=total_points, desc="Generating search grid points") as pbar:
         for i in range(-height_steps // 2, height_steps // 2 + 1):
             for j in range(-width_steps // 2, width_steps // 2 + 1):
@@ -108,33 +108,32 @@ def generate_grid_points(
                 point = geopy.distance.distance(meters=j * step_length).destination(north_point, 90)
                 points.append((point.latitude, point.longitude, i, j))
                 pbar.update(1)
-    
+
     return points
+
 
 def get_processed_points(file_path: str) -> set:
     """
     Get set of already processed points from existing download file.
-    
+
     Args:
         file_path: Path to the intermediate download file
-    
+
     Returns:
         Set of (latitude, longitude) tuples for processed points
     """
     if not os.path.exists(file_path):
         return set()
-    
+
     try:
-        df = pd.read_csv(
-            file_path,
-            dtype=METADATA_DTYPES
-        )
-        return {(row['query_lat'], row['query_lon']) for _, row in df.iterrows()}
+        df = pd.read_csv(file_path, dtype=METADATA_DTYPES)
+        return {(row["query_lat"], row["query_lon"]) for _, row in df.iterrows()}
     except Exception as e:
         logger.error(f"Error reading existing file: {str(e)}")
         return set()
-    
-def standardize_capture_date(date_str: Optional[str]) -> Optional[str]:
+
+
+def standardize_capture_date(date_str: str | None) -> str | None:
     """Standardizes a capture date string to ISO 8601 format (YYYY-MM-DD).
 
     The Google Street View Static API can return capture dates in various formats.
@@ -152,9 +151,9 @@ def standardize_capture_date(date_str: Optional[str]) -> Optional[str]:
         return None
 
     formats_to_try = [
-        '%Y-%m-%d',  # Most precise format (YYYY-MM-DD), try first
-        '%Y-%m',      # Year and month (YYYY-MM)
-        '%Y',          # Year only (YYYY)
+        "%Y-%m-%d",  # Most precise format (YYYY-MM-DD), try first
+        "%Y-%m",  # Year and month (YYYY-MM)
+        "%Y",  # Year only (YYYY)
     ]
 
     for fmt in formats_to_try:
@@ -166,15 +165,16 @@ def standardize_capture_date(date_str: Optional[str]) -> Optional[str]:
 
     return None  # Return None if no format matches
 
+
 async def process_batch_async(
-    points: List[Tuple[float, float, int, int]],
+    points: list[tuple[float, float, int, int]],
     api_key: str,
     progress_queue: asyncio.Queue,
     base_file_path: str,
     timeout: aiohttp.ClientTimeout,
     connection_limit: int,
-    failed_points_queue: asyncio.Queue
-) -> List[Dict]:
+    failed_points_queue: asyncio.Queue,
+) -> list[dict]:
     """
     Process a batch of points asynchronously and append results to the
     in-progress CSV under a file lock (so a second process on the same city
@@ -182,63 +182,67 @@ async def process_batch_async(
     """
     results = []
     lock_file = f"{base_file_path}.lock"
-    
+
     try:
         # Create connection-limited session
         connector = aiohttp.TCPConnector(limit=connection_limit)
         async with aiohttp.ClientSession(connector=connector) as session:
             tasks = []
-            for lat, lon, i, j in points:
+            for lat, lon, _i, _j in points:
                 task = fetch_gsv_pano_metadata_async(lat, lon, api_key, session, timeout)
                 tasks.append(task)
-            
+
             responses = await asyncio.gather(*tasks, return_exceptions=True)
-            
+
             batch_results = []
-            for (lat, lon, i, j), response in zip(points, responses):
+            for (lat, lon, i, j), response in zip(points, responses, strict=False):
                 if isinstance(response, Exception):
                     logger.error(f"Error processing point ({lat}, {lon}): {str(response)}")
                     await failed_points_queue.put((lat, lon, i, j))
                     continue
-                
+
                 # Get the current UTC datetime
-                now_utc = datetime.now(timezone.utc)
+                now_utc = datetime.now(UTC)
 
                 # Format the datetime as ISO 8601
                 query_timestamp = now_utc.isoformat()
-                
-                status = response['status']
+
+                status = response["status"]
                 result = {
-                    'query_lat': lat,
-                    'query_lon': lon,
-                    'query_timestamp': query_timestamp,
-                    'pano_lat': None,
-                    'pano_lon': None,
-                    'pano_id': None,
-                    'capture_date': None,
-                    'copyright_info': None,
-                    'status': status
+                    "query_lat": lat,
+                    "query_lon": lon,
+                    "query_timestamp": query_timestamp,
+                    "pano_lat": None,
+                    "pano_lon": None,
+                    "pano_id": None,
+                    "capture_date": None,
+                    "copyright_info": None,
+                    "status": status,
                 }
-                
-                if status == 'OK':
+
+                if status == "OK":
                     # I have found that capture_date can be formatted in a variety of formats like format='%Y-%m' (most commonly) or format='%Y-%m-%d'.
                     # So, we should standardize the data format to make it consistent and easier for others to use once archived in a file
-                    capture_date_raw = response.get('date', None)  # Get the raw capture date from the API response
+                    capture_date_raw = response.get(
+                        "date", None
+                    )  # Get the raw capture date from the API response
                     capture_date_standardized = standardize_capture_date(capture_date_raw)
 
-                    result.update({
-                        'pano_lat': response['location']['lat'],
-                        'pano_lon': response['location']['lng'],
-                        'pano_id': response['pano_id'],
-                        'copyright_info': response.get('copyright', None),
-                        'capture_date': capture_date_standardized
-                    })
-                    if not result['capture_date']:
-                        result['status'] = 'NO_DATE'
-                
+                    result.update(
+                        {
+                            "pano_lat": response["location"]["lat"],
+                            "pano_lon": response["location"]["lng"],
+                            "pano_id": response["pano_id"],
+                            "copyright_info": response.get("copyright", None),
+                            "capture_date": capture_date_standardized,
+                        }
+                    )
+                    if not result["capture_date"]:
+                        result["status"] = "NO_DATE"
+
                 batch_results.append(result)
                 await progress_queue.put(1)
-        
+
         # Append batch results to the in-progress CSV under a file lock
         df_batch = pd.DataFrame(batch_results)  # First create the DataFrame
         df_batch = df_batch.astype(METADATA_DTYPES)  # Then apply the dtypes
@@ -247,11 +251,13 @@ async def process_batch_async(
         try:
             with lock:
                 if os.path.exists(base_file_path):
-                    df_batch.to_csv(base_file_path, mode='a', header=False, index=False)
+                    df_batch.to_csv(base_file_path, mode="a", header=False, index=False)
                 else:
                     df_batch.to_csv(base_file_path, index=False)
-        except PermissionError:
-            raise PermissionError("FileLock failure: " + create_helpful_permission_error(base_file_path))
+        except PermissionError as e:
+            raise PermissionError(
+                "FileLock failure: " + create_helpful_permission_error(base_file_path)
+            ) from e
         finally:
             try:
                 if os.path.exists(lock_file):
@@ -267,9 +273,10 @@ async def process_batch_async(
                 os.remove(lock_file)
         except Exception as cleanup_error:
             logger.error(f"Error cleaning up {lock_file}: {cleanup_error}")
-        raise DownloadError(f"Error processing batch: {str(e)}")
+        raise DownloadError(f"Error processing batch: {str(e)}") from e
 
     return results
+
 
 async def download_gsv_metadata_async(
     city_name: str,
@@ -283,8 +290,8 @@ async def download_gsv_metadata_async(
     batch_size: int = 50,
     connection_limit: int = 50,
     request_timeout: float = 30.0,
-    max_retries: int = 3
-) -> Dict[str, Any]:
+    max_retries: int = 3,
+) -> dict[str, Any]:
     """
     Fetch GSV metadata for a city using async/await pattern with safe intermediate file saving.
 
@@ -314,23 +321,25 @@ async def download_gsv_metadata_async(
             started_at / finished_at: UTC ISO 8601 timestamps
     """
     start_time = time.time()
-    started_at = datetime.now(timezone.utc).isoformat()
+    started_at = datetime.now(UTC).isoformat()
     api_requests = 0
 
-    logger.info(f"Examining street view data for {city_name} centered at {center_lat},{center_lon}" +
-                f" with a grid of {grid_width/1000:.1f}km x {grid_height/1000:.1f}km and step_length={step_length} meters")
+    logger.info(
+        f"Examining street view data for {city_name} centered at {center_lat},{center_lon}"
+        + f" with a grid of {grid_width / 1000:.1f}km x {grid_height / 1000:.1f}km and step_length={step_length} meters"
+    )
     logger.info(f"Using batch_size={batch_size}, connection_limit={connection_limit}")
 
     # Set up timeout
     timeout = aiohttp.ClientTimeout(total=request_timeout)
 
     # Derive working file paths from the requested output path
-    if not output_csv_gz_path.endswith('.csv.gz'):
+    if not output_csv_gz_path.endswith(".csv.gz"):
         raise ValueError(f"output_csv_gz_path must end in .csv.gz, got: {output_csv_gz_path}")
     file_name_compressed_with_path = output_csv_gz_path
-    file_name_with_path = output_csv_gz_path[:-len('.gz')]          # .csv
+    file_name_with_path = output_csv_gz_path[: -len(".gz")]  # .csv
     file_name_downloading_with_path = file_name_with_path + ".downloading"
-    failed_points_file = output_csv_gz_path[:-len('.csv.gz')] + "_failed_points.csv"
+    failed_points_file = output_csv_gz_path[: -len(".csv.gz")] + "_failed_points.csv"
 
     Path(os.path.dirname(os.path.abspath(output_csv_gz_path))).mkdir(parents=True, exist_ok=True)
 
@@ -338,46 +347,51 @@ async def download_gsv_metadata_async(
         # Calculate grid dimensions
         width_steps = int(grid_width / step_length)
         height_steps = int(grid_height / step_length)
-        
+
         # Generate all points
         origin = geopy.Point(center_lat, center_lon)
         all_points = generate_grid_points(origin, width_steps, height_steps, step_length)
-        
+
         # Get already processed points
         processed_points = get_processed_points(file_name_downloading_with_path)
-        
+
         # Filter out already processed points
         remaining_points = [
-            point for point in all_points 
-            if (point[0], point[1]) not in processed_points
+            point for point in all_points if (point[0], point[1]) not in processed_points
         ]
-     
+
         if len(processed_points) > 0:
-            logger.info(f"Found {len(processed_points)} already processed points. {len(remaining_points)} points remaining.")
+            logger.info(
+                f"Found {len(processed_points)} already processed points. {len(remaining_points)} points remaining."
+            )
         else:
-            logger.info(f"No previous points processed. Processing all points ({len(remaining_points)} total).")
-        
+            logger.info(
+                f"No previous points processed. Processing all points ({len(remaining_points)} total)."
+            )
+
         if len(remaining_points) == 0:
             logger.info("All points already processed.")
             if not os.path.exists(file_name_downloading_with_path):
                 raise DownloadError(
                     f"Grid produced no points to download and no partial file "
-                    f"exists (grid {grid_width}x{grid_height}m, step {step_length}m)")
+                    f"exists (grid {grid_width}x{grid_height}m, step {step_length}m)"
+                )
             os.rename(file_name_downloading_with_path, file_name_with_path)
         else:
             # Initialize queues
             progress_queue = asyncio.Queue()
             failed_points_queue = asyncio.Queue()
-            
+
             # Create progress bar
             progress_bar = tqdm(
-                total=len(all_points), 
+                total=len(all_points),
                 initial=len(processed_points),
-                desc=f"Downloading GSV pano data for {city_name}")
-            
+                desc=f"Downloading GSV pano data for {city_name}",
+            )
+
             # Process initial points in batches
             for i in range(0, len(remaining_points), batch_size):
-                batch_points = remaining_points[i:i + batch_size]
+                batch_points = remaining_points[i : i + batch_size]
                 api_requests += len(batch_points)
                 await process_batch_async(
                     batch_points,
@@ -386,29 +400,29 @@ async def download_gsv_metadata_async(
                     file_name_downloading_with_path,
                     timeout,
                     connection_limit,
-                    failed_points_queue
+                    failed_points_queue,
                 )
 
                 # Update progress bar
                 while not progress_queue.empty():
                     await progress_queue.get()
                     progress_bar.update(1)
-            
+
             # Process failed points with retries
             retry_count = 0
             while not failed_points_queue.empty() and retry_count < max_retries:
                 retry_count += 1
                 logger.info(f"Starting retry attempt {retry_count} for failed points")
-                
+
                 # Collect all failed points for this retry attempt
                 failed_points = []
                 while not failed_points_queue.empty():
                     failed_points.append(await failed_points_queue.get())
-                
+
                 if failed_points:
                     logger.info(f"Retrying {len(failed_points)} failed points")
                     for i in range(0, len(failed_points), batch_size):
-                        batch_points = failed_points[i:i + batch_size]
+                        batch_points = failed_points[i : i + batch_size]
                         api_requests += len(batch_points)
                         await process_batch_async(
                             batch_points,
@@ -417,9 +431,9 @@ async def download_gsv_metadata_async(
                             file_name_downloading_with_path,
                             timeout,
                             connection_limit,
-                            failed_points_queue
+                            failed_points_queue,
                         )
-                
+
                 # Wait a bit before next retry
                 if retry_count < max_retries and not failed_points_queue.empty():
                     await asyncio.sleep(5 * retry_count)  # Increasing delay between retries
@@ -429,43 +443,47 @@ async def download_gsv_metadata_async(
             while not failed_points_queue.empty():
                 point = await failed_points_queue.get()
                 remaining_failed.append(point)
-            
+
             if remaining_failed:
-                logger.error(f"Failed to download data for {len(remaining_failed)} points after all retries")
-                with open(failed_points_file, 'w') as f:
+                logger.error(
+                    f"Failed to download data for {len(remaining_failed)} points after all retries"
+                )
+                with open(failed_points_file, "w") as f:
                     f.write("lat,lon,i,j\n")  # Write header
                     for lat, lon, i, j in remaining_failed:
                         f.write(f"{lat},{lon},{i},{j}\n")
-            
+
             progress_bar.close()
 
             # Rename the downloading file to final csv
             os.rename(file_name_downloading_with_path, file_name_with_path)
-        
+
         # Compress the final CSV file
-        with open(file_name_with_path, 'rb') as f_in:
-            with gzip.open(file_name_compressed_with_path, 'wb') as f_out:
+        with open(file_name_with_path, "rb") as f_in:
+            with gzip.open(file_name_compressed_with_path, "wb") as f_out:
                 shutil.copyfileobj(f_in, f_out)
-        
+
         # Remove the uncompressed CSV file
         os.remove(file_name_with_path)
-        
+
         # Read the final compressed file
         df = load_city_csv_file(file_name_compressed_with_path)
- 
+
         end_time = time.time()
         elapsed_time = end_time - start_time
-        logger.info(f"Downloaded {len(df)} rows in {elapsed_time:.2f} seconds "
-                    f"({api_requests} API requests this session)")
+        logger.info(
+            f"Downloaded {len(df)} rows in {elapsed_time:.2f} seconds "
+            f"({api_requests} API requests this session)"
+        )
         logger.info(f"Data compressed and saved to {file_name_compressed_with_path}")
 
         return {
-                "df": df,
-                "filename_with_path": file_name_compressed_with_path,
-                "api_requests": api_requests,
-                "started_at": started_at,
-                "finished_at": datetime.now(timezone.utc).isoformat()
-            }
+            "df": df,
+            "filename_with_path": file_name_compressed_with_path,
+            "api_requests": api_requests,
+            "started_at": started_at,
+            "finished_at": datetime.now(UTC).isoformat(),
+        }
 
     except Exception as e:
         raise DownloadError(f"Download failed: {str(e)}") from e

--- a/gsv_metadata_tracker/download_gsv_history.py
+++ b/gsv_metadata_tracker/download_gsv_history.py
@@ -46,9 +46,9 @@ import os
 import random
 import re
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any
 
 import aiohttp
 import backoff
@@ -57,8 +57,7 @@ import numpy as np
 import pandas as pd
 from tqdm import tqdm
 
-from .download_async import (DownloadError, generate_grid_points,
-                             standardize_capture_date)
+from .download_async import DownloadError, generate_grid_points, standardize_capture_date
 
 logger = logging.getLogger(__name__)
 
@@ -66,14 +65,14 @@ logger = logging.getLogger(__name__)
 # Distinct from config.METADATA_DTYPES (a per-grid-point run sample); this is a
 # per-pano historical census, so it gets its own columns.
 HISTORY_DTYPES = {
-    'pano_id': str,
-    'capture_date': str,                 # ISO YYYY-MM-DD (day defaults to 01;
-                                         # the endpoint's precision is a month)
-    'pano_lat': np.float64,
-    'pano_lon': np.float64,
-    'nearest_query_lat': np.float64,     # grid point whose search first
-    'nearest_query_lon': np.float64,     # surfaced this pano
-    'harvested_at': str,                 # UTC ISO 8601
+    "pano_id": str,
+    "capture_date": str,  # ISO YYYY-MM-DD (day defaults to 01;
+    # the endpoint's precision is a month)
+    "pano_lat": np.float64,
+    "pano_lon": np.float64,
+    "nearest_query_lat": np.float64,  # grid point whose search first
+    "nearest_query_lon": np.float64,  # surfaced this pano
+    "harvested_at": str,  # UTC ISO 8601
 }
 
 _SEARCH_URL = (
@@ -87,16 +86,19 @@ _CALLBACK_RE = re.compile(r"callbackfunc\( (.*) \)$", re.DOTALL)
 _NO_IMAGES_SENTINEL = [[5, "generic", "Search returned no images."]]
 
 # A realistic browser UA; the endpoint is meant to be called from Maps JS.
-_USER_AGENT = ("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
-               "AppleWebKit/537.36 (KHTML, like Gecko) "
-               "Chrome/126.0 Safari/537.36")
+_USER_AGENT = (
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+    "AppleWebKit/537.36 (KHTML, like Gecko) "
+    "Chrome/126.0 Safari/537.36"
+)
 
 
 @dataclass(frozen=True)
 class HistoricalPano:
     """One official Google panorama and its capture month."""
+
     pano_id: str
-    capture_date: str            # standardized ISO 'YYYY-MM-DD'
+    capture_date: str  # standardized ISO 'YYYY-MM-DD'
     lat: float
     lon: float
 
@@ -114,7 +116,7 @@ def build_search_url(lat: float, lon: float) -> str:
     return _SEARCH_URL.format(lat=lat, lon=lon)
 
 
-def parse_search_response(text: str) -> List[HistoricalPano]:
+def parse_search_response(text: str) -> list[HistoricalPano]:
     """
     Extract dated official-Google panoramas from one endpoint response.
 
@@ -146,14 +148,14 @@ def parse_search_response(text: str) -> List[HistoricalPano]:
     except (IndexError, KeyError, TypeError):
         return []
 
-    dates: List[str] = []
+    dates: list[str] = []
     for d in raw_dates:
         try:
             dates.append(f"{d[1][0]}-{int(d[1][1]):02d}")
         except (IndexError, KeyError, TypeError, ValueError):
             dates.append("")
 
-    out: List[HistoricalPano] = []
+    out: list[HistoricalPano] = []
     for i, pano in enumerate(raw_panos):
         raw_date = dates[i] if i < len(dates) else ""
         iso = standardize_capture_date(raw_date)
@@ -165,8 +167,9 @@ def parse_search_response(text: str) -> List[HistoricalPano]:
             lon = pano[2][0][3]
         except (IndexError, KeyError, TypeError):
             continue
-        out.append(HistoricalPano(pano_id=str(pano_id), capture_date=iso,
-                                  lat=float(lat), lon=float(lon)))
+        out.append(
+            HistoricalPano(pano_id=str(pano_id), capture_date=iso, lat=float(lat), lon=float(lon))
+        )
     return out
 
 
@@ -194,10 +197,12 @@ class _CircuitBreaker:
         return self.consecutive >= self.limit
 
 
-@backoff.on_exception(backoff.expo, (asyncio.TimeoutError, aiohttp.ClientError),
-                      max_tries=4, max_time=90)
-async def _fetch_search(session: aiohttp.ClientSession, url: str,
-                        timeout: aiohttp.ClientTimeout) -> str:
+@backoff.on_exception(
+    backoff.expo, (asyncio.TimeoutError, aiohttp.ClientError), max_tries=4, max_time=90
+)
+async def _fetch_search(
+    session: aiohttp.ClientSession, url: str, timeout: aiohttp.ClientTimeout
+) -> str:
     """
     One search request with retry/backoff. Throttle-ish statuses (429/403/503)
     raise ClientResponseError so backoff retries with growing delay; if the
@@ -219,40 +224,43 @@ async def _fetch_search(session: aiohttp.ClientSession, url: str,
 
 # ── Checkpoint (resume) ────────────────────────────────────────────────────
 
+
 def _checkpoint_path(output_csv_gz_path: str) -> str:
     return output_csv_gz_path + ".harvesting"
 
 
-def _load_checkpoint(path: str) -> Tuple[set, Dict[str, dict], int]:
+def _load_checkpoint(path: str) -> tuple[set, dict[str, dict], int]:
     """Return (done grid indices, panos-by-id, api_requests) from a checkpoint."""
     if not os.path.exists(path):
         return set(), {}, 0
     try:
-        with open(path, "r", encoding="utf-8") as f:
+        with open(path, encoding="utf-8") as f:
             state = json.load(f)
         done = {tuple(ij) for ij in state.get("done", [])}
         panos = state.get("panos", {})
         api_requests = int(state.get("api_requests", 0))
-        logger.info(f"Resuming harvest from {path}: "
-                    f"{len(done)} grid points already done, "
-                    f"{len(panos)} panos so far")
+        logger.info(
+            f"Resuming harvest from {path}: "
+            f"{len(done)} grid points already done, "
+            f"{len(panos)} panos so far"
+        )
         return done, panos, api_requests
     except (ValueError, OSError, KeyError):
         logger.warning(f"Ignoring unreadable checkpoint {path}")
         return set(), {}, 0
 
 
-def _save_checkpoint(path: str, done: set, panos: Dict[str, dict],
-                     api_requests: int) -> None:
+def _save_checkpoint(path: str, done: set, panos: dict[str, dict], api_requests: int) -> None:
     tmp = path + ".tmp"
     with open(tmp, "w", encoding="utf-8") as f:
-        json.dump({"done": [list(ij) for ij in done],
-                   "panos": panos,
-                   "api_requests": api_requests}, f)
+        json.dump(
+            {"done": [list(ij) for ij in done], "panos": panos, "api_requests": api_requests}, f
+        )
     os.replace(tmp, path)  # atomic
 
 
 # ── Harvest ────────────────────────────────────────────────────────────────
+
 
 async def harvest_gsv_history_async(
     city_name: str,
@@ -264,10 +272,10 @@ async def harvest_gsv_history_async(
     output_csv_gz_path: str,
     connection_limit: int = 2,
     request_timeout: float = 30,
-    jitter_seconds: Tuple[float, float] = (0.2, 0.6),
+    jitter_seconds: tuple[float, float] = (0.2, 0.6),
     chunk_size: int = 25,
     circuit_breaker_limit: int = 8,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """
     Sweep a city's frozen grid and harvest every official Google panorama's
     capture date from the unpublished single-image-search endpoint.
@@ -284,32 +292,31 @@ async def harvest_gsv_history_async(
     Raises HarvestBlockedError if the endpoint appears to be throttling us (the
     checkpoint is kept for a later resume).
     """
-    started_at = datetime.now(timezone.utc).isoformat()
+    started_at = datetime.now(UTC).isoformat()
     if not output_csv_gz_path.endswith(".csv.gz"):
-        raise ValueError(
-            f"output_csv_gz_path must end in .csv.gz, got: {output_csv_gz_path}")
-    Path(os.path.dirname(os.path.abspath(output_csv_gz_path))).mkdir(
-        parents=True, exist_ok=True)
+        raise ValueError(f"output_csv_gz_path must end in .csv.gz, got: {output_csv_gz_path}")
+    Path(os.path.dirname(os.path.abspath(output_csv_gz_path))).mkdir(parents=True, exist_ok=True)
 
     width_steps = int(grid_width / step_length)
     height_steps = int(grid_height / step_length)
     origin = geopy.Point(center_lat, center_lon)
-    grid_points = generate_grid_points(origin, width_steps, height_steps,
-                                        step_length)
+    grid_points = generate_grid_points(origin, width_steps, height_steps, step_length)
 
     checkpoint = _checkpoint_path(output_csv_gz_path)
     done, panos, api_requests = _load_checkpoint(checkpoint)
-    remaining = [(lat, lon, i, j) for (lat, lon, i, j) in grid_points
-                 if (i, j) not in done]
-    logger.info(f"Harvesting GSV history for {city_name}: {len(remaining)} of "
-                f"{len(grid_points)} grid points to query "
-                f"(connection_limit={connection_limit}, gentle mode)")
+    remaining = [(lat, lon, i, j) for (lat, lon, i, j) in grid_points if (i, j) not in done]
+    logger.info(
+        f"Harvesting GSV history for {city_name}: {len(remaining)} of "
+        f"{len(grid_points)} grid points to query "
+        f"(connection_limit={connection_limit}, gentle mode)"
+    )
 
     breaker = _CircuitBreaker(limit=circuit_breaker_limit)
     semaphore = asyncio.Semaphore(connection_limit)
     timeout = aiohttp.ClientTimeout(total=request_timeout)
-    progress = tqdm(total=len(grid_points), initial=len(done),
-                    desc=f"Harvesting GSV history for {city_name}")
+    progress = tqdm(
+        total=len(grid_points), initial=len(done), desc=f"Harvesting GSV history for {city_name}"
+    )
 
     async def query_point(session, lat, lon, i, j):
         nonlocal api_requests
@@ -317,9 +324,8 @@ async def harvest_gsv_history_async(
             await asyncio.sleep(random.uniform(*jitter_seconds))
             api_requests += 1
             try:
-                text = await _fetch_search(session, build_search_url(lat, lon),
-                                           timeout)
-            except (asyncio.TimeoutError, aiohttp.ClientError) as e:
+                text = await _fetch_search(session, build_search_url(lat, lon), timeout)
+            except (TimeoutError, aiohttp.ClientError) as e:
                 breaker.record(ok=False)
                 return (i, j, lat, lon, None, e)
         breaker.record(ok=True)
@@ -329,10 +335,10 @@ async def harvest_gsv_history_async(
     blocked = False
     async with aiohttp.ClientSession(headers=headers) as session:
         for start in range(0, len(remaining), chunk_size):
-            chunk = remaining[start:start + chunk_size]
+            chunk = remaining[start : start + chunk_size]
             results = await asyncio.gather(
-                *(query_point(session, lat, lon, i, j)
-                  for (lat, lon, i, j) in chunk))
+                *(query_point(session, lat, lon, i, j) for (lat, lon, i, j) in chunk)
+            )
             for i, j, lat, lon, found, err in results:
                 progress.update(1)
                 if err is not None:
@@ -360,18 +366,22 @@ async def harvest_gsv_history_async(
         raise HarvestBlockedError(
             f"Harvest aborted for {city_name}: {breaker.consecutive} consecutive "
             f"failed searches suggest the endpoint is throttling us. Progress "
-            f"saved to {checkpoint}; rerun to resume.")
+            f"saved to {checkpoint}; rerun to resume."
+        )
 
-    harvested_at = datetime.now(timezone.utc).isoformat()
-    rows = [{
-        "pano_id": pid,
-        "capture_date": rec["capture_date"],
-        "pano_lat": rec["pano_lat"],
-        "pano_lon": rec["pano_lon"],
-        "nearest_query_lat": rec["nearest_query_lat"],
-        "nearest_query_lon": rec["nearest_query_lon"],
-        "harvested_at": harvested_at,
-    } for pid, rec in panos.items()]
+    harvested_at = datetime.now(UTC).isoformat()
+    rows = [
+        {
+            "pano_id": pid,
+            "capture_date": rec["capture_date"],
+            "pano_lat": rec["pano_lat"],
+            "pano_lon": rec["pano_lon"],
+            "nearest_query_lat": rec["nearest_query_lat"],
+            "nearest_query_lon": rec["nearest_query_lon"],
+            "harvested_at": harvested_at,
+        }
+        for pid, rec in panos.items()
+    ]
     df = pd.DataFrame(rows, columns=list(HISTORY_DTYPES.keys()))
     df = df.sort_values(["capture_date", "pano_id"]).reset_index(drop=True)
 
@@ -383,9 +393,11 @@ async def harvest_gsv_history_async(
     dates = df["capture_date"].dropna()
     oldest = dates.min() if len(dates) else None
     newest = dates.max() if len(dates) else None
-    logger.info(f"Harvested {len(df)} unique official Google panos for "
-                f"{city_name} ({oldest}..{newest}) from {api_requests} searches "
-                f"-> {output_csv_gz_path}")
+    logger.info(
+        f"Harvested {len(df)} unique official Google panos for "
+        f"{city_name} ({oldest}..{newest}) from {api_requests} searches "
+        f"-> {output_csv_gz_path}"
+    )
 
     return {
         "df": df,

--- a/gsv_metadata_tracker/download_mapillary.py
+++ b/gsv_metadata_tracker/download_mapillary.py
@@ -30,9 +30,9 @@ import gzip
 import logging
 import math
 import os
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
-from typing import Dict, Any, Iterable, List, Tuple
+from typing import Any
 
 import aiohttp
 import backoff
@@ -49,8 +49,9 @@ from .fileutils import load_city_csv_file
 logger = logging.getLogger(__name__)
 
 TILE_ZOOM = 14  # the only zoom level whose tiles carry per-image metadata
-TILE_URL_TEMPLATE = ("https://tiles.mapillary.com/maps/vtp/mly1_computed_public"
-                     "/2/{z}/{x}/{y}?access_token={token}")
+TILE_URL_TEMPLATE = (
+    "https://tiles.mapillary.com/maps/vtp/mly1_computed_public/2/{z}/{x}/{y}?access_token={token}"
+)
 IMAGE_LAYER = "image"
 
 # Meters per degree of latitude (WGS84 mean). Used only for nearest-grid-
@@ -61,36 +62,39 @@ _M_PER_DEG_LAT = 111320.0
 
 # ── Slippy-map tile math (stdlib only) ─────────────────────────────────────
 
-def lonlat_to_tile_frac(lon: float, lat: float, zoom: int) -> Tuple[float, float]:
+
+def lonlat_to_tile_frac(lon: float, lat: float, zoom: int) -> tuple[float, float]:
     """Fractional Web-Mercator tile coordinates (x, y; y from the top)."""
-    n = 2 ** zoom
+    n = 2**zoom
     fx = (lon + 180.0) / 360.0 * n
     lat_rad = math.radians(lat)
     fy = (1.0 - math.asinh(math.tan(lat_rad)) / math.pi) / 2.0 * n
     return fx, fy
 
 
-def tile_frac_to_lonlat(fx: float, fy: float, zoom: int) -> Tuple[float, float]:
+def tile_frac_to_lonlat(fx: float, fy: float, zoom: int) -> tuple[float, float]:
     """Inverse of lonlat_to_tile_frac."""
-    n = 2 ** zoom
+    n = 2**zoom
     lon = fx / n * 360.0 - 180.0
     lat = math.degrees(math.atan(math.sinh(math.pi * (1 - 2 * fy / n))))
     return lon, lat
 
 
-def tiles_for_bbox(min_lon: float, min_lat: float, max_lon: float,
-                   max_lat: float, zoom: int = TILE_ZOOM) -> List[Tuple[int, int]]:
+def tiles_for_bbox(
+    min_lon: float, min_lat: float, max_lon: float, max_lat: float, zoom: int = TILE_ZOOM
+) -> list[tuple[int, int]]:
     """All (x, y) tile indices at the given zoom intersecting the bbox."""
     fx_min, fy_max = lonlat_to_tile_frac(min_lon, min_lat, zoom)  # y grows southward
     fx_max, fy_min = lonlat_to_tile_frac(max_lon, max_lat, zoom)
-    n = 2 ** zoom
+    n = 2**zoom
     x_range = range(max(0, int(fx_min)), min(n - 1, int(fx_max)) + 1)
     y_range = range(max(0, int(fy_min)), min(n - 1, int(fy_max)) + 1)
     return [(x, y) for x in x_range for y in y_range]
 
 
-def grid_bbox(center_lat: float, center_lon: float, grid_width: float,
-              grid_height: float, step_length: float) -> Tuple[float, float, float, float]:
+def grid_bbox(
+    center_lat: float, center_lon: float, grid_width: float, grid_height: float, step_length: float
+) -> tuple[float, float, float, float]:
     """
     (min_lon, min_lat, max_lon, max_lat) covering the sampling grid plus a
     half-step margin, computed with the same geodesic math that builds the
@@ -107,21 +111,28 @@ def grid_bbox(center_lat: float, center_lon: float, grid_width: float,
     return west.longitude, south.latitude, east.longitude, north.latitude
 
 
-def estimate_tile_count(center_lat: float, center_lon: float,
-                        grid_width: float, grid_height: float,
-                        step_length: float = 20) -> int:
+def estimate_tile_count(
+    center_lat: float,
+    center_lon: float,
+    grid_width: float,
+    grid_height: float,
+    step_length: float = 20,
+) -> int:
     """
     Number of z14 tile requests a run will make — the Mapillary analogue of
     the scheduler's grid-point request estimate for GSV.
     """
-    return len(tiles_for_bbox(*grid_bbox(center_lat, center_lon,
-                                         grid_width, grid_height, step_length)))
+    return len(
+        tiles_for_bbox(*grid_bbox(center_lat, center_lon, grid_width, grid_height, step_length))
+    )
 
 
 # ── Tile decoding ──────────────────────────────────────────────────────────
 
-def decode_image_features(tile_bytes: bytes, tile_x: int, tile_y: int,
-                          zoom: int = TILE_ZOOM) -> List[Dict[str, Any]]:
+
+def decode_image_features(
+    tile_bytes: bytes, tile_x: int, tile_y: int, zoom: int = TILE_ZOOM
+) -> list[dict[str, Any]]:
     """
     Extract pano image records from one raw vector tile.
 
@@ -133,33 +144,35 @@ def decode_image_features(tile_bytes: bytes, tile_x: int, tile_y: int,
     layer = decoded.get(IMAGE_LAYER)
     if not layer:
         return []
-    extent = layer.get('extent', 4096)
+    extent = layer.get("extent", 4096)
 
     records = []
-    for feature in layer['features']:
-        props = feature.get('properties', {})
-        if not props.get('is_pano'):
+    for feature in layer["features"]:
+        props = feature.get("properties", {})
+        if not props.get("is_pano"):
             continue
-        geometry = feature.get('geometry', {})
-        if geometry.get('type') != 'Point':
+        geometry = feature.get("geometry", {})
+        if geometry.get("type") != "Point":
             continue
-        px, py = geometry['coordinates']
+        px, py = geometry["coordinates"]
         # decode() returns y-up tile-local coords; convert to global fractions
         fx = tile_x + px / extent
         fy = tile_y + (1 - py / extent)
         lon, lat = tile_frac_to_lonlat(fx, fy, zoom)
 
-        image_id = props.get('id', feature.get('id'))
+        image_id = props.get("id", feature.get("id"))
         if image_id is None:
             continue
-        captured_at = props.get('captured_at')
-        records.append({
-            'id': str(image_id),
-            'lon': lon,
-            'lat': lat,
-            'captured_at_ms': captured_at,
-            'creator_id': props.get('creator_id'),
-        })
+        captured_at = props.get("captured_at")
+        records.append(
+            {
+                "id": str(image_id),
+                "lon": lon,
+                "lat": lat,
+                "captured_at_ms": captured_at,
+                "creator_id": props.get("creator_id"),
+            }
+        )
     return records
 
 
@@ -171,22 +184,28 @@ def captured_at_to_iso_date(captured_at_ms) -> str:
     Mapillary could plausibly have imagery, or in the future).
     """
     if not captured_at_ms:
-        return ''
+        return ""
     try:
-        dt = datetime.fromtimestamp(int(captured_at_ms) / 1000, tz=timezone.utc)
+        dt = datetime.fromtimestamp(int(captured_at_ms) / 1000, tz=UTC)
     except (ValueError, OSError, OverflowError):
-        return ''
-    if dt.year < 2004 or dt > datetime.now(timezone.utc):
-        return ''
+        return ""
+    if dt.year < 2004 or dt > datetime.now(UTC):
+        return ""
     return dt.date().isoformat()
 
 
 # ── Grid assignment ────────────────────────────────────────────────────────
 
-def assign_to_grid(image_lats: np.ndarray, image_lons: np.ndarray,
-                   center_lat: float, center_lon: float,
-                   width_steps: int, height_steps: int,
-                   step_length: float) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+
+def assign_to_grid(
+    image_lats: np.ndarray,
+    image_lons: np.ndarray,
+    center_lat: float,
+    center_lon: float,
+    width_steps: int,
+    height_steps: int,
+    step_length: float,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
     """
     Vectorized nearest-grid-point assignment.
 
@@ -214,19 +233,19 @@ def assign_to_grid(image_lats: np.ndarray, image_lons: np.ndarray,
 
 # ── Download ───────────────────────────────────────────────────────────────
 
+
 @backoff.on_exception(
-    backoff.expo,
-    (asyncio.TimeoutError, aiohttp.ClientError),
-    max_tries=3,
-    max_time=60
+    backoff.expo, (asyncio.TimeoutError, aiohttp.ClientError), max_tries=3, max_time=60
 )
-async def _fetch_tile(session: aiohttp.ClientSession, url: str,
-                      timeout: aiohttp.ClientTimeout) -> bytes:
+async def _fetch_tile(
+    session: aiohttp.ClientSession, url: str, timeout: aiohttp.ClientTimeout
+) -> bytes:
     async with session.get(url, timeout=timeout) as response:
         if response.status in (401, 403):
             raise DownloadError(
                 f"Mapillary rejected the access token (HTTP {response.status}). "
-                "Check MAPILLARY_ACCESS_TOKEN.")
+                "Check MAPILLARY_ACCESS_TOKEN."
+            )
         if response.status != 200:
             # 429/5xx raise ClientResponseError, which backoff retries
             response.raise_for_status()
@@ -244,7 +263,7 @@ async def download_mapillary_metadata_async(
     output_csv_gz_path: str,
     connection_limit: int = 5,
     request_timeout: float = 30,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """
     Fetch Mapillary pano metadata for a city and write it as a run csv.gz.
 
@@ -259,14 +278,12 @@ async def download_mapillary_metadata_async(
             api_requests: number of tile requests issued this call
             started_at / finished_at: UTC ISO 8601 timestamps
     """
-    started_at = datetime.now(timezone.utc).isoformat()
+    started_at = datetime.now(UTC).isoformat()
     query_timestamp = started_at
 
-    if not output_csv_gz_path.endswith('.csv.gz'):
-        raise ValueError(
-            f"output_csv_gz_path must end in .csv.gz, got: {output_csv_gz_path}")
-    Path(os.path.dirname(os.path.abspath(output_csv_gz_path))).mkdir(
-        parents=True, exist_ok=True)
+    if not output_csv_gz_path.endswith(".csv.gz"):
+        raise ValueError(f"output_csv_gz_path must end in .csv.gz, got: {output_csv_gz_path}")
+    Path(os.path.dirname(os.path.abspath(output_csv_gz_path))).mkdir(parents=True, exist_ok=True)
 
     width_steps = int(grid_width / step_length)
     height_steps = int(grid_height / step_length)
@@ -278,15 +295,15 @@ async def download_mapillary_metadata_async(
     tiles = tiles_for_bbox(*bbox)
     logger.info(
         f"Fetching Mapillary metadata for {city_name}: {len(tiles)} z{TILE_ZOOM} "
-        f"tiles covering bbox {tuple(round(v, 4) for v in bbox)}")
+        f"tiles covering bbox {tuple(round(v, 4) for v in bbox)}"
+    )
 
     api_requests = 0
     timeout = aiohttp.ClientTimeout(total=request_timeout)
     semaphore = asyncio.Semaphore(connection_limit)
-    progress_bar = tqdm(total=len(tiles),
-                        desc=f"Downloading Mapillary tiles for {city_name}")
+    progress_bar = tqdm(total=len(tiles), desc=f"Downloading Mapillary tiles for {city_name}")
 
-    async def fetch_one(x: int, y: int) -> List[Dict[str, Any]]:
+    async def fetch_one(x: int, y: int) -> list[dict[str, Any]]:
         nonlocal api_requests
         url = TILE_URL_TEMPLATE.format(z=TILE_ZOOM, x=x, y=y, token=access_token)
         async with semaphore:
@@ -298,7 +315,7 @@ async def download_mapillary_metadata_async(
     try:
         async with aiohttp.ClientSession() as session:
             results = await asyncio.gather(*(fetch_one(x, y) for x, y in tiles))
-    except (asyncio.TimeoutError, aiohttp.ClientError) as e:
+    except (TimeoutError, aiohttp.ClientError) as e:
         raise DownloadError(f"Mapillary tile download failed: {e}") from e
     finally:
         progress_bar.close()
@@ -308,72 +325,81 @@ async def download_mapillary_metadata_async(
     images_by_id = {}
     for records in results:
         for record in records:
-            images_by_id[record['id']] = record
+            images_by_id[record["id"]] = record
     images = list(images_by_id.values())
-    logger.info(f"Decoded {sum(len(r) for r in results)} pano features "
-                f"({len(images)} unique) from {len(tiles)} tiles")
+    logger.info(
+        f"Decoded {sum(len(r) for r in results)} pano features "
+        f"({len(images)} unique) from {len(tiles)} tiles"
+    )
 
     rows = []
     covered_points = set()
     if images:
-        lats = np.array([img['lat'] for img in images])
-        lons = np.array([img['lon'] for img in images])
+        lats = np.array([img["lat"] for img in images])
+        lons = np.array([img["lon"] for img in images])
         i_idx, j_idx, in_grid = assign_to_grid(
-            lats, lons, center_lat, center_lon,
-            width_steps, height_steps, step_length)
-        for img, i, j, keep in zip(images, i_idx, j_idx, in_grid):
+            lats, lons, center_lat, center_lon, width_steps, height_steps, step_length
+        )
+        for img, i, j, keep in zip(images, i_idx, j_idx, in_grid, strict=False):
             if not keep:
                 continue
             grid_lat, grid_lon = point_by_index[(int(i), int(j))]
-            capture_date = captured_at_to_iso_date(img['captured_at_ms'])
-            creator = img['creator_id']
-            copyright_info = (f"© Mapillary contributor {creator}"
-                              if creator is not None else "© Mapillary")
-            rows.append({
-                'query_lat': grid_lat,
-                'query_lon': grid_lon,
-                'query_timestamp': query_timestamp,
-                'pano_lat': img['lat'],
-                'pano_lon': img['lon'],
-                'pano_id': img['id'],
-                'capture_date': capture_date,
-                'copyright_info': copyright_info,
-                # Mirror GSV's convention: an image without a usable
-                # capture date is present but doesn't count as coverage
-                'status': 'OK' if capture_date else 'NO_DATE',
-            })
+            capture_date = captured_at_to_iso_date(img["captured_at_ms"])
+            creator = img["creator_id"]
+            copyright_info = (
+                f"© Mapillary contributor {creator}" if creator is not None else "© Mapillary"
+            )
+            rows.append(
+                {
+                    "query_lat": grid_lat,
+                    "query_lon": grid_lon,
+                    "query_timestamp": query_timestamp,
+                    "pano_lat": img["lat"],
+                    "pano_lon": img["lon"],
+                    "pano_id": img["id"],
+                    "capture_date": capture_date,
+                    "copyright_info": copyright_info,
+                    # Mirror GSV's convention: an image without a usable
+                    # capture date is present but doesn't count as coverage
+                    "status": "OK" if capture_date else "NO_DATE",
+                }
+            )
             covered_points.add((int(i), int(j)))
 
     for (i, j), (grid_lat, grid_lon) in point_by_index.items():
         if (i, j) not in covered_points:
-            rows.append({
-                'query_lat': grid_lat,
-                'query_lon': grid_lon,
-                'query_timestamp': query_timestamp,
-                'pano_lat': None,
-                'pano_lon': None,
-                'pano_id': None,
-                'capture_date': None,
-                'copyright_info': None,
-                'status': 'ZERO_RESULTS',
-            })
+            rows.append(
+                {
+                    "query_lat": grid_lat,
+                    "query_lon": grid_lon,
+                    "query_timestamp": query_timestamp,
+                    "pano_lat": None,
+                    "pano_lon": None,
+                    "pano_id": None,
+                    "capture_date": None,
+                    "copyright_info": None,
+                    "status": "ZERO_RESULTS",
+                }
+            )
 
     df = pd.DataFrame(rows, columns=list(METADATA_DTYPES.keys()))
-    csv_bytes = df.to_csv(index=False).encode('utf-8')
-    with gzip.open(output_csv_gz_path, 'wb') as f:
+    csv_bytes = df.to_csv(index=False).encode("utf-8")
+    with gzip.open(output_csv_gz_path, "wb") as f:
         f.write(csv_bytes)
 
     # Read back through the shared loader so dtypes match GSV runs exactly
     df = load_city_csv_file(output_csv_gz_path)
-    n_panos = int((df['status'] == 'OK').sum())
-    logger.info(f"Wrote {len(df)} rows ({n_panos} panos, "
-                f"{len(point_by_index) - len(covered_points)} empty grid points) "
-                f"to {output_csv_gz_path}")
+    n_panos = int((df["status"] == "OK").sum())
+    logger.info(
+        f"Wrote {len(df)} rows ({n_panos} panos, "
+        f"{len(point_by_index) - len(covered_points)} empty grid points) "
+        f"to {output_csv_gz_path}"
+    )
 
     return {
         "df": df,
         "filename_with_path": output_csv_gz_path,
         "api_requests": api_requests,
         "started_at": started_at,
-        "finished_at": datetime.now(timezone.utc).isoformat(),
+        "finished_at": datetime.now(UTC).isoformat(),
     }

--- a/gsv_metadata_tracker/fileutils.py
+++ b/gsv_metadata_tracker/fileutils.py
@@ -1,49 +1,50 @@
-import os, glob
+import glob
 import logging
-from typing import Tuple, Optional, List
-import pandas as pd
-from pathlib import Path
+import os
 import platform
 import subprocess
 import webbrowser
+from pathlib import Path
+
+import pandas as pd
+
+from . import geoutils
 from .config import METADATA_DTYPES
-from .paths import get_default_data_dir, get_default_vis_dir
+
 # Filename helpers live in naming.py; re-exported here for backward compatibility.
 from .naming import (
-    ParsedFilename,
     generate_base_filename,
-    generate_run_filename,
-    parse_filename,
-    sanitize_city_query_str,
 )
-from . import geoutils
+from .paths import get_default_data_dir
 
 logger = logging.getLogger(__name__)
 
-def get_list_of_city_csv_files(data_dir = None) -> List[str]:
+
+def get_list_of_city_csv_files(data_dir=None) -> list[str]:
     if data_dir is None:
         data_dir = get_default_data_dir()
 
     csv_files = glob.glob(os.path.join(data_dir, "**/*.csv.gz"), recursive=True)
     return csv_files
 
-def does_city_csv_file_exist(data_dir: str, city_query_str: str,     
-                             grid_width: float, grid_height: float,
-                             step_length: float) -> str | None:
+
+def does_city_csv_file_exist(
+    data_dir: str, city_query_str: str, grid_width: float, grid_height: float, step_length: float
+) -> str | None:
     """
     Check if a city CSV file exists by trying different name permutations.
     Uses location data to generate various possible filenames based on city, state, and country.
-    
+
     Args:
         data_dir: Directory to search for CSV files
         city_query_str: Query string that may contain city, state, and/or country
         grid_width: Width of search grid in meters
         grid_height: Height of search grid in meters
         step_length: Step size in meters
-        
+
     Returns:
         str | None: Full path to the matching file if found, None if no matching file exists
-        
+
     Examples:
         >>> does_city_csv_file_exist("/data", "Paris, France", 1000, 1000, 20)
         '/data/paris--france_width_1000_height_1000_step_20.csv.gz'  # If file exists
@@ -64,7 +65,7 @@ def does_city_csv_file_exist(data_dir: str, city_query_str: str,
 
     # Generate possible name permutations based on available location data
     name_permutations = []
-    
+
     city = location.city
     state_code = location.state_code
     state = location.state
@@ -97,7 +98,9 @@ def does_city_csv_file_exist(data_dir: str, city_query_str: str,
 
     # Try each permutation
     for city_query_str_to_test in name_permutations:
-        base_filename = generate_base_filename(city_query_str_to_test, grid_width, grid_height, step_length)
+        base_filename = generate_base_filename(
+            city_query_str_to_test, grid_width, grid_height, step_length
+        )
         full_path = os.path.join(data_dir, f"{base_filename}.csv.gz")
         logger.debug(f"Checking for file: {full_path}")
         if os.path.exists(full_path):
@@ -107,18 +110,19 @@ def does_city_csv_file_exist(data_dir: str, city_query_str: str,
     logger.info(f"No matching file found for {city_query_str} with any permutation")
     return None
 
+
 def load_city_csv_file(csv_path: str) -> pd.DataFrame:
     """
     Read a CSV file into a DataFrame, automatically detecting if it's gzipped based on file extension.
     Handles YYYY-MM format (most common) and YYYY-MM-DD format for capture_date.
     Uses modern pandas datetime parsing methods.
-    
+
     Args:
         csv_path: Path to the CSV file (can be either .csv or .csv.gz)
-    
+
     Returns:
         pd.DataFrame: Loaded and processed DataFrame
-    
+
     Raises:
         ValueError: If the file extension is neither .csv nor .csv.gz
         FileNotFoundError: If the specified file doesn't exist
@@ -126,18 +130,20 @@ def load_city_csv_file(csv_path: str) -> pd.DataFrame:
     logger.debug(f"Loading CSV file: {csv_path}")
 
     file_path = Path(csv_path)
-    
+
     if not file_path.exists():
         raise FileNotFoundError(f"File not found: {csv_path}")
-    
+
     # Determine compression based on file extension
-    if file_path.suffix == '.gz' or str(file_path).endswith('.csv.gz'):
-        compression = 'gzip'
-    elif file_path.suffix == '.csv':
+    if file_path.suffix == ".gz" or str(file_path).endswith(".csv.gz"):
+        compression = "gzip"
+    elif file_path.suffix == ".csv":
         compression = None
     else:
-        raise ValueError(f"Unsupported file format. Expected .csv or .csv.gz, got: {file_path.suffix}")
-    
+        raise ValueError(
+            f"Unsupported file format. Expected .csv or .csv.gz, got: {file_path.suffix}"
+        )
+
     try:
         logger.debug(f"Reading CSV file with compression: {compression}")
 
@@ -147,14 +153,13 @@ def load_city_csv_file(csv_path: str) -> pd.DataFrame:
             dtype=METADATA_DTYPES,
             compression=compression,
         )
-        
+
         # Convert query_timestamp (ISO 8601 with timezone)
-        df['query_timestamp'] = pd.to_datetime(df['query_timestamp'], format='ISO8601')
-        
+        df["query_timestamp"] = pd.to_datetime(df["query_timestamp"], format="ISO8601")
+
         # Convert capture_date (YYYY-MM-DD)
-        df['capture_date'] = pd.to_datetime(df['capture_date'], format='%Y-%m-%d', errors='coerce')
-    
-        
+        df["capture_date"] = pd.to_datetime(df["capture_date"], format="%Y-%m-%d", errors="coerce")
+
         logger.debug(f"Loaded {len(df)} rows from {csv_path}")
         logger.debug(f"The DataFrame has columns: {df.columns} with dtypes: {df.dtypes}")
 
@@ -164,76 +169,78 @@ def load_city_csv_file(csv_path: str) -> pd.DataFrame:
             logger.debug(f"  {col:15} {dtype}")
 
         return df
-        
-    except pd.errors.EmptyDataError:
-        raise ValueError(f"The file {csv_path} is empty")
+
+    except pd.errors.EmptyDataError as e:
+        raise ValueError(f"The file {csv_path} is empty") from e
     except pd.errors.ParserError as e:
-        raise ValueError(f"Error parsing file {csv_path}: {str(e)}")
+        raise ValueError(f"Error parsing file {csv_path}: {str(e)}") from e
+
 
 def try_open_with_system_command(file_path: str) -> bool:
     """
     Attempt to open file using system-specific commands as fallback.
-    
+
     Args:
         file_path: Path to the file to open
-    
+
     Returns:
         bool: True if successful, False otherwise
     """
     try:
         system = platform.system().lower()
-        if system == 'darwin':  # macOS
-            subprocess.run(['open', file_path], check=True)
-        elif system == 'windows':
-            subprocess.run(['start', file_path], shell=True, check=True)
-        elif system == 'linux':
-            subprocess.run(['xdg-open', file_path], check=True)
+        if system == "darwin":  # macOS
+            subprocess.run(["open", file_path], check=True)
+        elif system == "windows":
+            subprocess.run(["start", file_path], shell=True, check=True)
+        elif system == "linux":
+            subprocess.run(["xdg-open", file_path], check=True)
         else:
             return False
         return True
     except subprocess.SubprocessError:
         return False
 
-def open_in_browser(file_path: str) -> Tuple[bool, Optional[str]]:
+
+def open_in_browser(file_path: str) -> tuple[bool, str | None]:
     """
     Open a file in the default web browser with error handling and fallback options.
-    
+
     Args:
         file_path: Path to the file to open
-    
+
     Returns:
         Tuple[bool, Optional[str]]: (Success status, Error message if any)
     """
     path = Path(file_path).resolve()
-    
+
     if not path.exists():
         return False, f"File not found: {file_path}"
-    
+
     try:
         # Convert to proper file URI based on platform
-        if platform.system() == 'Windows':
+        if platform.system() == "Windows":
             uri = path.as_uri()
         else:
-            uri = f'file://{path}'
-        
+            uri = f"file://{path}"
+
         # Try primary method: webbrowser module
         if webbrowser.open(uri, new=2):
             return True, None
-            
+
         # First fallback: Try specific browsers
-        for browser in ['google-chrome', 'firefox', 'safari', 'edge']:
+        for browser in ["google-chrome", "firefox", "safari", "edge"]:
             try:
                 browser_ctrl = webbrowser.get(browser)
                 if browser_ctrl.open(uri, new=2):
                     return True, None
             except webbrowser.Error:
                 continue
-                
+
         # Second fallback: system-specific commands
         if try_open_with_system_command(str(path)):
             return True, None
-            
+
         return False, "Failed to open browser using all available methods"
-        
+
     except Exception as e:
         return False, f"Error opening browser: {str(e)}"

--- a/gsv_metadata_tracker/geoutils.py
+++ b/gsv_metadata_tracker/geoutils.py
@@ -1,15 +1,13 @@
-import pycountry # for ISO country codes
-import us  # for US states
-
-from typing import Optional, Dict, Tuple
-from geopy.geocoders import Nominatim
-from geopy.exc import GeocoderTimedOut, GeocoderUnavailable
-from geopy.extra.rate_limiter import RateLimiter
-from geopy.location import Location
-from geopy.distance import geodesic
-import pandas as pd
 import logging
 from functools import lru_cache
+
+import pandas as pd
+import pycountry  # for ISO country codes
+import us  # for US states
+from geopy.distance import geodesic
+from geopy.exc import GeocoderTimedOut, GeocoderUnavailable
+from geopy.extra.rate_limiter import RateLimiter
+from geopy.geocoders import Nominatim
 
 logger = logging.getLogger(__name__)
 
@@ -20,9 +18,9 @@ _geolocator = Nominatim(user_agent=NOMINATIM_USER_AGENT, timeout=10)
 _rate_limited_geocode = RateLimiter(_geolocator.geocode, min_delay_seconds=1.1)
 
 
-def geocode_boundary_raw(city_name: str,
-                         state_name: Optional[str] = None,
-                         country_name: Optional[str] = None) -> Optional[dict]:
+def geocode_boundary_raw(
+    city_name: str, state_name: str | None = None, country_name: str | None = None
+) -> dict | None:
     """
     Rate-limited Nominatim lookup returning the raw top result including
     the boundary polygon GeoJSON, or None when nothing matches.
@@ -43,86 +41,90 @@ def geocode_boundary_raw(city_name: str,
         >>> raw['geojson']['type']
         'MultiPolygon'
     """
-    query = {key: value for key, value in
-             [('city', city_name), ('state', state_name),
-              ('country', country_name)] if value}
-    location = _rate_limited_geocode(query, language='en',
-                                     addressdetails=True, geometry='geojson')
+    query = {
+        key: value
+        for key, value in [("city", city_name), ("state", state_name), ("country", country_name)]
+        if value
+    }
+    location = _rate_limited_geocode(query, language="en", addressdetails=True, geometry="geojson")
     return dict(location.raw) if location is not None else None
 
-def get_state_abbreviation(state_name: Optional[str]) -> Optional[str]:
+
+def get_state_abbreviation(state_name: str | None) -> str | None:
     """
     Get the standard two-letter abbreviation for a US state.
     Returns original string if no abbreviation is found.
-    
+
     Args:
         state_name: Full name of the US state
-        
+
     Returns:
         Two-letter state abbreviation, original string if not found, or None if input is None
     """
     if not state_name:
         return None
-        
+
     try:
         state = us.states.lookup(state_name)
         return state.abbr if state else state_name
     except AttributeError:
         return state_name
 
-def get_country_code(country_name: Optional[str]) -> Optional[str]:
+
+def get_country_code(country_name: str | None) -> str | None:
     """
     Get the standard two-letter ISO country code.
     Returns original string if no code is found.
-    
+
     Args:
         country_name: Full name of the country
-        
+
     Returns:
         Two-letter ISO country code, original string if not found, or None if input is None
     """
     if not country_name:
         return None
-        
+
     # Handle common variations in country names
     name_variations = {
-        'United States': 'USA',
-        'United States of America': 'USA',
-        'USA': 'USA',
-        'UK': 'United Kingdom',
-        'Great Britain': 'United Kingdom',
-        'Russia': 'Russian Federation',
-        'South Korea': 'Korea, Republic of',
-        'North Korea': "Korea, Democratic People's Republic of",
-        'Taiwan': 'Taiwan, Province of China',
+        "United States": "USA",
+        "United States of America": "USA",
+        "USA": "USA",
+        "UK": "United Kingdom",
+        "Great Britain": "United Kingdom",
+        "Russia": "Russian Federation",
+        "South Korea": "Korea, Republic of",
+        "North Korea": "Korea, Democratic People's Republic of",
+        "Taiwan": "Taiwan, Province of China",
     }
-    
+
     # Normalize the country name
     normalized_name = name_variations.get(country_name, country_name)
-    
+
     try:
         # First try direct lookup
         country = pycountry.countries.get(name=normalized_name)
         if country:
             return country.alpha_2
-            
+
         # Try fuzzy matching if direct lookup fails
         matches = pycountry.countries.search_fuzzy(normalized_name)
         if matches:
             return matches[0].alpha_2
-            
+
     except (LookupError, AttributeError):
         pass
-        
+
     return country_name
+
 
 class EnhancedLocation:
     """
     A wrapper class for geopy Location objects that adds convenient access to country and state information.
-    
+
     This class uses the delegation pattern to wrap the original Location object while adding new properties
     for easier access to commonly needed address components. It maintains all original Location functionality
-    through delegation while providing cleaner access to country and state data that would normally require 
+    through delegation while providing cleaner access to country and state data that would normally require
     multiple dictionary lookups.
 
     https://geopy.readthedocs.io/en/stable/index.html?highlight=location#geopy.location.Location
@@ -131,14 +133,15 @@ class EnhancedLocation:
         _location: The wrapped geopy Location object
         _country: Cached country name extracted from location.raw['address']
         _state: Cached state/region name extracted from location.raw['address']
-        
+
     Properties:
         country: The country name, or None if not available
         state: The state/region name, or None if not available
-        
+
     All other attributes are delegated to the wrapped Location object, so this class can be used
     as a drop-in replacement for the original Location class.
     """
+
     def __init__(self, city_query_str, location):
         """
         Initialize the enhanced location wrapper.
@@ -167,128 +170,143 @@ class EnhancedLocation:
         self._width = None
         self._height = None
 
-
         logger.debug(f"EnhancedLocation created for {location}")
-        
-        if hasattr(location, 'raw'):
-            address_data = location.raw.get('address', {})
+
+        if hasattr(location, "raw"):
+            address_data = location.raw.get("address", {})
             logger.debug(f"EnhancedLocation address_data {address_data}")
 
-            self._country = address_data.get('country')
+            self._country = address_data.get("country")
 
-            COUNTRY_CODE_FIELD = 'country_code'
+            COUNTRY_CODE_FIELD = "country_code"
             if COUNTRY_CODE_FIELD in address_data:
                 self._country_code = address_data.get(COUNTRY_CODE_FIELD)
-                logger.debug(f"EnhancedLocation country code '{self._country_code}' found with field '{COUNTRY_CODE_FIELD}'")
+                logger.debug(
+                    f"EnhancedLocation country code '{self._country_code}' found with field '{COUNTRY_CODE_FIELD}'"
+                )
             elif self._country:
                 self._country_code = get_country_code(self._country)
-                logger.debug(f"EnhancedLocation country '{self._country}' and code '{self._country_code}' extracted from '{address_data}'")
-            
+                logger.debug(
+                    f"EnhancedLocation country '{self._country}' and code '{self._country_code}' extracted from '{address_data}'"
+                )
+
             # Try different possible state field names
-            for field in ['state', 'county', 'state_district', 'region']:
+            for field in ["state", "county", "state_district", "region"]:
                 if field in address_data:
                     self._state = address_data.get(field)
-                    logger.debug(f"EnhancedLocation state '{self._state}' found with field '{field}'")
+                    logger.debug(
+                        f"EnhancedLocation state '{self._state}' found with field '{field}'"
+                    )
                     break
 
-            ISO_3166_2_FIELD = 'ISO3166-2-lvl4'
+            ISO_3166_2_FIELD = "ISO3166-2-lvl4"
             if ISO_3166_2_FIELD in address_data:
                 iso_code = address_data.get(ISO_3166_2_FIELD)
 
                 # Split on hyphen and take the second part
                 # e.g., 'US-WA' becomes ['US', 'WA'] and we take 'WA'
-                self._state_code = iso_code.split('-')[1] if '-' in iso_code else None
-                logger.debug(f"EnhancedLocation state code '{self._state_code}' extracted from '{iso_code}' and field '{ISO_3166_2_FIELD}'")
+                self._state_code = iso_code.split("-")[1] if "-" in iso_code else None
+                logger.debug(
+                    f"EnhancedLocation state code '{self._state_code}' extracted from '{iso_code}' and field '{ISO_3166_2_FIELD}'"
+                )
             elif self._state:
                 self._state_code = get_state_abbreviation(self._state)
-                logger.debug(f"EnhancedLocation state code '{self._state_code}' derived from state name '{self._state}'")
+                logger.debug(
+                    f"EnhancedLocation state code '{self._state_code}' derived from state name '{self._state}'"
+                )
 
             # Try different possible city field names
-            for field in ['city', 'town', 'township', 'village', 'municipality', 'suburb']:
+            for field in ["city", "town", "township", "village", "municipality", "suburb"]:
                 if field in address_data:
                     self._city = address_data.get(field)
-                    logger.debug(f"EnhancedLocation state '{self._city}' found with field '{field}'")
+                    logger.debug(
+                        f"EnhancedLocation state '{self._city}' found with field '{field}'"
+                    )
                     break
 
             if self._city is None:
-                logger.warning(f"Could not find city in {address_data}, will attempt to extract from query string '{self._city_query_str}'")
-                if ',' in self._city_query_str:
-                    self._city = self._city_query_str.split(',')[0].strip()
+                logger.warning(
+                    f"Could not find city in {address_data}, will attempt to extract from query string '{self._city_query_str}'"
+                )
+                if "," in self._city_query_str:
+                    self._city = self._city_query_str.split(",")[0].strip()
                 else:
                     self._city = self._city_query_str
-                
+
                 logger.info(f"Extracted city from query string: {self._city}")
 
-            if 'boundingbox' in self._location.raw:
+            if "boundingbox" in self._location.raw:
                 try:
-                    bbox = self._location.raw['boundingbox']
+                    bbox = self._location.raw["boundingbox"]
                     logger.debug(f"Found bounding box data: {bbox}")
-                    
+
                     # Nominatim returns boundingbox as [south, north, west, east]
                     south, north, west, east = map(float, bbox)
-                    
+
                     # Store corners as tuples (lat, lng)
                     self._top_left = (north, west)
                     self._bot_right = (south, east)
-                    
+
                     # Calculate dimensions using geodesic distance
                     self._width = geodesic((south, west), (south, east)).kilometers
                     self._height = geodesic((south, west), (north, west)).kilometers
                     self._area = self._width * self._height
-                    
-                    logger.debug(f"EnhancedLocation bounding box calculated: area={self._area:.2f}km², " 
-                                f"width={self._width:.2f}km, height={self._height:.2f}km")
+
+                    logger.debug(
+                        f"EnhancedLocation bounding box calculated: area={self._area:.2f}km², "
+                        f"width={self._width:.2f}km, height={self._height:.2f}km"
+                    )
                 except Exception as e:
                     logger.warning(f"Error processing bounding box data: {e}")
-            
+
     @property
-    def country_code(self) -> Optional[str]:
+    def country_code(self) -> str | None:
         """
         Get the two-letter ISO country code.
-        
+
         Returns:
             str or None: The ISO 3166-1 alpha-2 country code if available, None otherwise
         """
         return self._country_code
-        
+
     @property
-    def state_code(self) -> Optional[str]:
+    def state_code(self) -> str | None:
         """
         Get the state/region abbreviation (currently supports US states).
-        
+
         Returns:
             str or None: The state abbreviation if available (e.g., 'CA' for California),
             None otherwise
         """
         return self._state_code
-    
+
     @property
-    def country(self) -> Optional[str]:
+    def country(self) -> str | None:
         """
         Get the country name.
-        
+
         Returns:
             str or None: The country name if available, None otherwise
         """
         return self._country
-        
+
     @property
-    def state(self) -> Optional[str]:
+    def state(self) -> str | None:
         """
         Get the state/region name.
-        
+
         Returns:
             str or None: The state or region name if available, None otherwise.
             This could be a state (US), county (UK), or other regional division
             depending on the country.
         """
         return self._state
-    
+
     @property
-    def city(self) -> Optional[str]:
+    def city(self) -> str | None:
         """
         Get the city name.
-        
+
         Returns:
             str or None: The city name if available, None otherwise.
             This could come from various fields in the raw data:
@@ -299,39 +317,39 @@ class EnhancedLocation:
             - suburb: Used for city subdivisions in some areas
         """
         return self._city
-    
+
     @property
-    def area(self) -> Optional[float]:
+    def area(self) -> float | None:
         """
         Get the area of the bounding box in square kilometers.
-        
+
         Returns:
             float or None: The area in km² if bounding box is available, None otherwise
         """
         return self._area
 
     @property
-    def top_left(self) -> Optional[tuple]:
+    def top_left(self) -> tuple | None:
         """
         Get the top-left coordinates of the bounding box.
-        
+
         Returns:
             tuple or None: (latitude, longitude) tuple if available, None otherwise
         """
         return self._top_left
 
     @property
-    def bottom_right(self) -> Optional[tuple]:
+    def bottom_right(self) -> tuple | None:
         """
         Get the bottom-right coordinates of the bounding box.
-        
+
         Returns:
             tuple or None: (latitude, longitude) tuple if available, None otherwise
         """
         return self._bot_right
 
     @property
-    def bbox_center(self) -> Optional[tuple]:
+    def bbox_center(self) -> tuple | None:
         """
         Get the midpoint of the OSM bounding box.
 
@@ -352,35 +370,35 @@ class EnhancedLocation:
         return ((north + south) / 2.0, (west + east) / 2.0)
 
     @property
-    def width(self) -> Optional[float]:
+    def width(self) -> float | None:
         """
         Get the width of the bounding box in kilometers.
-        
+
         Returns:
             float or None: The width in km if bounding box is available, None otherwise
         """
         return self._width
 
     @property
-    def height(self) -> Optional[float]:
+    def height(self) -> float | None:
         """
         Get the height of the bounding box in kilometers.
-        
+
         Returns:
             float or None: The height in km if bounding box is available, None otherwise
         """
         return self._height
-    
+
     @property
-    def bbox_tuple(self) -> Optional[tuple]:
+    def bbox_tuple(self) -> tuple | None:
         """
         Get the bounding box coordinates in (north, south, east, west) format.
         This format is compatible with libraries like osmnx for network analysis.
-        
+
         Returns:
-            tuple or None: A tuple of (north, south, east, west) coordinates if 
+            tuple or None: A tuple of (north, south, east, west) coordinates if
             bounding box is available, None otherwise
-            
+
         Example:
             >>> location = EnhancedLocation(...)
             >>> north, south, east, west = location.bbox_tuple
@@ -391,11 +409,11 @@ class EnhancedLocation:
             south, east = self._bot_right
             return (north, south, east, west)
         return None
-        
+
     def __getattr__(self, name):
         """
         Delegate any unknown attribute access to the wrapped Location object.
-        
+
         This allows the EnhancedLocation to be used anywhere a Location object
         would be used, maintaining backward compatibility while adding new features.
 
@@ -409,106 +427,105 @@ class EnhancedLocation:
             AttributeError: If the attribute doesn't exist on the wrapped Location object
         """
         return getattr(self._location, name)
-    
+
     def __detailed_str__(self) -> str:
         """
         Returns a detailed, formatted string representation of the location with
         hierarchical components including coordinates and geographical bounds.
-        
+
         Returns:
             str: A multi-line formatted string containing detailed location information
-            
+
         Example output:
             City: San Francisco
             State: California (CA)
             Country: United States (US)
             Center: (37.7749, -122.4194)
-            Bounding Box: 
+            Bounding Box:
             Top-Left: (37.8199, -122.4784)
             Bottom-Right: (37.7299, -122.3604)
             Area: 121.4 km²
         """
         lines = []
-        
+
         # Add city
         if self._city:
             lines.append(f"City: {self._city}")
-        
+
         # Add state with code if available
         if self._state:
             state_str = self._state
             if self._state_code:
                 state_str += f" ({self._state_code})"
             lines.append(f"State: {state_str}")
-        
+
         # Add country with code if available
         if self._country:
             country_str = self._country
             if self._country_code:
                 country_str += f" ({self._country_code})"
             lines.append(f"Country: {country_str}")
-        
+
         # Add center coordinates
-        if hasattr(self._location, 'latitude') and hasattr(self._location, 'longitude'):
+        if hasattr(self._location, "latitude") and hasattr(self._location, "longitude"):
             lines.append(f"Center: ({self._location.latitude:.4f}, {self._location.longitude:.4f})")
-        
+
         # Add bounding box if available
         if self._top_left and self._bot_right:
             lines.append("Bounding Box:")
             lines.append(f"  Top-Left: ({self._top_left[0]:.4f}, {self._top_left[1]:.4f})")
             lines.append(f"  Bottom-Right: ({self._bot_right[0]:.4f}, {self._bot_right[1]:.4f})")
             lines.append(f"Area: {self._area:.1f} km²")
-        
+
         return "\n".join(lines) if lines else "Unknown Location"
 
     def __str__(self) -> str:
         """
         Returns a human-readable string representation of the location.
-        
+
         The string includes available location components in a hierarchical format:
         city, state (state_code), country (country_code). Components that aren't
         available are omitted.
-        
+
         Returns:
             str: A formatted string containing the available location information
-        
+
         Examples:
             "San Francisco, California (CA), United States (US)"
             "London, United Kingdom (GB)"
             "Paris, Île-de-France, France (FR)"
         """
         components = []
-        
+
         # Add city if available
         if self._city:
             components.append(self._city)
-            
+
         # Add state with code if available
         if self._state:
             state_str = self._state
             if self._state_code:
                 state_str += f" ({self._state_code})"
             components.append(state_str)
-            
+
         # Add country with code if available
         if self._country:
             country_str = self._country
             if self._country_code:
                 country_str += f" ({self._country_code})"
             components.append(country_str)
-            
+
         # Handle empty case
         if not components:
             return "Unknown Location"
-            
+
         return ", ".join(components)
+
 
 @lru_cache(maxsize=128)
 def get_city_location_data(
-    city_query_str: str, 
-    center_lat: Optional[float] = None, 
-    center_lng: Optional[float] = None
-) -> Optional[EnhancedLocation]:
+    city_query_str: str, center_lat: float | None = None, center_lng: float | None = None
+) -> EnhancedLocation | None:
     """
     Get location information for a city including coordinates, country, and bounding box.
     If center coordinates are provided, uses them to help disambiguate common city names.
@@ -522,12 +539,12 @@ def get_city_location_data(
 
     # Will find Springfield, Massachusetts
     location = get_city_location_data("Springfield", 42.1015, -72.5898)
-    
+
     Args:
         city_query_str: Name of the city to look up
         center_lat: Optional latitude to help disambiguate city location
         center_lng: Optional longitude to help disambiguate city location
-        
+
     Returns:
         Location object with these key attributes:
             - latitude: float (e.g., 48.8566)
@@ -540,11 +557,11 @@ def get_city_location_data(
             - raw['boundingbox']: list of [south, north, west, east] coordinates
                 Example: ['48.8155755', '48.9021560', '2.2241989', '2.4697602']
         Returns None if city not found or on error
-        
+
     Example:
         >>> # Basic usage
         >>> location = get_city_location_data("Paris")
-        >>> 
+        >>>
         >>> # With disambiguation coordinates (e.g., for Springfield, IL)
         >>> location = get_city_location_data("Springfield", 39.7817, -89.6501)
         >>> if location:
@@ -557,28 +574,24 @@ def get_city_location_data(
     if not city_query_str or not city_query_str.strip():
         logging.error("City name cannot be empty")
         return None
-        
+
     try:
         # If center coordinates provided, use them for disambiguation
         found_loc = None
         if center_lat is not None and center_lng is not None:
             # Get multiple location results
             locations = _rate_limited_geocode(
-                city_query_str,
-                language="en",
-                addressdetails=True,
-                exactly_one=False
+                city_query_str, language="en", addressdetails=True, exactly_one=False
             )
-            
+
             if locations:
                 # Find closest location to provided coordinates
                 center_point = (center_lat, center_lng)
                 closest_location = min(
                     locations,
-                    key=lambda loc: geodesic(
-                        center_point, 
-                        (loc.latitude, loc.longitude)
-                    ).kilometers
+                    key=lambda loc: (
+                        geodesic(center_point, (loc.latitude, loc.longitude)).kilometers
+                    ),
                 )
                 logging.info(
                     f"Found closest match for {city_query_str} near ({center_lat}, {center_lng}): "
@@ -588,23 +601,21 @@ def get_city_location_data(
 
         if not found_loc:
             # If no center coordinates or no results found, fall back to basic search
-            found_loc = _rate_limited_geocode(
-                city_query_str,
-                language="en",
-                addressdetails=True
-            )
-        
+            found_loc = _rate_limited_geocode(city_query_str, language="en", addressdetails=True)
+
         if found_loc is not None:
-            logging.info(f"Found coordinates for {city_query_str}: {found_loc.latitude}, {found_loc.longitude}")
-            
+            logging.info(
+                f"Found coordinates for {city_query_str}: {found_loc.latitude}, {found_loc.longitude}"
+            )
+
             enhancedLoc = EnhancedLocation(city_query_str, found_loc)
             logging.info(f"From query string '{city_query_str}', created '{enhancedLoc}'")
             return enhancedLoc
-            
+
         else:
             logging.warning(f"Could not find coordinates for {city_query_str}")
             return None
-            
+
     except GeocoderTimedOut:
         logging.error(f"Timeout looking up coordinates for {city_query_str}")
         return None
@@ -616,123 +627,127 @@ def get_city_location_data(
         return None
 
 
-def get_bounding_box(df: pd.DataFrame) -> Dict[str, float]:
+def get_bounding_box(df: pd.DataFrame) -> dict[str, float]:
     """
     Get the bounding box coordinates from a DataFrame of points.
-    
+
     Args:
         df: DataFrame with 'pano_lat' and 'pano_lon' columns
-    
+
     Returns:
         Dictionary with 'south', 'west', 'north', and 'east' keys
     """
     return {
-        'south': df['pano_lat'].min(),
-        'west': df['pano_lon'].min(),
-        'north': df['pano_lat'].max(),
-        'east': df['pano_lon'].max()
+        "south": df["pano_lat"].min(),
+        "west": df["pano_lon"].min(),
+        "north": df["pano_lat"].max(),
+        "east": df["pano_lon"].max(),
     }
+
 
 def get_bounding_box_size(df: pd.DataFrame) -> tuple[float, float]:
     """
     Calculate the width and height of a bounding box containing all points
     using geopy's geodesic calculations.
-    
+
     Returns:
         tuple of (width_meters, height_meters)
     """
     # Get bounding box coordinates
-    min_lat = df['pano_lat'].min()
-    max_lat = df['pano_lat'].max()
-    min_lon = df['pano_lon'].min()
-    max_lon = df['pano_lon'].max()
-    
+    min_lat = df["pano_lat"].min()
+    max_lat = df["pano_lat"].max()
+    min_lon = df["pano_lon"].min()
+    max_lon = df["pano_lon"].max()
+
     # Calculate width using the middle latitude
     mid_lat = (min_lat + max_lat) / 2
     width = geodesic((mid_lat, min_lon), (mid_lat, max_lon)).meters
-    
+
     # Calculate height
     height = geodesic((min_lat, min_lon), (max_lat, min_lon)).meters
-    
+
     return width, height
 
+
 def get_search_dimensions(
-    city_name: str, 
-    default_width: float, 
-    default_height: float
+    city_name: str, default_width: float, default_height: float
 ) -> tuple[float, float]:
     """
     Calculate the width and height dimensions for a city search area.
-    
+
     Attempts to determine search dimensions by calculating them from the city's
     geographic boundaries using OpenStreetMap data. Falls back to the provided
     default dimensions if boundary data cannot be obtained.
-    
+
     The dimensions are calculated using geodesic distances:
     - Width is measured along the middle latitude of the bounding box
     - Height is measured along the western edge of the bounding box
-    
+
     Args:
         city_name: Name of the city to look up boundaries for
         default_width: Default width in meters if boundary lookup fails
         default_height: Default height in meters if boundary lookup fails
-    
+
     Returns:
         tuple[float, float]: A tuple of (width_meters, height_meters) representing
         the search area dimensions
-        
+
     Example:
         >>> width, height = get_search_dimensions("Paris", 5000, 5000)
         Using inferred city boundaries for Paris: 11532m x 8377m
         Search area for Paris: 96.6 square km
     """
-    
+
     width, height = default_width, default_height
-    
+
     try:
         location = get_city_location_data(city_name)
-        if location and 'boundingbox' in location.raw:
+        if location and "boundingbox" in location.raw:
             # boundingbox is [south, north, west, east]
-            bbox = location.raw['boundingbox']
+            bbox = location.raw["boundingbox"]
             # Convert string coordinates to float
             south, north, west, east = map(float, bbox)
-            
+
             # Calculate width using middle latitude
             mid_lat = (north + south) / 2
             west_point = (mid_lat, west)
             east_point = (mid_lat, east)
             width = geodesic(west_point, east_point).meters
-            
+
             # Calculate height
             sw_point = (south, west)
             nw_point = (north, west)
             height = geodesic(sw_point, nw_point).meters
-            
+
             print(f"Using inferred city boundaries for {city_name}: {width:.0f}m x {height:.0f}m")
-            logger.info(f"Using inferred city boundaries for {city_name}: {width:.0f}m x {height:.0f}m")
+            logger.info(
+                f"Using inferred city boundaries for {city_name}: {width:.0f}m x {height:.0f}m"
+            )
         else:
             print(f"Could not find boundary data for {city_name}, using defaults")
             logger.warning(f"Could not find boundary data for {city_name}, using defaults")
     except Exception as e:
         print(f"Failed to infer city boundaries: {str(e)}")
         logger.error(f"Failed to infer city boundaries: {str(e)}")
-    
+
     area = (width * height) / 1000000.0  # Convert to square km
     print(f"Search area for {city_name}: {area:,.1f} square km")
     logger.info(f"Search area for {city_name}: {area:,.1f} square km")
-    
+
     return width, height
 
-def get_best_folium_zoom_level(search_grid_width_in_meters: float,
-                             search_grid_height_in_meters: float) -> int:
+
+def get_best_folium_zoom_level(
+    search_grid_width_in_meters: float, search_grid_height_in_meters: float
+) -> int:
     """
     Determine the optimal Folium map zoom level based on search area dimensions.
-    
+
     Selects the most appropriate zoom level to ensure the entire search grid is
     visible while maintaining useful detail. Uses the larger dimension between
     width and height to determine zoom level. Zoom levels correspond to these
     approximate viewing scales:
-    
+
     Zoom | Approximate Coverage | Typical Use Case
     -----|---------------------|------------------
     20   | 50m                 | Building level detail
@@ -744,15 +759,15 @@ def get_best_folium_zoom_level(search_grid_width_in_meters: float,
     14   | 3km                 | Small city
     13   | 6km                 | Medium city
     12   | 12km+               | Large city/region
-    
+
     Args:
         search_grid_width_in_meters: Width of the search area in meters
         search_grid_height_in_meters: Height of the search area in meters
-        
+
     Returns:
         int: Folium zoom level between 12 (most zoomed out) and 19 (most zoomed in)
         that best fits the search area dimensions
-        
+
     Example:
         >>> zoom = get_best_folium_zoom_level(1200, 800)
         >>> print(zoom)  # Returns 15 since max dimension (1200m) fits in 1.5km scale
@@ -775,5 +790,5 @@ def get_best_folium_zoom_level(search_grid_width_in_meters: float,
         zoom_level = 13
     else:
         zoom_level = 12
-    
+
     return zoom_level

--- a/gsv_metadata_tracker/json_summarizer.py
+++ b/gsv_metadata_tracker/json_summarizer.py
@@ -1,23 +1,25 @@
-import json
 import gzip
-from datetime import datetime
-import pandas as pd
-import numpy as np
-import os
-from tqdm import tqdm
-from typing import Optional, Dict, Any, List, Union
+import json
 import logging
+import os
 from dataclasses import asdict
-from .fileutils import load_city_csv_file, get_list_of_city_csv_files, parse_filename
-from .geoutils import get_city_location_data, get_state_abbreviation, get_country_code
+from typing import Any
+
+import numpy as np
+import pandas as pd
+from tqdm import tqdm
+
 from .analysis import (
-    calculate_pano_stats,
-    calculate_age_stats,
-    calculate_coverage_stats,
     PRESENT_STATUSES,
+    calculate_coverage_stats,
+    calculate_pano_stats,
 )
+from .fileutils import get_list_of_city_csv_files, load_city_csv_file
+from .geoutils import get_city_location_data, get_country_code, get_state_abbreviation
+from .naming import parse_filename
 
 logger = logging.getLogger(__name__)
+
 
 def sanitize_for_json(obj: Any) -> Any:
     """
@@ -33,7 +35,8 @@ def sanitize_for_json(obj: Any) -> Any:
         return None
     return obj
 
-def find_missing_json_files(data_dir: str) -> List[str]:
+
+def find_missing_json_files(data_dir: str) -> list[str]:
     """
     Find all csv.gz files that don't have corresponding JSON.gz files.
 
@@ -47,32 +50,37 @@ def find_missing_json_files(data_dir: str) -> List[str]:
 
     missing_json = []
     for csv_file in csv_files:
-        json_file = csv_file.rsplit('.csv.gz', 1)[0] + '.json.gz'
+        json_file = csv_file.rsplit(".csv.gz", 1)[0] + ".json.gz"
         if not os.path.exists(json_file):
             missing_json.append(csv_file)
-    
+
     return missing_json
+
 
 def generate_missing_city_json_files(data_dir: str) -> None:
     """
     Generate missing JSON metadata files for all csv.gz files in directory.
-    
+
     This is useful if a .json file was never created for a given city or if
     the .json file needs to be recreated due to changes in analysis code.
     """
     logger.info(f"Scanning {data_dir} for csv.gz files missing JSON metadata...")
-    
+
     all_csv_files = get_list_of_city_csv_files(data_dir)
     missing_json_files = find_missing_json_files(data_dir)
-    
+
     if not missing_json_files:
         file_text = "file" if len(all_csv_files) == 1 else "files"
-        logger.info(f"Found {len(all_csv_files)} csv.gz {file_text}. All csv.gz files already have a corresponding .json metadata file.")
+        logger.info(
+            f"Found {len(all_csv_files)} csv.gz {file_text}. All csv.gz files already have a corresponding .json metadata file."
+        )
         return
-    
+
     file_text = "file" if len(missing_json_files) == 1 else "files"
-    logger.info(f"Found {len(missing_json_files)} of {len(all_csv_files)} {file_text} needing a .json metadata file.")
-    
+    logger.info(
+        f"Found {len(missing_json_files)} of {len(all_csv_files)} {file_text} needing a .json metadata file."
+    )
+
     cnt_generated_json_files = 0
     for csv_path in tqdm(missing_json_files, desc="Generating metadata .json files"):
         try:
@@ -82,17 +90,21 @@ def generate_missing_city_json_files(data_dir: str) -> None:
             search_height = params.height_meters
             step = params.step_meters
 
-            logger.debug(f"Parsed filename into city: {city_query_str}, width: {search_width}, height: {search_height}, step: {step}")
-            
+            logger.debug(
+                f"Parsed filename into city: {city_query_str}, width: {search_width}, height: {search_height}, step: {step}"
+            )
+
             df = load_city_csv_file(csv_path)
 
-            center_lat = float(df['query_lat'].mean())
-            center_lon = float(df['query_lon'].mean())
-            
+            center_lat = float(df["query_lat"].mean())
+            center_lon = float(df["query_lon"].mean())
+
             # Reverse geocode city name with lat,lng as hints
             city_loc_data = get_city_location_data(city_query_str, center_lat, center_lon)
 
-            logger.debug(f"Generating .json metadata for {csv_path} at {city_loc_data.city}, {city_loc_data.state}, {city_loc_data.country}")
+            logger.debug(
+                f"Generating .json metadata for {csv_path} at {city_loc_data.city}, {city_loc_data.state}, {city_loc_data.country}"
+            )
 
             generate_city_metadata_summary_as_json(
                 csv_gz_path=csv_path,
@@ -102,16 +114,19 @@ def generate_missing_city_json_files(data_dir: str) -> None:
                 country_name=city_loc_data.country,
                 grid_width=search_width,
                 grid_height=search_height,
-                step_length=step
+                step_length=step,
             )
-            
-            logger.debug(f"Generated .json metadata for {csv_path} at {city_loc_data.city}, {city_loc_data.state}, {city_loc_data.country}")
+
+            logger.debug(
+                f"Generated .json metadata for {csv_path} at {city_loc_data.city}, {city_loc_data.state}, {city_loc_data.country}"
+            )
             cnt_generated_json_files += 1
         except Exception as e:
             logger.error(f"Error processing {csv_path}: {str(e)}")
             continue
-    
+
     logger.info(f"Metadata generation completed for {cnt_generated_json_files} file(s).")
+
 
 def _merge_histogram_into(histogram, accumulator, year_keys: bool) -> None:
     """
@@ -132,7 +147,7 @@ def _merge_histogram_into(histogram, accumulator, year_keys: bool) -> None:
         accumulator[key] = accumulator.get(key, 0) + count
 
 
-def merge_capture_date_histograms(cities_data: List[Dict]) -> Dict[str, Dict[Union[int, str], int]]:
+def merge_capture_date_histograms(cities_data: list[dict]) -> dict[str, dict[int | str, int]]:
     """
     Merge yearly and daily histograms from multiple cities' per-run JSONs.
 
@@ -161,35 +176,47 @@ def merge_capture_date_histograms(cities_data: List[Dict]) -> Dict[str, Dict[Uni
 
         all_panos = city_data.get("all_panos", {})
         missing_fields = [
-            f"all_panos.{f}" for f in ("histogram_of_capture_dates_by_year",
-                                       "histogram_of_capture_dates")
-            if f not in all_panos]
+            f"all_panos.{f}"
+            for f in ("histogram_of_capture_dates_by_year", "histogram_of_capture_dates")
+            if f not in all_panos
+        ]
         if missing_fields:
             logger.warning(f"Skipping {city_name}: missing fields: {', '.join(missing_fields)}")
             skipped_cities.append((city_name, missing_fields))
             continue
 
-        _merge_histogram_into(all_panos["histogram_of_capture_dates_by_year"],
-                              merged["all_panos_yearly"], year_keys=True)
-        _merge_histogram_into(all_panos["histogram_of_capture_dates"],
-                              merged["all_panos_daily"], year_keys=False)
+        _merge_histogram_into(
+            all_panos["histogram_of_capture_dates_by_year"],
+            merged["all_panos_yearly"],
+            year_keys=True,
+        )
+        _merge_histogram_into(
+            all_panos["histogram_of_capture_dates"], merged["all_panos_daily"], year_keys=False
+        )
 
         google_panos = city_data.get("google_panos")
         if google_panos:
-            _merge_histogram_into(google_panos.get("histogram_of_capture_dates_by_year", {}),
-                                  merged["google_panos_yearly"], year_keys=True)
-            _merge_histogram_into(google_panos.get("histogram_of_capture_dates", {}),
-                                  merged["google_panos_daily"], year_keys=False)
+            _merge_histogram_into(
+                google_panos.get("histogram_of_capture_dates_by_year", {}),
+                merged["google_panos_yearly"],
+                year_keys=True,
+            )
+            _merge_histogram_into(
+                google_panos.get("histogram_of_capture_dates", {}),
+                merged["google_panos_daily"],
+                year_keys=False,
+            )
 
     if skipped_cities:
-        logger.warning(f"\n{'='*60}")
+        logger.warning(f"\n{'=' * 60}")
         logger.warning(f"Skipped {len(skipped_cities)} cities with outdated JSON schema:")
         for name, fields in skipped_cities:
             logger.warning(f"  {name}: missing {', '.join(fields)}")
-        logger.warning(f"To fix: delete their .json.gz files and rerun generate_json.py")
-        logger.warning(f"{'='*60}\n")
+        logger.warning("To fix: delete their .json.gz files and rerun generate_json.py")
+        logger.warning(f"{'=' * 60}\n")
 
     return {key: dict(sorted(value.items())) for key, value in merged.items()}
+
 
 def generate_city_metadata_summary_as_json(
     csv_gz_path: str,
@@ -201,10 +228,10 @@ def generate_city_metadata_summary_as_json(
     grid_height: float,
     step_length: float,
     force_recreate_file: bool = False,
-    run_date: Optional[Any] = None,
+    run_date: Any | None = None,
     is_baseline: bool = False,
-    change_from_previous_run: Optional[Dict[str, Any]] = None,
-    provider: str = 'gsv'
+    change_from_previous_run: dict[str, Any] | None = None,
+    provider: str = "gsv",
 ) -> str:
     """
     Generate and save download statistics for an individual city run to a
@@ -234,33 +261,35 @@ def generate_city_metadata_summary_as_json(
             for other providers all rows are already provider imagery, so
             only 'all_panos' is emitted.
     """
-    logger.debug(f"Generating metadata summary for {city_name}, {state_name}, {country_name} from {csv_gz_path}")
+    logger.debug(
+        f"Generating metadata summary for {city_name}, {state_name}, {country_name} from {csv_gz_path}"
+    )
 
     # Generate JSON.gz path by replacing .csv.gz extension with .json.gz
-    json_filename_with_path = csv_gz_path.rsplit('.csv.gz', 1)[0] + '.json.gz'
+    json_filename_with_path = csv_gz_path.rsplit(".csv.gz", 1)[0] + ".json.gz"
 
     if os.path.exists(json_filename_with_path) and not force_recreate_file:
         logger.info(f"JSON.gz file already exists: {json_filename_with_path}; returning...")
         return json_filename_with_path
-    
+
     # Calculate center coordinates from query points
-    center_lat = float(df['query_lat'].mean())
-    center_lon = float(df['query_lon'].mean())
+    center_lat = float(df["query_lat"].mean())
+    center_lon = float(df["query_lon"].mean())
 
     # Calculate ranges to verify grid dimensions
     diagonal_meters = np.sqrt(grid_width**2 + grid_height**2)
-    
+
     # Calculate extents
     query_bounds = {
-        "min_lat": float(df['query_lat'].min()),
-        "max_lat": float(df['query_lat'].max()),
-        "min_lon": float(df['query_lon'].min()),
-        "max_lon": float(df['query_lon'].max())
+        "min_lat": float(df["query_lat"].min()),
+        "max_lat": float(df["query_lat"].max()),
+        "min_lon": float(df["query_lon"].min()),
+        "max_lon": float(df["query_lon"].max()),
     }
 
     # Get start and end times from query_timestamp
-    df['query_timestamp_converted'] = pd.to_datetime(df['query_timestamp'], errors='coerce')
-    problematic_timestamps = df[df['query_timestamp_converted'].isna()]
+    df["query_timestamp_converted"] = pd.to_datetime(df["query_timestamp"], errors="coerce")
+    problematic_timestamps = df[df["query_timestamp_converted"].isna()]
 
     if len(problematic_timestamps) > 0:
         logger.warning(f"\nFound {len(problematic_timestamps)} problematic timestamps:")
@@ -270,8 +299,8 @@ def generate_city_metadata_summary_as_json(
     else:
         logger.debug(f"All timestamps converted successfully in {csv_gz_path}!")
 
-    start_time = df['query_timestamp_converted'].min()
-    end_time = df['query_timestamp_converted'].max()
+    start_time = df["query_timestamp_converted"].min()
+    end_time = df["query_timestamp_converted"].max()
 
     try:
         duration = end_time - start_time
@@ -289,50 +318,48 @@ def generate_city_metadata_summary_as_json(
     # so the google_panos block is omitted and a flag records why.
     all_pano_stats = calculate_pano_stats(df, now)
     gsv_copyright_available = True
-    if provider == 'gsv':
-        present_rows = df[df['status'].isin(PRESENT_STATUSES)]
-        gsv_copyright_available = (len(present_rows) == 0
-                                   or bool(present_rows['copyright_info'].notna().any()))
-    google_pano_stats = (calculate_pano_stats(df, now, google_only=True)
-                         if provider == 'gsv' and gsv_copyright_available
-                         else None)
+    if provider == "gsv":
+        present_rows = df[df["status"].isin(PRESENT_STATUSES)]
+        gsv_copyright_available = len(present_rows) == 0 or bool(
+            present_rows["copyright_info"].notna().any()
+        )
+    google_pano_stats = (
+        calculate_pano_stats(df, now, google_only=True)
+        if provider == "gsv" and gsv_copyright_available
+        else None
+    )
 
     # Calculate coverage statistics
     coverage_stats = calculate_coverage_stats(df)
 
-    top_10_photographers = dict(sorted(
-        all_pano_stats.photographer_stats.photographer_counts.items(), 
-        key=lambda x: x[1], reverse=True)[:10])
+    top_10_photographers = dict(
+        sorted(
+            all_pano_stats.photographer_stats.photographer_counts.items(),
+            key=lambda x: x[1],
+            reverse=True,
+        )[:10]
+    )
 
     metadata = {
         "schema_version": 2,
         "provider": provider,
         "run": {
             "run_date": (run_date.isoformat() if run_date is not None else None),
-            "is_baseline": is_baseline
+            "is_baseline": is_baseline,
         },
         "change_from_previous_run": change_from_previous_run,
         "data_file": {
             "filename": os.path.basename(csv_gz_path),
             "format": "csv.gz",
             "rows": len(df),
-            "size_bytes": os.path.getsize(csv_gz_path)
+            "size_bytes": os.path.getsize(csv_gz_path),
         },
         "city": {
             "name": city_name,
-            "state": {
-                "name": state_name,
-                "code": get_state_abbreviation(state_name)
-            },
-            "country": {
-                "name": country_name,
-                "code": get_country_code(country_name)
-            },
-            "center": {
-                "latitude": center_lat,
-                "longitude": center_lon
-            },
-            "bounds": query_bounds
+            "state": {"name": state_name, "code": get_state_abbreviation(state_name)},
+            "country": {"name": country_name, "code": get_country_code(country_name)},
+            "center": {"latitude": center_lat, "longitude": center_lon},
+            "bounds": query_bounds,
         },
         "search_grid": {
             "width_meters": grid_width,
@@ -341,9 +368,8 @@ def generate_city_metadata_summary_as_json(
             "diagonal_meters": diagonal_meters,
             # Unique query points, not len(df): Mapillary runs have one row
             # per pano, so several rows can share a grid point
-            "total_search_points": int(
-                df[['query_lat', 'query_lon']].drop_duplicates().shape[0]),
-            "area_km2": (grid_width * grid_height) / 1_000_000
+            "total_search_points": int(df[["query_lat", "query_lon"]].drop_duplicates().shape[0]),
+            "area_km2": (grid_width * grid_height) / 1_000_000,
         },
         "download": {
             "start_time": start_time.isoformat() if start_time is not None else None,
@@ -359,35 +385,35 @@ def generate_city_metadata_summary_as_json(
             "top_10_photographers": top_10_photographers,
         },
     }
-    if provider == 'gsv':
+    if provider == "gsv":
         metadata["copyright_info_available"] = gsv_copyright_available
     if google_pano_stats is not None:
         metadata["google_panos"] = {
             "duplicate_stats": asdict(google_pano_stats.duplicate_stats),
             "age_stats": asdict(google_pano_stats.age_stats),
             "histogram_of_capture_dates_by_year": asdict(google_pano_stats.yearly_distribution),
-            "histogram_of_capture_dates": asdict(google_pano_stats.daily_distribution)
+            "histogram_of_capture_dates": asdict(google_pano_stats.daily_distribution),
         }
 
-
     # Save compressed JSON (sanitize first: NaN is not valid JSON)
-    with gzip.open(json_filename_with_path, 'wt', encoding='utf-8') as f:
+    with gzip.open(json_filename_with_path, "wt", encoding="utf-8") as f:
         json.dump(sanitize_for_json(metadata), f, indent=2, allow_nan=False)
 
     logger.info(f"Saved compressed JSON to: {json_filename_with_path}")
     return json_filename_with_path
 
-def _load_city_json(json_path: str) -> Optional[Dict[str, Any]]:
+
+def _load_city_json(json_path: str) -> dict[str, Any] | None:
     """Load a per-run city json.gz, returning None on any failure."""
     try:
-        with gzip.open(json_path, 'rt', encoding='utf-8') as f:
+        with gzip.open(json_path, "rt", encoding="utf-8") as f:
             return json.load(f)
     except Exception as e:
         logger.error(f"Error reading {json_path}: {e}")
         return None
 
 
-def _build_provider_summary(runs, latest_json, data_dir, conn) -> Dict[str, Any]:
+def _build_provider_summary(runs, latest_json, data_dir, conn) -> dict[str, Any]:
     """
     Build one provider's {latest, runs, change} block for a city's
     aggregate record. `runs` is that provider's run series (oldest first)
@@ -428,15 +454,14 @@ def _build_provider_summary(runs, latest_json, data_dir, conn) -> Dict[str, Any]
     # Archival GSV imports flag copyright_info_available=false instead and
     # omit google_panos (frontends fall back to all-pano stats).
     if "copyright_info_available" in latest_json:
-        latest_block["copyright_info_available"] = \
-            latest_json["copyright_info_available"]
+        latest_block["copyright_info_available"] = latest_json["copyright_info_available"]
     google_panos = latest_json.get("google_panos")
     if google_panos:
-        panorama_counts["unique_google_panos"] = \
-            google_panos["duplicate_stats"]["total_unique_panos"]
+        panorama_counts["unique_google_panos"] = google_panos["duplicate_stats"][
+            "total_unique_panos"
+        ]
         latest_block["google_panos_age_stats"] = google_panos["age_stats"]
-        histograms_by_year["google_panos"] = \
-            google_panos["histogram_of_capture_dates_by_year"]
+        histograms_by_year["google_panos"] = google_panos["histogram_of_capture_dates_by_year"]
 
     # Change summary vs the previous run (None for the first run)
     change = None
@@ -454,21 +479,24 @@ def _build_provider_summary(runs, latest_json, data_dir, conn) -> Dict[str, Any]
 
     return {
         "latest": latest_block,
-        "runs": [{
-            "run_date": r.run_date,
-            "is_baseline": r.is_baseline,
-            "data_file": r.csv_filename,
-            "json_file": r.json_filename,
-            "unique_panos": r.unique_panos,
-            "unique_google_panos": r.unique_google_panos,
-            "coverage_rate_percent": r.coverage_rate_pct,
-            "median_pano_age_years": r.median_pano_age_years,
-        } for r in runs],
+        "runs": [
+            {
+                "run_date": r.run_date,
+                "is_baseline": r.is_baseline,
+                "data_file": r.csv_filename,
+                "json_file": r.json_filename,
+                "unique_panos": r.unique_panos,
+                "unique_google_panos": r.unique_google_panos,
+                "coverage_rate_percent": r.coverage_rate_pct,
+                "median_pano_age_years": r.median_pano_age_years,
+            }
+            for r in runs
+        ],
         "change": change,
     }
 
 
-def generate_aggregate_v2(conn, data_dir: str) -> Dict[str, Any]:
+def generate_aggregate_v2(conn, data_dir: str) -> dict[str, Any]:
     """
     Generate the aggregate cities.json.gz (schema v3) from the SQLite
     catalog. (The function name predates the provider dimension; it is the
@@ -499,16 +527,16 @@ def generate_aggregate_v2(conn, data_dir: str) -> Dict[str, Any]:
 
     cities_out = []
     # Raw per-run JSON of each city's latest run per provider, for the merge
-    latest_run_jsons_by_provider: Dict[str, List[Dict]] = {}
+    latest_run_jsons_by_provider: dict[str, list[dict]] = {}
 
     for city in tqdm(db.get_all_cities(conn), desc="Aggregating cities", unit="city"):
-        runs_by_provider: Dict[str, list] = {}
+        runs_by_provider: dict[str, list] = {}
         for run in db.get_runs_for_city(conn, city.city_id, provider=None):
             runs_by_provider.setdefault(run.provider, []).append(run)
 
         providers_out = {}
         city_block = None
-        for provider in sorted(runs_by_provider, key=lambda p: p != 'gsv'):
+        for provider in sorted(runs_by_provider, key=lambda p: p != "gsv"):
             runs = runs_by_provider[provider]
             latest = runs[-1]
             latest_json = None
@@ -517,21 +545,23 @@ def generate_aggregate_v2(conn, data_dir: str) -> Dict[str, Any]:
             if latest_json is None:
                 logger.warning(
                     f"Skipping {city.city_id} [{provider}]: missing/unreadable "
-                    f"per-run JSON ({latest.json_filename})")
+                    f"per-run JSON ({latest.json_filename})"
+                )
                 continue
-            providers_out[provider] = _build_provider_summary(
-                runs, latest_json, data_dir, conn)
+            providers_out[provider] = _build_provider_summary(runs, latest_json, data_dir, conn)
             latest_run_jsons_by_provider.setdefault(provider, []).append(latest_json)
             if city_block is None:  # gsv first, so GSV's city block wins
                 city_block = latest_json["city"]
 
         if not providers_out:
             continue
-        cities_out.append({
-            "city_id": city.city_id,
-            "city": city_block,
-            "providers": providers_out,
-        })
+        cities_out.append(
+            {
+                "city_id": city.city_id,
+                "city": city_block,
+                "providers": providers_out,
+            }
+        )
 
     merged_histograms = {
         provider: merge_capture_date_histograms(jsons)
@@ -540,48 +570,51 @@ def generate_aggregate_v2(conn, data_dir: str) -> Dict[str, Any]:
 
     summary = {
         "schema_version": 3,
-        "generated_at": pd.Timestamp.now(tz='UTC').isoformat(),
+        "generated_at": pd.Timestamp.now(tz="UTC").isoformat(),
         "cities_count": len(cities_out),
         "histogram_of_capture_dates": merged_histograms,
         "cities": cities_out,
     }
 
-    output_path = os.path.join(data_dir, 'cities.json.gz')
-    with gzip.open(output_path, 'wt', encoding='utf-8') as f:
+    output_path = os.path.join(data_dir, "cities.json.gz")
+    with gzip.open(output_path, "wt", encoding="utf-8") as f:
         json.dump(sanitize_for_json(summary), f, indent=2, allow_nan=False)
     logger.info(f"Wrote v3 aggregate for {len(cities_out)} cities to {output_path}")
 
     return summary
 
 
-def generate_aggregate_summary_as_json(json_dir: str) -> Dict[str, Any]:
+def generate_aggregate_summary_as_json(json_dir: str) -> dict[str, Any]:
     """
     Generate and save a summary of all city JSON files in the specified directory.
-    
+
     Args:
         json_path: Path to directory containing city JSON files
-        
+
     Returns:
         Dictionary containing aggregated city summaries
     """
-    logger.debug(f"Generating aggregate summary cities.json file for all city JSON files in {json_dir}")
+    logger.debug(
+        f"Generating aggregate summary cities.json file for all city JSON files in {json_dir}"
+    )
 
     cities_data = []
     raw_city_data = []  # Store complete city data for histogram merging
-    
+
     # Find all JSON files in directory except the cities.json file
-    json_files = [f for f in os.listdir(json_dir) 
-                 if f.endswith('.json.gz') and f != 'cities.json.gz']
+    json_files = [
+        f for f in os.listdir(json_dir) if f.endswith(".json.gz") and f != "cities.json.gz"
+    ]
     logger.info(f"Found {len(json_files)} JSON.gz files in {json_dir}")
 
     for json_file in tqdm(json_files, desc="Processing city files", unit="file"):
         file_path = os.path.join(json_dir, json_file)
-        
+
         try:
             logger.debug(f"Opening {file_path}...")
-            with gzip.open(file_path, 'rt', encoding='utf-8') as f:
+            with gzip.open(file_path, "rt", encoding="utf-8") as f:
                 city_data = json.load(f)
-            
+
             raw_city_data.append(city_data)  # Store complete data for histogram merging
 
             # Extract relevant information
@@ -590,76 +623,72 @@ def generate_aggregate_summary_as_json(json_dir: str) -> Dict[str, Any]:
                 "city": city_data["city"]["name"],
                 "state": {
                     "name": city_data["city"]["state"]["name"],
-                    "code": city_data["city"]["state"]["code"]
+                    "code": city_data["city"]["state"]["code"],
                 },
                 "country": {
                     "name": city_data["city"]["country"]["name"],
-                    "code": city_data["city"]["country"]["code"]
+                    "code": city_data["city"]["country"]["code"],
                 },
-                
                 # Location information
                 "center": {
                     "latitude": city_data["city"]["center"]["latitude"],
-                    "longitude": city_data["city"]["center"]["longitude"]
+                    "longitude": city_data["city"]["center"]["longitude"],
                 },
                 "bounds": city_data["city"]["bounds"],
-                
                 # File information
                 "data_file": {
                     "filename": city_data["data_file"]["filename"],
-                    "size_bytes": city_data["data_file"]["size_bytes"]
+                    "size_bytes": city_data["data_file"]["size_bytes"],
                 },
-                
                 # Coverage information
                 "search_area_km2": city_data["search_grid"]["area_km2"],
                 "coverage_rate_percent": city_data["coverage"]["coverage_rate"],
-                
                 # Panorama counts
                 "panorama_counts": {
                     "unique_panos": city_data["all_panos"]["duplicate_stats"]["total_unique_panos"],
-                    "unique_google_panos": city_data["google_panos"]["duplicate_stats"]["total_unique_panos"]
+                    "unique_google_panos": city_data["google_panos"]["duplicate_stats"][
+                        "total_unique_panos"
+                    ],
                 },
-                
                 # Age statistics for unique panoramas
                 "all_panos_age_stats": city_data["all_panos"]["age_stats"],
                 "google_panos_age_stats": city_data["google_panos"]["age_stats"],
-                
                 # Collection metadata
                 "collection_info": {
                     "start_time": city_data["download"]["start_time"],
                     "end_time": city_data["download"]["end_time"],
-                    "duration_seconds": city_data["download"]["duration_seconds"]
+                    "duration_seconds": city_data["download"]["duration_seconds"],
                 },
-
                 # Add city-specific histograms
                 "histogram_of_capture_dates_by_year": {
                     "all_panos": city_data["all_panos"]["histogram_of_capture_dates_by_year"],
-                    "google_panos": city_data["google_panos"]["histogram_of_capture_dates_by_year"]
-                }
+                    "google_panos": city_data["google_panos"]["histogram_of_capture_dates_by_year"],
+                },
             }
-            
+
             cities_data.append(city_summary)
-            
+
         except Exception as e:
             import traceback
+
             logger.error(f"Error processing {json_file}: {str(e)}")
             logger.error("Full traceback:")
             logger.error(traceback.format_exc())
 
     # Merge histograms from all cities
     merged_histograms = merge_capture_date_histograms(raw_city_data)
-    
+
     # Create the final summary
     summary = {
         "cities_count": len(cities_data),
         "creation_timestamp": pd.Timestamp.now().isoformat(),
         "histogram_of_capture_dates": merged_histograms,
-        "cities": cities_data
+        "cities": cities_data,
     }
-    
+
     # Save the aggregate summary as compressed JSON (sanitize first: NaN is not valid JSON)
-    output_path = os.path.join(json_dir, 'cities.json.gz')
-    with gzip.open(output_path, 'wt', encoding='utf-8') as f:
+    output_path = os.path.join(json_dir, "cities.json.gz")
+    with gzip.open(output_path, "wt", encoding="utf-8") as f:
         json.dump(sanitize_for_json(summary), f, indent=2, allow_nan=False)
 
     return summary

--- a/gsv_metadata_tracker/naming.py
+++ b/gsv_metadata_tracker/naming.py
@@ -20,38 +20,38 @@ import os
 import re
 from dataclasses import dataclass
 from datetime import date
-from typing import Optional
 
 # Providers with a filename token. GSV files carry no token (legacy compat),
 # so 'gsv' never appears in filenames but is the parse default.
-DEFAULT_PROVIDER = 'gsv'
-KNOWN_PROVIDERS = ('gsv', 'mapillary')
+DEFAULT_PROVIDER = "gsv"
+KNOWN_PROVIDERS = ("gsv", "mapillary")
 
 # Accepts int or float numeric groups, an optional provider token, and an
 # optional trailing ISO run date. The groups can't bleed into each other:
 # step is numeric, provider alphabetic, date digits-and-dashes.
 FILENAME_RE = re.compile(
-    r'^(?P<slug>.+?)'
-    r'_width_(?P<w>\d+(?:\.\d+)?)'
-    r'_height_(?P<h>\d+(?:\.\d+)?)'
-    r'_step_(?P<s>\d+(?:\.\d+)?)'
-    r'(?:_(?P<provider>[a-z]+))?'
-    r'(?:_(?P<date>\d{4}-\d{2}-\d{2}))?$'
+    r"^(?P<slug>.+?)"
+    r"_width_(?P<w>\d+(?:\.\d+)?)"
+    r"_height_(?P<h>\d+(?:\.\d+)?)"
+    r"_step_(?P<s>\d+(?:\.\d+)?)"
+    r"(?:_(?P<provider>[a-z]+))?"
+    r"(?:_(?P<date>\d{4}-\d{2}-\d{2}))?$"
 )
 
 # Extensions stripped before parsing, longest first.
-_KNOWN_EXTENSIONS = ('.csv.gz', '.json.gz', '.csv', '.json', '.html')
+_KNOWN_EXTENSIONS = (".csv.gz", ".json.gz", ".csv", ".json", ".html")
 
 
 @dataclass(frozen=True)
 class ParsedFilename:
     """Components extracted from a GSV metadata filename."""
-    slug: str                    # sanitized location slug, e.g. 'grand-marais--mn'
-    city_query_str: str          # human-readable reconstruction, e.g. 'Grand Marais, MN'
+
+    slug: str  # sanitized location slug, e.g. 'grand-marais--mn'
+    city_query_str: str  # human-readable reconstruction, e.g. 'Grand Marais, MN'
     width_meters: int
     height_meters: int
     step_meters: int
-    run_date: Optional[date]     # None for legacy undated files
+    run_date: date | None  # None for legacy undated files
     provider: str = DEFAULT_PROVIDER  # 'gsv' when no token in the filename
 
 
@@ -87,19 +87,19 @@ def sanitize_city_query_str(city_query_str: str) -> str:
     stripped) — this matches the slugs of all previously collected data
     files, so it must not change.
     """
-    parts = [p.strip() for p in city_query_str.split(',')]
+    parts = [p.strip() for p in city_query_str.split(",")]
 
     cleaned_parts = []
     for part in parts:
         # \s (not ' ') so Unicode whitespace like the non-breaking spaces
         # Nominatim sometimes returns (e.g. "Ann\xa0Arbor") is normalized too
-        cleaned = re.sub(r'\s', '-', part)
-        cleaned = re.sub(r'[<>:"/\\|?*]', '', cleaned)
-        cleaned = cleaned.strip('.-')
+        cleaned = re.sub(r"\s", "-", part)
+        cleaned = re.sub(r'[<>:"/\\|?*]', "", cleaned)
+        cleaned = cleaned.strip(".-")
         cleaned = cleaned.lower()
         cleaned_parts.append(cleaned)
 
-    return '--'.join(cleaned_parts)
+    return "--".join(cleaned_parts)
 
 
 def slug_to_query_str(slug: str) -> str:
@@ -110,10 +110,10 @@ def slug_to_query_str(slug: str) -> str:
     'Grand Marais, Mn, Usa'
     """
     processed_parts = []
-    for part in slug.split('--'):
-        words = part.split('-')
-        processed_parts.append(' '.join(word.capitalize() for word in words))
-    return ', '.join(processed_parts)
+    for part in slug.split("--"):
+        words = part.split("-")
+        processed_parts.append(" ".join(word.capitalize() for word in words))
+    return ", ".join(processed_parts)
 
 
 def parse_filename(filename: str) -> ParsedFilename:
@@ -151,40 +151,38 @@ def parse_filename(filename: str) -> ParsedFilename:
     base = os.path.basename(filename)
     for ext in _KNOWN_EXTENSIONS:
         if base.endswith(ext):
-            base = base[:-len(ext)]
+            base = base[: -len(ext)]
             break
 
     match = FILENAME_RE.match(base)
     if not match:
         raise ValueError(f"Filename {filename} doesn't match expected format")
 
-    provider = match.group('provider') or DEFAULT_PROVIDER
+    provider = match.group("provider") or DEFAULT_PROVIDER
     if provider not in KNOWN_PROVIDERS:
         raise ValueError(
             f"Filename {filename} has unknown provider token {provider!r} "
-            f"(known: {', '.join(KNOWN_PROVIDERS)})")
+            f"(known: {', '.join(KNOWN_PROVIDERS)})"
+        )
 
     run_date = None
-    if match.group('date'):
-        run_date = date.fromisoformat(match.group('date'))
+    if match.group("date"):
+        run_date = date.fromisoformat(match.group("date"))
 
-    slug = match.group('slug')
+    slug = match.group("slug")
     return ParsedFilename(
         slug=slug,
         city_query_str=slug_to_query_str(slug),
-        width_meters=int(float(match.group('w'))),
-        height_meters=int(float(match.group('h'))),
-        step_meters=int(float(match.group('s'))),
+        width_meters=int(float(match.group("w"))),
+        height_meters=int(float(match.group("h"))),
+        step_meters=int(float(match.group("s"))),
         run_date=run_date,
         provider=provider,
     )
 
 
 def generate_base_filename(
-    city_query_str: str,
-    grid_width: float,
-    grid_height: float,
-    step_length: float
+    city_query_str: str, grid_width: float, grid_height: float, step_length: float
 ) -> str:
     """
     Generate a legacy (undated) base filename for GSV metadata files.
@@ -206,7 +204,7 @@ def generate_run_filename(
     grid_height: float,
     step_length: float,
     run_date: date,
-    provider: str = DEFAULT_PROVIDER
+    provider: str = DEFAULT_PROVIDER,
 ) -> str:
     """
     Generate the dated base filename (no extension) for a collection run.
@@ -227,9 +225,11 @@ def generate_run_filename(
     """
     if provider not in KNOWN_PROVIDERS:
         raise ValueError(f"Unknown provider {provider!r} (known: {', '.join(KNOWN_PROVIDERS)})")
-    provider_token = '' if provider == DEFAULT_PROVIDER else f"_{provider}"
-    return (f"{city_id}_width_{int(grid_width)}_height_{int(grid_height)}"
-            f"_step_{int(step_length)}{provider_token}_{run_date.isoformat()}")
+    provider_token = "" if provider == DEFAULT_PROVIDER else f"_{provider}"
+    return (
+        f"{city_id}_width_{int(grid_width)}_height_{int(grid_height)}"
+        f"_step_{int(step_length)}{provider_token}_{run_date.isoformat()}"
+    )
 
 
 # ── Historical-dates harvest files (issue #2) ──────────────────────────────
@@ -244,21 +244,22 @@ def generate_run_filename(
 # parse_filename() rejects it (callers already treat a ValueError as "not a run
 # file"). Published as a normal *.csv.gz, so sync picks it up unchanged.
 
-HISTORY_MARKER = 'gsv_history'
+HISTORY_MARKER = "gsv_history"
 
 _HISTORY_FILENAME_RE = re.compile(
-    r'^(?P<slug>.+?)'
-    r'_width_(?P<w>\d+)'
-    r'_height_(?P<h>\d+)'
-    r'_step_(?P<s>\d+)'
-    r'_' + HISTORY_MARKER + r'_'
-    r'(?P<date>\d{4}-\d{2}-\d{2})$'
+    r"^(?P<slug>.+?)"
+    r"_width_(?P<w>\d+)"
+    r"_height_(?P<h>\d+)"
+    r"_step_(?P<s>\d+)"
+    r"_" + HISTORY_MARKER + r"_"
+    r"(?P<date>\d{4}-\d{2}-\d{2})$"
 )
 
 
 @dataclass(frozen=True)
 class ParsedHistoryFilename:
     """Components extracted from a historical-dates harvest filename."""
+
     slug: str
     city_query_str: str
     width_meters: int
@@ -282,8 +283,10 @@ def generate_history_filename(
         >>> generate_history_filename("bend--oregon--united-states", 5000, 5000, 20, date(2026, 7, 8))
         'bend--oregon--united-states_width_5000_height_5000_step_20_gsv_history_2026-07-08'
     """
-    return (f"{city_id}_width_{int(grid_width)}_height_{int(grid_height)}"
-            f"_step_{int(step_length)}_{HISTORY_MARKER}_{harvest_date.isoformat()}")
+    return (
+        f"{city_id}_width_{int(grid_width)}_height_{int(grid_height)}"
+        f"_step_{int(step_length)}_{HISTORY_MARKER}_{harvest_date.isoformat()}"
+    )
 
 
 def parse_history_filename(filename: str) -> ParsedHistoryFilename:
@@ -301,20 +304,19 @@ def parse_history_filename(filename: str) -> ParsedHistoryFilename:
     base = os.path.basename(filename)
     for ext in _KNOWN_EXTENSIONS:
         if base.endswith(ext):
-            base = base[:-len(ext)]
+            base = base[: -len(ext)]
             break
     match = _HISTORY_FILENAME_RE.match(base)
     if not match:
-        raise ValueError(
-            f"Filename {filename} is not a {HISTORY_MARKER} harvest file")
-    slug = match.group('slug')
+        raise ValueError(f"Filename {filename} is not a {HISTORY_MARKER} harvest file")
+    slug = match.group("slug")
     return ParsedHistoryFilename(
         slug=slug,
         city_query_str=slug_to_query_str(slug),
-        width_meters=int(match.group('w')),
-        height_meters=int(match.group('h')),
-        step_meters=int(match.group('s')),
-        harvest_date=date.fromisoformat(match.group('date')),
+        width_meters=int(match.group("w")),
+        height_meters=int(match.group("h")),
+        step_meters=int(match.group("s")),
+        harvest_date=date.fromisoformat(match.group("date")),
     )
 
 
@@ -340,5 +342,8 @@ def same_grid_geometry(filename_a: str, filename_b: str) -> bool:
         b = parse_filename(filename_b)
     except ValueError:
         return False
-    return ((a.width_meters, a.height_meters, a.step_meters)
-            == (b.width_meters, b.height_meters, b.step_meters))
+    return (a.width_meters, a.height_meters, a.step_meters) == (
+        b.width_meters,
+        b.height_meters,
+        b.step_meters,
+    )

--- a/gsv_metadata_tracker/paths.py
+++ b/gsv_metadata_tracker/paths.py
@@ -1,29 +1,31 @@
 import os
-from pathlib import Path
+
 
 def get_project_root() -> str:
     """
     Get the project root directory.
-    
+
     Returns:
         str: Path to the project root directory
     """
     current_dir = os.path.dirname(os.path.abspath(__file__))
     return os.path.dirname(current_dir)
 
+
 def get_default_data_dir() -> str:
     """
     Get the default data directory for the current platform.
-    
+
     Returns:
         str: Path to the default data directory
     """
     return os.path.join(get_project_root(), "data")
 
+
 def get_default_vis_dir() -> str:
     """
     Get the default visualization directory for the current platform.
-    
+
     Returns:
         str: Path to the default visualization directory
     """

--- a/gsv_metadata_tracker/scheduler.py
+++ b/gsv_metadata_tracker/scheduler.py
@@ -25,9 +25,8 @@ import sys
 import time
 import tomllib
 from dataclasses import dataclass
-from datetime import date, datetime, timezone
+from datetime import UTC, date, datetime
 from pathlib import Path
-from typing import Dict, List, Optional
 
 from tabulate import tabulate
 
@@ -45,6 +44,7 @@ DEFAULT_CONFIG_PATH = _PROJECT_ROOT / "config" / "scheduler.toml"
 @dataclass
 class ProviderConfig:
     """Per-provider scheduling settings ([providers.NAME] in the TOML)."""
+
     enabled: bool = True
     daily_request_budget: int = 250_000  # gsv: metadata requests; mapillary: tiles
 
@@ -72,98 +72,101 @@ class SchedulerConfig:
     publish_script: str = str(_PROJECT_ROOT / "sync_data_to_server.sh")
     # [providers.*] — when None (no section in the TOML), falls back to
     # gsv-only with the legacy [schedule].daily_request_budget
-    providers: Optional[Dict[str, ProviderConfig]] = None
+    providers: dict[str, ProviderConfig] | None = None
 
     def __post_init__(self):
         if not self.db_path:
             self.db_path = db.get_default_db_path(self.data_dir)
         if self.providers is None:
-            self.providers = {
-                'gsv': ProviderConfig(daily_request_budget=self.daily_request_budget)}
+            self.providers = {"gsv": ProviderConfig(daily_request_budget=self.daily_request_budget)}
 
-    def enabled_providers(self) -> List[str]:
+    def enabled_providers(self) -> list[str]:
         """Enabled provider names, gsv first (the expensive series leads)."""
-        return sorted((p for p, pc in self.providers.items() if pc.enabled),
-                      key=lambda p: p != 'gsv')
+        return sorted(
+            (p for p, pc in self.providers.items() if pc.enabled), key=lambda p: p != "gsv"
+        )
 
 
-def load_scheduler_config(path: Optional[str] = None) -> SchedulerConfig:
+def load_scheduler_config(path: str | None = None) -> SchedulerConfig:
     """Load scheduler config from TOML; missing file yields defaults."""
     config_path = Path(path) if path else DEFAULT_CONFIG_PATH
     if not config_path.exists():
         logger.warning(f"Config {config_path} not found; using defaults")
         return SchedulerConfig()
 
-    with open(config_path, 'rb') as f:
+    with open(config_path, "rb") as f:
         raw = tomllib.load(f)
 
-    sched = raw.get('schedule', {})
-    dl = raw.get('download', {})
-    paths = raw.get('paths', {})
-    pub = raw.get('publish', {})
+    sched = raw.get("schedule", {})
+    dl = raw.get("download", {})
+    paths = raw.get("paths", {})
+    pub = raw.get("publish", {})
 
     providers = None
-    if 'providers' in raw:
+    if "providers" in raw:
         providers = {}
-        for name, p in raw['providers'].items():
+        for name, p in raw["providers"].items():
             if name not in KNOWN_PROVIDERS:
-                logger.warning(f"Ignoring unknown provider [providers.{name}] "
-                               f"(known: {', '.join(KNOWN_PROVIDERS)})")
+                logger.warning(
+                    f"Ignoring unknown provider [providers.{name}] "
+                    f"(known: {', '.join(KNOWN_PROVIDERS)})"
+                )
                 continue
             providers[name] = ProviderConfig(
-                enabled=p.get('enabled', True),
-                daily_request_budget=p.get('daily_request_budget', 250_000))
+                enabled=p.get("enabled", True),
+                daily_request_budget=p.get("daily_request_budget", 250_000),
+            )
 
     return SchedulerConfig(
-        cycle_days=sched.get('cycle_days', 90),
-        grace_days=sched.get('grace_days', 7),
-        daily_request_budget=sched.get('daily_request_budget', 10_000_000),
-        max_cities_per_day=sched.get('max_cities_per_day', 20),
-        max_consecutive_failures=sched.get('max_consecutive_failures', 5),
-        city_timeout_minutes=sched.get('city_timeout_minutes', 180),
-        batch_size=dl.get('batch_size', 100),
-        connection_limit=dl.get('connection_limit', 50),
-        request_timeout_s=dl.get('request_timeout_s', 30.0),
-        sleep_between_cities_s=dl.get('sleep_between_cities_s', 60),
-        data_dir=paths.get('data_dir', str(_PROJECT_ROOT / "data")),
-        db_path=paths.get('db_path', ''),
-        log_dir=paths.get('log_dir', str(_PROJECT_ROOT / "logs")),
-        publish_enabled=pub.get('enabled', False),
-        publish_script=pub.get('publish_script', str(_PROJECT_ROOT / "sync_data_to_server.sh")),
+        cycle_days=sched.get("cycle_days", 90),
+        grace_days=sched.get("grace_days", 7),
+        daily_request_budget=sched.get("daily_request_budget", 10_000_000),
+        max_cities_per_day=sched.get("max_cities_per_day", 20),
+        max_consecutive_failures=sched.get("max_consecutive_failures", 5),
+        city_timeout_minutes=sched.get("city_timeout_minutes", 180),
+        batch_size=dl.get("batch_size", 100),
+        connection_limit=dl.get("connection_limit", 50),
+        request_timeout_s=dl.get("request_timeout_s", 30.0),
+        sleep_between_cities_s=dl.get("sleep_between_cities_s", 60),
+        data_dir=paths.get("data_dir", str(_PROJECT_ROOT / "data")),
+        db_path=paths.get("db_path", ""),
+        log_dir=paths.get("log_dir", str(_PROJECT_ROOT / "logs")),
+        publish_enabled=pub.get("enabled", False),
+        publish_script=pub.get("publish_script", str(_PROJECT_ROOT / "sync_data_to_server.sh")),
         providers=providers,
     )
 
 
-def estimate_requests(city: db.CityRow, provider: str = 'gsv') -> int:
+def estimate_requests(city: db.CityRow, provider: str = "gsv") -> int:
     """
     Estimated API requests for one run: grid points for GSV (one metadata
     request per point), z14 tile count for Mapillary (bulk metadata).
     """
-    if provider == 'mapillary':
-        return estimate_tile_count(city.center_lat, city.center_lon,
-                                   city.grid_width_m, city.grid_height_m,
-                                   city.step_m)
-    return ((city.grid_width_m // city.step_m + 1)
-            * (city.grid_height_m // city.step_m + 1))
+    if provider == "mapillary":
+        return estimate_tile_count(
+            city.center_lat, city.center_lon, city.grid_width_m, city.grid_height_m, city.step_m
+        )
+    return (city.grid_width_m // city.step_m + 1) * (city.grid_height_m // city.step_m + 1)
 
 
 def setup_logging(cfg: SchedulerConfig, verbose: bool = False) -> None:
     os.makedirs(cfg.log_dir, exist_ok=True)
     handlers = [logging.StreamHandler(sys.stdout)]
     file_handler = logging.handlers.TimedRotatingFileHandler(
-        os.path.join(cfg.log_dir, "gsv_scheduler.log"),
-        when='midnight', backupCount=30)
+        os.path.join(cfg.log_dir, "gsv_scheduler.log"), when="midnight", backupCount=30
+    )
     handlers.append(file_handler)
     logging.basicConfig(
         level=logging.DEBUG if verbose else logging.INFO,
-        format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
-        handlers=handlers)
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+        handlers=handlers,
+    )
 
 
 def cmd_status(cfg: SchedulerConfig) -> int:
     """Print a per-(city, provider) schedule table plus today's budgets."""
     conn = db.connect(cfg.db_path)
-    today = datetime.now(timezone.utc).date()
+    today = datetime.now(UTC).date()
     providers = cfg.enabled_providers()
 
     rows = conn.execute(
@@ -174,32 +177,53 @@ def cmd_status(cfg: SchedulerConfig) -> int:
                      AND r.provider = COALESCE(s.provider, 'gsv')) AS last_run
            FROM cities c LEFT JOIN schedule_state s ON s.city_id = c.city_id
            ORDER BY s.last_success_at ASC NULLS FIRST, c.city_id,
-                    s.provider""").fetchall()
+                    s.provider"""
+    ).fetchall()
 
     due_pairs = set()
     due_counts = {}
     for provider in providers:
-        due = db.get_due_cities(conn, today=today, cycle_days=cfg.cycle_days,
-                                grace_days=cfg.grace_days,
-                                max_consecutive_failures=cfg.max_consecutive_failures,
-                                provider=provider)
+        due = db.get_due_cities(
+            conn,
+            today=today,
+            cycle_days=cfg.cycle_days,
+            grace_days=cfg.grace_days,
+            max_consecutive_failures=cfg.max_consecutive_failures,
+            provider=provider,
+        )
         due_counts[provider] = len(due)
         due_pairs.update((c.city_id, provider) for c in due)
 
-    table = [[r['city_id'],
-              r['provider'] or '—',
-              'yes' if r['enabled'] else 'no',
-              r['day_of_cycle'],
-              r['last_run'] or '—',
-              (r['last_success_at'] or '—')[:10],
-              r['consecutive_failures'] or 0,
-              'DUE' if (r['city_id'], r['provider'] or 'gsv') in due_pairs else '']
-             for r in rows
-             if r['provider'] is None or r['provider'] in providers]
-    print(tabulate(table,
-                   headers=['city', 'provider', 'enabled', 'cycle day',
-                            'last run', 'last success', 'failures', ''],
-                   tablefmt='simple'))
+    table = [
+        [
+            r["city_id"],
+            r["provider"] or "—",
+            "yes" if r["enabled"] else "no",
+            r["day_of_cycle"],
+            r["last_run"] or "—",
+            (r["last_success_at"] or "—")[:10],
+            r["consecutive_failures"] or 0,
+            "DUE" if (r["city_id"], r["provider"] or "gsv") in due_pairs else "",
+        ]
+        for r in rows
+        if r["provider"] is None or r["provider"] in providers
+    ]
+    print(
+        tabulate(
+            table,
+            headers=[
+                "city",
+                "provider",
+                "enabled",
+                "cycle day",
+                "last run",
+                "last success",
+                "failures",
+                "",
+            ],
+            tablefmt="simple",
+        )
+    )
 
     n_cities = conn.execute("SELECT COUNT(*) FROM cities").fetchone()[0]
     due_str = ", ".join(f"{due_counts[p]} {p}" for p in providers)
@@ -216,39 +240,53 @@ def cmd_assign(cfg: SchedulerConfig) -> int:
     conn = db.connect(cfg.db_path)
     providers = tuple(cfg.enabled_providers())
     n = db.assign_schedule(conn, cfg.cycle_days, providers=providers)
-    print(f"Assigned day_of_cycle for {n} enabled cities x "
-          f"{len(providers)} provider(s) over a {cfg.cycle_days}-day cycle "
-          f"(~{n / max(cfg.cycle_days, 1):.1f} cities/day).")
+    print(
+        f"Assigned day_of_cycle for {n} enabled cities x "
+        f"{len(providers)} provider(s) over a {cfg.cycle_days}-day cycle "
+        f"(~{n / max(cfg.cycle_days, 1):.1f} cities/day)."
+    )
     return 0
 
 
-def _run_one_city(cfg: SchedulerConfig, city: db.CityRow, today: date,
-                  provider: str = 'gsv') -> bool:
+def _run_one_city(
+    cfg: SchedulerConfig, city: db.CityRow, today: date, provider: str = "gsv"
+) -> bool:
     """Collect one (city, provider) via a gsv_tracker.py subprocess."""
     cmd = [
-        sys.executable, str(_PROJECT_ROOT / "gsv_tracker.py"),
+        sys.executable,
+        str(_PROJECT_ROOT / "gsv_tracker.py"),
         city.display_name,
-        "--provider", provider,
-        "--run-date", today.isoformat(),
-        "--download-dir", cfg.data_dir,
-        "--db-path", cfg.db_path,
-        "--batch-size", str(cfg.batch_size),
-        "--connection-limit", str(cfg.connection_limit),
-        "--timeout", str(cfg.request_timeout_s),
+        "--provider",
+        provider,
+        "--run-date",
+        today.isoformat(),
+        "--download-dir",
+        cfg.data_dir,
+        "--db-path",
+        cfg.db_path,
+        "--batch-size",
+        str(cfg.batch_size),
+        "--connection-limit",
+        str(cfg.connection_limit),
+        "--timeout",
+        str(cfg.request_timeout_s),
         "--no-visual",
         "--no-publish-json",
-        "--log-level", "INFO",
+        "--log-level",
+        "INFO",
     ]
-    logger.info(f"Collecting {city.city_id} [{provider}] "
-                f"(~{estimate_requests(city, provider):,} requests estimated)")
+    logger.info(
+        f"Collecting {city.city_id} [{provider}] "
+        f"(~{estimate_requests(city, provider):,} requests estimated)"
+    )
     logger.debug(f"Command: {' '.join(cmd)}")
     try:
-        result = subprocess.run(
-            cmd, timeout=cfg.city_timeout_minutes * 60, cwd=str(_PROJECT_ROOT))
+        result = subprocess.run(cmd, timeout=cfg.city_timeout_minutes * 60, cwd=str(_PROJECT_ROOT))
         return result.returncode == 0
     except subprocess.TimeoutExpired:
-        logger.error(f"{city.city_id} [{provider}]: timed out after "
-                     f"{cfg.city_timeout_minutes} minutes")
+        logger.error(
+            f"{city.city_id} [{provider}]: timed out after {cfg.city_timeout_minutes} minutes"
+        )
         return False
 
 
@@ -262,10 +300,13 @@ def _collect_due(conn, cfg: SchedulerConfig, today: date):
     """
     due_by_provider = {
         provider: db.get_due_cities(
-            conn, today=today, cycle_days=cfg.cycle_days,
+            conn,
+            today=today,
+            cycle_days=cfg.cycle_days,
             grace_days=cfg.grace_days,
             max_consecutive_failures=cfg.max_consecutive_failures,
-            provider=provider)
+            provider=provider,
+        )
         for provider in cfg.enabled_providers()
     }
     ordered, seen = [], set()
@@ -279,11 +320,10 @@ def _collect_due(conn, cfg: SchedulerConfig, today: date):
     return ordered, providers_for_city
 
 
-def cmd_run_due(cfg: SchedulerConfig, dry_run: bool = False,
-                limit: Optional[int] = None) -> int:
+def cmd_run_due(cfg: SchedulerConfig, dry_run: bool = False, limit: int | None = None) -> int:
     """Collect all cities due today, within per-provider budgets, publish."""
     conn = db.connect(cfg.db_path)
-    today = datetime.now(timezone.utc).date()
+    today = datetime.now(UTC).date()
     providers = cfg.enabled_providers()
 
     # Ensure new cities (and newly enabled providers) have stagger assignments
@@ -294,16 +334,18 @@ def cmd_run_due(cfg: SchedulerConfig, dry_run: bool = False,
         due = due[:limit]
     day_cap = min(len(due), cfg.max_cities_per_day)
 
-    budget_str = ", ".join(
-        f"{cfg.providers[p].daily_request_budget:,} {p}" for p in providers)
-    logger.info(f"{len(due)} cities due on {today}; "
-                f"processing up to {day_cap} within daily budgets of "
-                f"{budget_str} requests")
+    budget_str = ", ".join(f"{cfg.providers[p].daily_request_budget:,} {p}" for p in providers)
+    logger.info(
+        f"{len(due)} cities due on {today}; "
+        f"processing up to {day_cap} within daily budgets of "
+        f"{budget_str} requests"
+    )
 
     if dry_run:
         budget_left = {
             p: cfg.providers[p].daily_request_budget - db.get_api_usage(conn, today, p)
-            for p in providers}
+            for p in providers
+        }
         left_str = ", ".join(f"{budget_left[p]:,} {p}" for p in providers)
         print(f"DRY RUN — would process (budget remaining {left_str}):")
         for city in due[:day_cap]:
@@ -333,7 +375,8 @@ def cmd_run_due(cfg: SchedulerConfig, dry_run: bool = False,
                     f"{city.city_id} [{provider}]: ~{est:,} estimated requests "
                     f"exceeds the entire daily budget ({budget:,}). "
                     f"Skipping — run manually with gsv_tracker.py --force, "
-                    f"raise daily_request_budget, or set enabled=0.")
+                    f"raise daily_request_budget, or set enabled=0."
+                )
                 skipped_budget += 1
                 continue
 
@@ -344,7 +387,8 @@ def cmd_run_due(cfg: SchedulerConfig, dry_run: bool = False,
                 # when the budget is fresh.
                 logger.info(
                     f"{city.city_id} [{provider}] (~{est:,} req) doesn't fit "
-                    f"remaining budget ({budget - used:,} left); skipping.")
+                    f"remaining budget ({budget - used:,} left); skipping."
+                )
                 skipped_budget += 1
                 continue
 
@@ -353,12 +397,15 @@ def cmd_run_due(cfg: SchedulerConfig, dry_run: bool = False,
             attempted += 1
             if ok:
                 succeeded += 1
-                db.record_attempt(conn, city.city_id, success=True,
-                                  provider=provider)
+                db.record_attempt(conn, city.city_id, success=True, provider=provider)
             else:
-                db.record_attempt(conn, city.city_id, success=False,
-                                  error=f"subprocess failed on {today}",
-                                  provider=provider)
+                db.record_attempt(
+                    conn,
+                    city.city_id,
+                    success=False,
+                    error=f"subprocess failed on {today}",
+                    provider=provider,
+                )
                 logger.error(f"{city.city_id} [{provider}]: collection failed")
 
         if ran_any:
@@ -366,9 +413,11 @@ def cmd_run_due(cfg: SchedulerConfig, dry_run: bool = False,
             if processed < len(due):
                 time.sleep(cfg.sleep_between_cities_s)
 
-    logger.info(f"Done: {succeeded}/{attempted} runs succeeded across "
-                f"{processed} cities"
-                + (f"; {skipped_budget} deferred for budget" if skipped_budget else ""))
+    logger.info(
+        f"Done: {succeeded}/{attempted} runs succeeded across "
+        f"{processed} cities"
+        + (f"; {skipped_budget} deferred for budget" if skipped_budget else "")
+    )
 
     # Regenerate the aggregate once for the whole batch
     if succeeded > 0:
@@ -379,6 +428,7 @@ def cmd_run_due(cfg: SchedulerConfig, dry_run: bool = False,
     backup_path = os.path.join(cfg.log_dir, "gsv_tracker.db.backup")
     try:
         import sqlite3
+
         with sqlite3.connect(backup_path) as backup_conn:
             conn.backup(backup_conn)
         logger.info(f"Catalog backed up to {backup_path}")
@@ -398,32 +448,32 @@ def cmd_run_due(cfg: SchedulerConfig, dry_run: bool = False,
 def main() -> int:
     parser = argparse.ArgumentParser(
         prog="python -m gsv_metadata_tracker.scheduler",
-        description="Staggered GSV collection scheduler")
-    parser.add_argument('--config', default=None,
-                        help=f'Path to scheduler TOML (default: {DEFAULT_CONFIG_PATH})')
-    parser.add_argument('--verbose', action='store_true')
-    sub = parser.add_subparsers(dest='command', required=True)
+        description="Staggered GSV collection scheduler",
+    )
+    parser.add_argument(
+        "--config", default=None, help=f"Path to scheduler TOML (default: {DEFAULT_CONFIG_PATH})"
+    )
+    parser.add_argument("--verbose", action="store_true")
+    sub = parser.add_subparsers(dest="command", required=True)
 
-    sub.add_parser('status', help='Show per-city schedule and budget status')
-    sub.add_parser('assign', help='(Re)compute stagger assignments')
-    p_run = sub.add_parser('run-due', help="Collect today's due cities")
-    p_run.add_argument('--dry-run', action='store_true',
-                       help='Print what would run; no downloads')
-    p_run.add_argument('--limit', type=int, default=None,
-                       help='Process at most N cities (testing)')
+    sub.add_parser("status", help="Show per-city schedule and budget status")
+    sub.add_parser("assign", help="(Re)compute stagger assignments")
+    p_run = sub.add_parser("run-due", help="Collect today's due cities")
+    p_run.add_argument("--dry-run", action="store_true", help="Print what would run; no downloads")
+    p_run.add_argument("--limit", type=int, default=None, help="Process at most N cities (testing)")
 
     args = parser.parse_args()
     cfg = load_scheduler_config(args.config)
     setup_logging(cfg, verbose=args.verbose)
 
-    if args.command == 'status':
+    if args.command == "status":
         return cmd_status(cfg)
-    if args.command == 'assign':
+    if args.command == "assign":
         return cmd_assign(cfg)
-    if args.command == 'run-due':
+    if args.command == "run-due":
         return cmd_run_due(cfg, dry_run=args.dry_run, limit=args.limit)
     return 2
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     sys.exit(main())

--- a/gsv_metadata_tracker/vis.py
+++ b/gsv_metadata_tracker/vis.py
@@ -1,34 +1,33 @@
 # gsv_metadata_tracker/vis.py
 
-import folium
-from folium import plugins, FeatureGroup, Element
-import branca.colormap as cm
-import pandas as pd
-from datetime import datetime
 import json
 import logging
+from datetime import datetime
+from math import cos, pi
+
+import branca.colormap as cm
+import folium
+import matplotlib.colors
+import matplotlib.dates as mdates
+import matplotlib.pyplot as plt
+import pandas as pd
 import seaborn as sns
 from tqdm import tqdm
-import matplotlib.colors
-import matplotlib.pyplot as plt
-import matplotlib.dates as mdates
-from math import cos, pi
-from typing import Optional
-import zlib
-import base64
-import sys
+
 from .analysis import is_google_copyright
-from .geoutils import get_best_folium_zoom_level
-from .geoutils import get_bounding_box_size
-from .geoutils import get_bounding_box
+from .geoutils import get_best_folium_zoom_level, get_bounding_box, get_bounding_box_size
 
 logger = logging.getLogger(__name__)
 
-def display_search_area(city_name: str, city_center_lat: float,
-                       city_center_lng: float,
-                       search_grid_width_in_meters: float,
-                       search_grid_height_in_meters: float,
-                       step_size_in_meters: float = 20) -> folium.Map:
+
+def display_search_area(
+    city_name: str,
+    city_center_lat: float,
+    city_center_lng: float,
+    search_grid_width_in_meters: float,
+    search_grid_height_in_meters: float,
+    step_size_in_meters: float = 20,
+) -> folium.Map:
     """
     Creates an interactive map visualization showing a city's search area with grid overlay.
 
@@ -49,11 +48,11 @@ def display_search_area(city_name: str, city_center_lat: float,
     """
 
     # Grid styling parameters
-    GRID_BACKGROUND_COLOR = '#3B82F6'  # Medium blue
+    GRID_BACKGROUND_COLOR = "#3B82F6"  # Medium blue
     GRID_BACKGROUND_OPACITY = 0.15
-    GRID_BORDER_COLOR = '#2563EB'      # Slightly darker blue
+    GRID_BORDER_COLOR = "#2563EB"  # Slightly darker blue
     GRID_BORDER_WEIGHT = 2
-    GRID_LINE_COLOR = 'blue'
+    GRID_LINE_COLOR = "blue"
     GRID_LINE_WEIGHT = 1.0
     GRID_LINE_OPACITY = 0.5
 
@@ -61,7 +60,7 @@ def display_search_area(city_name: str, city_center_lat: float,
     points_width = int(search_grid_width_in_meters / step_size_in_meters) + 1
     points_height = int(search_grid_height_in_meters / step_size_in_meters) + 1
     total_points = points_width * points_height
-    
+
     # Calculate estimated download time (40 points/second)
     points_per_second = 40
     estimated_seconds = total_points / points_per_second
@@ -75,15 +74,17 @@ def display_search_area(city_name: str, city_center_lat: float,
         time_str = f"{minutes}m {seconds}s"
     else:
         time_str = f"{seconds}s"
-    
+
     # Create map centered on the city
-    zoom_level = get_best_folium_zoom_level(search_grid_width_in_meters, search_grid_height_in_meters)
-   
+    zoom_level = get_best_folium_zoom_level(
+        search_grid_width_in_meters, search_grid_height_in_meters
+    )
+
     # Map base style
-    m = folium.Map(location=[city_center_lat, city_center_lng], 
-                zoom_start=zoom_level,
-                tiles='CartoDB positron')
-    
+    m = folium.Map(
+        location=[city_center_lat, city_center_lng], zoom_start=zoom_level, tiles="CartoDB positron"
+    )
+
     # Create styled HTML for popup
     popup_html = f"""
     <div style="font-family: Arial, sans-serif; line-height: 1.5; padding: 5px;">
@@ -117,7 +118,7 @@ def display_search_area(city_name: str, city_center_lat: float,
     folium.Marker(
         [city_center_lat, city_center_lng],
         popup=folium.Popup(popup_html, max_width=300),
-        icon=folium.Icon(color='red', icon='info-sign')
+        icon=folium.Icon(color="red", icon="info-sign"),
     ).add_to(m)
 
     # Calculate degrees using proper latitude adjustment
@@ -131,8 +132,8 @@ def display_search_area(city_name: str, city_center_lat: float,
 
     # Calculate bounds
     bounds = [
-        [city_center_lat - height_deg/2, city_center_lng - width_deg/2],
-        [city_center_lat + height_deg/2, city_center_lng + width_deg/2]
+        [city_center_lat - height_deg / 2, city_center_lng - width_deg / 2],
+        [city_center_lat + height_deg / 2, city_center_lng + width_deg / 2],
     ]
 
     # Draw rectangle for search area
@@ -143,7 +144,7 @@ def display_search_area(city_name: str, city_center_lat: float,
         weight=GRID_BORDER_WEIGHT,
         fillColor=GRID_BACKGROUND_COLOR,
         fillOpacity=GRID_BACKGROUND_OPACITY,
-        popup=f'Search Area: {search_grid_width_in_meters}m x {search_grid_height_in_meters}m'
+        popup=f"Search Area: {search_grid_width_in_meters}m x {search_grid_height_in_meters}m",
     ).add_to(m)
 
     # Add grid overlay
@@ -155,10 +156,7 @@ def display_search_area(city_name: str, city_center_lat: float,
     while lng <= bounds[1][1]:
         points = [[bounds[0][0], lng], [bounds[1][0], lng]]
         folium.PolyLine(
-            points,
-            color=GRID_LINE_COLOR,
-            weight=GRID_LINE_WEIGHT,
-            opacity=GRID_LINE_OPACITY
+            points, color=GRID_LINE_COLOR, weight=GRID_LINE_WEIGHT, opacity=GRID_LINE_OPACITY
         ).add_to(m)
         lng += step_size_lng
 
@@ -167,36 +165,33 @@ def display_search_area(city_name: str, city_center_lat: float,
     while lat <= bounds[1][0]:
         points = [[lat, bounds[0][1]], [lat, bounds[1][1]]]
         folium.PolyLine(
-            points,
-            color=GRID_LINE_COLOR,
-            weight=GRID_LINE_WEIGHT,
-            opacity=GRID_LINE_OPACITY
+            points, color=GRID_LINE_COLOR, weight=GRID_LINE_WEIGHT, opacity=GRID_LINE_OPACITY
         ).add_to(m)
         lat += step_size_lat
 
     # Add scale bar
-    folium.plugins.MeasureControl(position='bottomleft').add_to(m)
+    folium.plugins.MeasureControl(position="bottomleft").add_to(m)
 
     return m
+
 
 # User-facing labels and pano viewer deep-links per provider (mirrors the
 # PROVIDERS registry in www/js/gsv-utils.js)
 PROVIDER_DISPLAY = {
-    'gsv': {
-        'label': 'GSV',
-        'viewer_url': lambda pano_id:
-            f'https://www.google.com/maps/@?api=1&map_action=pano&pano={pano_id}',
+    "gsv": {
+        "label": "GSV",
+        "viewer_url": lambda pano_id: (
+            f"https://www.google.com/maps/@?api=1&map_action=pano&pano={pano_id}"
+        ),
     },
-    'mapillary': {
-        'label': 'Mapillary',
-        'viewer_url': lambda pano_id:
-            f'https://www.mapillary.com/app/?pKey={pano_id}',
+    "mapillary": {
+        "label": "Mapillary",
+        "viewer_url": lambda pano_id: f"https://www.mapillary.com/app/?pKey={pano_id}",
     },
 }
 
 
-def create_visualization_map(df: pd.DataFrame, city_name: str,
-                             provider: str = 'gsv') -> folium.Map:
+def create_visualization_map(df: pd.DataFrame, city_name: str, provider: str = "gsv") -> folium.Map:
     """
     Create an interactive map visualization of a run's pano metadata with a
     temporal histogram.
@@ -211,30 +206,25 @@ def create_visualization_map(df: pd.DataFrame, city_name: str,
         folium.Map object with the visualization
     """
     display = PROVIDER_DISPLAY[provider]
-    label = display['label']
-    logger.debug(f"Creating visualization map for {city_name} [{provider}] "
-                 f"with {len(df)} rows")
+    label = display["label"]
+    logger.debug(f"Creating visualization map for {city_name} [{provider}] with {len(df)} rows")
 
     # Filter for valid data
-    valid_rows = df[
-        (df['status'] == 'OK') &
-        (df['pano_lat'].notna()) &
-        (df['pano_lon'].notna())
-    ]
+    valid_rows = df[(df["status"] == "OK") & (df["pano_lat"].notna()) & (df["pano_lon"].notna())]
     logger.info(f"Rows with valid pano coordinates: {len(valid_rows)}")
 
     # Official-imagery filter applies only to GSV (Mapillary rows are all
     # provider imagery already)
-    if provider == 'gsv':
-        valid_rows = valid_rows[is_google_copyright(valid_rows['copyright_info'])]
+    if provider == "gsv":
+        valid_rows = valid_rows[is_google_copyright(valid_rows["copyright_info"])]
         logger.info(f"Filtered rows with official Google imagery: {len(valid_rows)}")
 
     # Filter for valid dates (same as before)
-    valid_rows = valid_rows.dropna(subset=['capture_date'])
+    valid_rows = valid_rows.dropna(subset=["capture_date"])
     logger.info(f"Filtered rows with valid capture dates: {len(valid_rows)}")
 
     # Filter for unique pano_ids
-    valid_rows = valid_rows.drop_duplicates(subset='pano_id')
+    valid_rows = valid_rows.drop_duplicates(subset="pano_id")
     logger.info(f"Final valid rows with unique pano_ids: {len(valid_rows)}")
 
     if len(valid_rows) == 0:
@@ -242,18 +232,20 @@ def create_visualization_map(df: pd.DataFrame, city_name: str,
         return folium.Map()
 
     # Calculate map center
-    map_center = [valid_rows['pano_lat'].mean(), valid_rows['pano_lon'].mean()]
+    map_center = [valid_rows["pano_lat"].mean(), valid_rows["pano_lon"].mean()]
 
     # Get bounding box using existing function
     bbox = get_bounding_box(valid_rows)
     bbox_coords = [
-        [bbox['south'], bbox['west']],  # Southwest corner
-        [bbox['north'], bbox['east']],  # Northeast corner
+        [bbox["south"], bbox["west"]],  # Southwest corner
+        [bbox["north"], bbox["east"]],  # Northeast corner
     ]
 
     # Calculate bounding box dimensions
     width_meters, height_meters = get_bounding_box_size(valid_rows)
-    logger.debug(f"Bounding box dimensions: {width_meters:.1f} x {height_meters:.1f} meters from {valid_rows.shape[0]} panos")
+    logger.debug(
+        f"Bounding box dimensions: {width_meters:.1f} x {height_meters:.1f} meters from {valid_rows.shape[0]} panos"
+    )
 
     area_km2 = (width_meters * height_meters) / 1_000_000  # Convert to km²
     zoom_level = get_best_folium_zoom_level(width_meters, height_meters)
@@ -265,38 +257,36 @@ def create_visualization_map(df: pd.DataFrame, city_name: str,
     # print(valid_rows['capture_date'].dtypes)
     # print(valid_rows['capture_date'].head())
     now = datetime.now()
-    valid_rows['capture_date'] = pd.to_datetime(valid_rows['capture_date'])
-    valid_rows['age_years'] = (now - valid_rows['capture_date']).dt.days / 365.25
-    
-    avg_age = valid_rows['age_years'].mean()
-    age_std = valid_rows['age_years'].std()
-    median_age = valid_rows['age_years'].median()
+    valid_rows["capture_date"] = pd.to_datetime(valid_rows["capture_date"])
+    valid_rows["age_years"] = (now - valid_rows["capture_date"]).dt.days / 365.25
+
+    avg_age = valid_rows["age_years"].mean()
+    age_std = valid_rows["age_years"].std()
+    median_age = valid_rows["age_years"].median()
     total_panos = len(valid_rows)
 
-    logger.info(f"Average age: {avg_age:.1f} years, Median age: {median_age:.1f} years, Total panos: {total_panos}, Area: {area_km2:.1f} km²")
-    
+    logger.info(
+        f"Average age: {avg_age:.1f} years, Median age: {median_age:.1f} years, Total panos: {total_panos}, Area: {area_km2:.1f} km²"
+    )
+
     # Calculate coverage density. Guard against a degenerate 0-area bbox (a
     # single pano, or collinear panos, gives a 0 x 0 bounding box), which would
     # otherwise raise ZeroDivisionError and crash the run's local viz step
     # after the run is already cataloged (issue #69).
-    density_per_km2 = total_panos / area_km2 if area_km2 > 0 else float('nan')
+    density_per_km2 = total_panos / area_km2 if area_km2 > 0 else float("nan")
     density_str = f"{density_per_km2:.1f}" if area_km2 > 0 else "n/a"
-    
+
     # Calculate temporal coverage
-    date_range = (valid_rows['capture_date'].max() - valid_rows['capture_date'].min()).days / 365.25
+    date_range = (valid_rows["capture_date"].max() - valid_rows["capture_date"].min()).days / 365.25
 
     # Create base map
-    folium_map = folium.Map(
-        location=map_center,
-        zoom_start=zoom_level,
-        tiles=None
-    )
+    folium_map = folium.Map(location=map_center, zoom_start=zoom_level, tiles=None)
 
     # Add dark theme tile layer
     folium.TileLayer(
-        tiles='cartodbdark_matter',
+        tiles="cartodbdark_matter",
         attr='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/attributions">CARTO</a>',
-        opacity=0.8
+        opacity=0.8,
     ).add_to(folium_map)
 
     # Create enhanced tooltip HTML
@@ -319,55 +309,62 @@ def create_visualization_map(df: pd.DataFrame, city_name: str,
             <strong>Temporal Coverage:</strong> {date_range:.1f} years
         </div>
         <div style='margin-bottom: 4px'>
-            <strong>Date Range:</strong> {valid_rows['capture_date'].min().strftime('%Y-%m')} to {valid_rows['capture_date'].max().strftime('%Y-%m')}
+            <strong>Date Range:</strong> {valid_rows["capture_date"].min().strftime("%Y-%m")} to {valid_rows["capture_date"].max().strftime("%Y-%m")}
         </div>
     </div>
     """
 
-     # Add bounding box rectangle with enhanced tooltip
+    # Add bounding box rectangle with enhanced tooltip
     folium.Rectangle(
         bounds=bbox_coords,
-        color='#4CC3D9',  # Muted cyan-blue
+        color="#4CC3D9",  # Muted cyan-blue
         weight=2,
         fill=False,
         opacity=0.7,
         popup=bbox_tooltip_html,  # Using the same content for popup and tooltip
-        tooltip=bbox_tooltip_html
+        tooltip=bbox_tooltip_html,
     ).add_to(folium_map)
 
     # Change the colormap creation to use years
-    oldest_date = valid_rows['capture_date'].min()
+    oldest_date = valid_rows["capture_date"].min()
     years_since_oldest = (datetime.now() - oldest_date).days / 365.25
     colormap = cm.linear.YlOrRd_09.scale(0, years_since_oldest)
-    colormap.caption = 'Age (Years)'  # Update caption
+    colormap.caption = "Age (Years)"  # Update caption
 
     # Prepare histogram data - now using years instead of days
-    hist_data = valid_rows.groupby('capture_date').size().reset_index()
-    hist_data.columns = ['date', 'count']
-    hist_data['date_str'] = hist_data['date'].dt.strftime('%Y-%m')
-    hist_data['years_ago'] = (datetime.now() - hist_data['date']).dt.days / 365.25
-    hist_data['color'] = hist_data['years_ago'].apply(lambda x: matplotlib.colors.to_hex(colormap(x)))
+    hist_data = valid_rows.groupby("capture_date").size().reset_index()
+    hist_data.columns = ["date", "count"]
+    hist_data["date_str"] = hist_data["date"].dt.strftime("%Y-%m")
+    hist_data["years_ago"] = (datetime.now() - hist_data["date"]).dt.days / 365.25
+    hist_data["color"] = hist_data["years_ago"].apply(
+        lambda x: matplotlib.colors.to_hex(colormap(x))
+    )
 
     # Add markers
     marker_data = []
     markers_fg = folium.FeatureGroup(name="Pano Markers")  # Create feature group for markers
-    for idx, row in tqdm(valid_rows.iterrows(), total=len(valid_rows), desc=f"Creating {label} point map markers"):
-        capture_date = row['capture_date']
-        date_str = capture_date.strftime('%Y-%m')
+    for idx, row in tqdm(
+        valid_rows.iterrows(), total=len(valid_rows), desc=f"Creating {label} point map markers"
+    ):
+        capture_date = row["capture_date"]
+        date_str = capture_date.strftime("%Y-%m")
         age_years = (datetime.now() - capture_date).days / 365.25
         color = matplotlib.colors.to_hex(colormap(age_years))
 
-        popup = folium.Popup(f"""
+        popup = folium.Popup(
+            f"""
             <div>
                 Capture Date: {date_str}
                 <br>Age: {age_years:.1f} years
-                <br>Photographer: {row['copyright_info']}
-                <br><a href="{display['viewer_url'](row['pano_id'])}" target="_blank">View in {label}</a>
+                <br>Photographer: {row["copyright_info"]}
+                <br><a href="{display["viewer_url"](row["pano_id"])}" target="_blank">View in {label}</a>
             </div>
-        """, max_width=300)
+        """,
+            max_width=300,
+        )
 
         circle_marker = folium.CircleMarker(
-            location=[row['pano_lat'], row['pano_lon']],
+            location=[row["pano_lat"], row["pano_lon"]],
             radius=2,
             color=color,
             stroke=False,
@@ -375,19 +372,16 @@ def create_visualization_map(df: pd.DataFrame, city_name: str,
             fill_color=color,
             fill_opacity=0.8,
             popup=popup,
-            tooltip=f"Capture Date: {date_str}<br>Age: {age_years:.1f} years", 
-            name='gsv-pano-marker'   
+            tooltip=f"Capture Date: {date_str}<br>Age: {age_years:.1f} years",
+            name="gsv-pano-marker",
         )
 
         # Add custom data attributes
-        #circle_marker.add_child(Element(f'<div data-date="{date_str}" data-age="{age_years}"></div>'))
+        # circle_marker.add_child(Element(f'<div data-date="{date_str}" data-age="{age_years}"></div>'))
         # circle_marker.add_child(Element(f'<path data-date="{date_str}" data-age="{age_years}"></path>'))
         markers_fg.add_child(circle_marker)
 
-        marker_data.append({
-            'element_id': f'marker_{idx}',
-            'date': date_str
-        })
+        marker_data.append({"element_id": f"marker_{idx}", "date": date_str})
 
     # Add feature group to map
     markers_fg.add_to(folium_map)
@@ -470,16 +464,18 @@ def create_visualization_map(df: pd.DataFrame, city_name: str,
     folium_map.get_root().html.add_child(folium.Element(legend_and_hist_html))
 
     # Add required JavaScript libraries
-    folium_map.get_root().html.add_child(folium.Element("""
+    folium_map.get_root().html.add_child(
+        folium.Element("""
     <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/3.7.0/chart.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/chartjs-plugin-datalabels/2.0.0/chartjs-plugin-datalabels.min.js"></script>
     <script>
     Chart.register(ChartDataLabels);
     </script>
-    """))
+    """)
+    )
 
     # Add JavaScript for interactive features
-    hist_data_json = json.dumps(hist_data.to_dict('records'), default=str)
+    hist_data_json = json.dumps(hist_data.to_dict("records"), default=str)
     marker_data_json = json.dumps(marker_data)
     histogram_js = f"""
     <script>
@@ -757,53 +753,55 @@ def create_visualization_map(df: pd.DataFrame, city_name: str,
 
     return folium_map
 
+
 def plot_status_distribution(df: pd.DataFrame, city_name: str, figsize: tuple = (10, 6)) -> None:
     """
     Draw a bar plot showing the distribution of different API response status types.
-    
+
     Args:
         df: DataFrame containing the GSV metadata
         city_name: Name of the city for the plot title
         figsize: Tuple of (width, height) for the plot
     """
     plt.figure(figsize=figsize)
-    
+
     # Create bar plot using seaborn
-    ax = sns.countplot(x='status', data=df)
-    
+    ax = sns.countplot(x="status", data=df)
+
     # Customize the plot
-    plt.title(f'Distribution of Status Occurrences in {city_name}')
-    plt.xlabel('Status')
-    plt.ylabel('Count')
-    
+    plt.title(f"Distribution of Status Occurrences in {city_name}")
+    plt.xlabel("Status")
+    plt.ylabel("Count")
+
     # Add count labels on top of bars
     for p in ax.patches:
         ax.annotate(
-            f'{int(p.get_height())}',
-            (p.get_x() + p.get_width() / 2., p.get_height()),
-            ha='center',
-            va='bottom'
+            f"{int(p.get_height())}",
+            (p.get_x() + p.get_width() / 2.0, p.get_height()),
+            ha="center",
+            va="bottom",
         )
-    
+
     # Rotate x-axis labels for better readability
-    plt.xticks(rotation=45, ha='right')
-    
+    plt.xticks(rotation=45, ha="right")
+
     # Adjust layout to prevent label cutoff
     plt.tight_layout()
-    
+
     plt.show()
+
 
 def plot_temporal_distribution(
     df: pd.DataFrame,
     city_name: str,
     figsize: tuple = (12, 6),
-    bin_freq: str = 'M',  # 'M' for month, 'Y' for year, etc.
-    color: str = 'blue',
-    kde: bool = False
+    bin_freq: str = "M",  # 'M' for month, 'Y' for year, etc.
+    color: str = "blue",
+    kde: bool = False,
 ) -> None:
     """
     Create a histogram showing the distribution of GSV images over time.
-    
+
     Args:
         df: DataFrame containing the GSV metadata
         city_name: Name of the city for the plot title
@@ -813,112 +811,96 @@ def plot_temporal_distribution(
         kde: Whether to show the kernel density estimation curve
     """
     # Filter for successful panos with valid dates
-    valid_data = df[
-        (df['status'] == 'OK') & 
-        (df['capture_date'].notna())
-    ].copy()
-    
+    valid_data = df[(df["status"] == "OK") & (df["capture_date"].notna())].copy()
+
     if len(valid_data) == 0:
         logger.warning("No valid data for temporal distribution plot")
         return
-    
+
     # Create figure and axes
     fig, ax = plt.subplots(figsize=figsize)
-    
+
     # Convert capture_date to datetime if it isn't already
-    valid_data['capture_date'] = pd.to_datetime(valid_data['capture_date'])
-    
+    valid_data["capture_date"] = pd.to_datetime(valid_data["capture_date"])
+
     # Create the histogram
-    sns.histplot(
-        data=valid_data,
-        x='capture_date',
-        bins=30,
-        kde=kde,
-        color=color,
-        ax=ax
-    )
-    
+    sns.histplot(data=valid_data, x="capture_date", bins=30, kde=kde, color=color, ax=ax)
+
     # Customize the plot
-    ax.set_title(f'Distribution of Street View Images Over Time in {city_name}')
-    ax.set_xlabel('Capture Date')
-    ax.set_ylabel('Number of Images')
-    
+    ax.set_title(f"Distribution of Street View Images Over Time in {city_name}")
+    ax.set_xlabel("Capture Date")
+    ax.set_ylabel("Number of Images")
+
     # Format x-axis to show dates nicely
-    if bin_freq == 'M':
+    if bin_freq == "M":
         ax.xaxis.set_major_locator(mdates.YearLocator())
-        ax.xaxis.set_major_formatter(mdates.DateFormatter('%Y-%m'))
+        ax.xaxis.set_major_formatter(mdates.DateFormatter("%Y-%m"))
     else:
         ax.xaxis.set_major_locator(mdates.YearLocator())
-        ax.xaxis.set_major_formatter(mdates.DateFormatter('%Y'))
-    
+        ax.xaxis.set_major_formatter(mdates.DateFormatter("%Y"))
+
     # Add count labels on top of bars
     for p in ax.patches:
         ax.annotate(
-            f'{int(p.get_height())}',
-            (p.get_x() + p.get_width() / 2., p.get_height()),
-            ha='center',
-            va='bottom'
+            f"{int(p.get_height())}",
+            (p.get_x() + p.get_width() / 2.0, p.get_height()),
+            ha="center",
+            va="bottom",
         )
-    
+
     # Rotate and align the tick labels so they look better
-    plt.setp(ax.get_xticklabels(), rotation=45, ha='right')
-    
+    plt.setp(ax.get_xticklabels(), rotation=45, ha="right")
+
     # Use a tight layout to prevent label cutoff
     plt.tight_layout()
-    
+
     plt.show()
+
 
 def create_summary_visualization(df: pd.DataFrame, city_name: str) -> None:
     """
     Create a comprehensive statistical visualization including status distribution
     and temporal distribution.
-    
+
     Args:
         df: DataFrame containing the GSV metadata
         city_name: Name of the city being analyzed
     """
     # Create a figure with two subplots
-    fig = plt.figure(figsize=(15, 6))
-    
+    plt.figure(figsize=(15, 6))
+
     # Add status distribution subplot
     plt.subplot(121)
-    ax1 = sns.countplot(x='status', data=df)
-    plt.title(f'Status Distribution in {city_name}')
-    plt.xlabel('Status')
-    plt.ylabel('Count')
-    plt.xticks(rotation=45, ha='right')
-    
+    ax1 = sns.countplot(x="status", data=df)
+    plt.title(f"Status Distribution in {city_name}")
+    plt.xlabel("Status")
+    plt.ylabel("Count")
+    plt.xticks(rotation=45, ha="right")
+
     # Add count labels
     for p in ax1.patches:
         ax1.annotate(
-            f'{int(p.get_height())}',
-            (p.get_x() + p.get_width() / 2., p.get_height()),
-            ha='center',
-            va='bottom'
+            f"{int(p.get_height())}",
+            (p.get_x() + p.get_width() / 2.0, p.get_height()),
+            ha="center",
+            va="bottom",
         )
-    
+
     # Add temporal distribution subplot
     plt.subplot(122)
-    valid_data = df[
-        (df['status'] == 'OK') & 
-        (df['capture_date'].notna())
-    ].copy()
-    
+    valid_data = df[(df["status"] == "OK") & (df["capture_date"].notna())].copy()
+
     if len(valid_data) > 0:
-        sns.histplot(
-            data=valid_data,
-            x='capture_date',
-            bins=30,
-            color='blue'
-        )
-        plt.title(f'Temporal Distribution in {city_name}')
-        plt.xlabel('Capture Date')
-        plt.ylabel('Number of Images')
-        plt.xticks(rotation=45, ha='right')
-    
+        sns.histplot(data=valid_data, x="capture_date", bins=30, color="blue")
+        plt.title(f"Temporal Distribution in {city_name}")
+        plt.xlabel("Capture Date")
+        plt.ylabel("Number of Images")
+        plt.xticks(rotation=45, ha="right")
+
     # Adjust layout
     plt.tight_layout()
     plt.show()
+
 
 # Example usage:
 """

--- a/gsv_street_analyzer/download_street_network.py
+++ b/gsv_street_analyzer/download_street_network.py
@@ -1,13 +1,12 @@
-import osmnx as ox
 import argparse
 import logging
-from pathlib import Path
-import networkx as nx
-import json
-from typing import Optional, Dict, Any
-from tenacity import retry, stop_after_attempt, wait_exponential
 import sys
 from pathlib import Path
+
+import networkx as nx
+import osmnx as ox
+from tenacity import retry, stop_after_attempt, wait_exponential
+
 # Add parent directory to Python path
 sys.path.append(str(Path(__file__).parent.parent))
 from gsv_metadata_tracker import geoutils
@@ -16,22 +15,23 @@ from gsv_metadata_tracker import geoutils
 logger = logging.getLogger(__name__)
 
 # Configure OSMnx
-ox.settings.log_console=True
-ox.settings.use_cache=True
-ox.settings.timeout=30
+ox.settings.log_console = True
+ox.settings.use_cache = True
+ox.settings.timeout = 30
+
 
 @retry(stop=stop_after_attempt(3), wait=wait_exponential(multiplier=1, min=4, max=10))
-def download_street_network(city_name: str, save_dir: str = "data") -> Optional[nx.MultiDiGraph]:
+def download_street_network(city_name: str, save_dir: str = "data") -> nx.MultiDiGraph | None:
     """
     Download street network for a given city using OSMnx with retry logic.
-    
+
     Args:
         city_name: Name of the city to download
         save_dir: Directory to save the network data
-        
+
     Returns:
         NetworkX MultiDiGraph object containing the street network
-        
+
     Example:
         >>> G = download_street_network("Amsterdam")
         >>> print(f"Downloaded {len(G.nodes)} nodes and {len(G.edges)} edges")
@@ -42,34 +42,35 @@ def download_street_network(city_name: str, save_dir: str = "data") -> Optional[
         if not location:
             logger.error(f"Could not find location data for {city_name}")
             return None
-        
+
         logger.info(f"Downloading street network for {location}")
         logger.info("\n" + location.__detailed_str__())
-            
+
         north, south, east, west = location.bbox_tuple
 
         # Download street network
         # https://osmnx.readthedocs.io/en/stable/user-reference.html#osmnx.graph.graph_from_bbox
         G = ox.graph_from_bbox(
             bbox=(west, south, east, north),  # Pass as single tuple
-            network_type='drive',
+            network_type="drive",
             simplify=True,
             retain_all=False,
             truncate_by_edge=True,
-            custom_filter=None
+            custom_filter=None,
         )
-        
+
         logger.info(f"Downloaded network with {len(G.nodes)} nodes and {len(G.edges)} edges")
         return G
-        
+
     except Exception as e:
         logger.error(f"Error downloading street network: {str(e)}")
         raise  # Let retry decorator handle it
 
+
 def save_network(G: nx.MultiDiGraph, city_name: str, save_dir: str = "data"):
     """
     Save street network in multiple formats for different use cases.
-    
+
     Args:
         G: NetworkX graph object
         city_name: Name of the city (used for filename)
@@ -77,42 +78,44 @@ def save_network(G: nx.MultiDiGraph, city_name: str, save_dir: str = "data"):
     """
     save_path = Path(save_dir)
     save_path.mkdir(exist_ok=True)
-    
+
     # Save as GraphML for complete network topology
     graphml_path = save_path / f"{city_name}_network.graphml"
     ox.save_graphml(G, graphml_path)
-    
+
     # Save as GeoJSON for web visualization
     geojson_path = save_path / f"{city_name}_network.geojson"
     ox.save_graph_geopackage(G, filepath=geojson_path, directed=True)
-    
+
     logger.info(f"Saved network to {save_path}")
+
 
 def main():
     parser = argparse.ArgumentParser(description="Download street network for a city")
     parser.add_argument("city", help="Name of the city")
     parser.add_argument("--save_dir", default="data", help="Directory to save network data")
     parser.add_argument(
-        '--log-level',
+        "--log-level",
         type=str,
-        default='WARNING',
-        choices=['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'],
-        help='Set the logging level for output messages'
+        default="WARNING",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
+        help="Set the logging level for output messages",
     )
-    
+
     args = parser.parse_args()
 
     # Configure logging - this is sync but only happens once at startup
     logging.basicConfig(
         level=getattr(logging, args.log_level.upper()),
-        format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
-        datefmt='%Y-%m-%d %H:%M:%S'
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
     )
-    
+
     # Download network
     G = download_street_network(args.city, args.save_dir)
     if G is not None:
         save_network(G, args.city, args.save_dir)
+
 
 if __name__ == "__main__":
     main()

--- a/gsv_tracker.py
+++ b/gsv_tracker.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 import sys
+
 from gsv_metadata_tracker.cli import main
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     sys.exit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,44 @@
+[project]
+# Minimal metadata only — Streetscape Tracker runs as scripts, not an installed
+# package. This file exists to hold tool config (ruff, pytest) in one standard
+# place; it does not define a build.
+name = "streetscape-tracker"
+version = "2.0.0"
+requires-python = ">=3.11"
+
+[tool.ruff]
+# Match the codebase's prevailing width; the formatter owns line wrapping.
+line-length = 100
+target-version = "py311"
+
+[tool.ruff.lint]
+# Curated set: real-bug catchers (pyflakes F, pycodestyle E/W, bugbear B),
+# import hygiene (I), comprehension cleanups (C4), and safe modernizations (UP).
+select = ["E", "F", "W", "I", "B", "C4", "UP"]
+ignore = [
+    # The formatter enforces line-length; E501 would only flag lines it can't
+    # break (long URLs, string literals) — pure noise, so leave it to the
+    # formatter.
+    "E501",
+    # dict(key=value) is used deliberately for readability in a few spots;
+    # rewriting to a literal with string keys reads worse here.
+    "C408",
+]
+
+[tool.ruff.lint.per-file-ignores]
+# argparse defaults are commonly function calls (e.g. get_default_data_dir());
+# B008 is a false positive for that idiom.
+"scripts/*.py" = ["B008"]
+# vis.py embeds HTML/JS map templates as triple-quoted strings; the formatter
+# leaves string contents alone, so W291/W293 here flag whitespace *inside those
+# templates*, not real code.
+"gsv_metadata_tracker/vis.py" = ["W291", "W293"]
+
+[tool.ruff.format]
+# Ruff's Black-compatible defaults (double quotes, spaces). Explicit for clarity.
+quote-style = "double"
+indent-style = "space"
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "-q"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,6 @@
+# Development dependencies: everything in requirements.txt plus tooling.
+# Install with:  pip install -r requirements-dev.txt
+-r requirements.txt
+
+# Linter + formatter (pinned to keep local and CI results identical).
+ruff==0.15.21

--- a/run_cities.py
+++ b/run_cities.py
@@ -11,29 +11,30 @@ Example cities.txt format:
     Vancouver, BC
 """
 
-import subprocess
-import sys
-import shlex
-from typing import List, Optional
-from pathlib import Path
 import argparse
 import logging
+import shlex
+import subprocess
+import sys
 from datetime import datetime
+from pathlib import Path
+
 from gsv_metadata_tracker.paths import get_default_data_dir, get_project_root
 
-def parse_city_line(line: str) -> Optional[List[str]]:
+
+def parse_city_line(line: str) -> list[str] | None:
     """
     Parse a line from the cities file into command line arguments.
-    
+
     Each line should be formatted exactly as you would type it on the command line.
     The city name comes first, followed by any optional parameters.
-    
+
     Args:
         line: A line from the cities file
-        
+
     Returns:
         List[str] if valid line, None if comment or empty
-        
+
     Examples:
         >>> parse_city_line("Seattle, WA --width 2000 --height 2000 --step 25")
         ["Seattle, WA", "--width", "2000", "--height", "2000", "--step", "25"]
@@ -44,28 +45,29 @@ def parse_city_line(line: str) -> Optional[List[str]]:
     """
     # Skip comments and empty lines
     line = line.strip()
-    if not line or line.startswith('#'):
+    if not line or line.startswith("#"):
         return None
-    
+
     # Use shlex to properly handle quoted strings and spaces
     return shlex.split(line)
 
-def load_cities(file_path: str) -> List[List[str]]:
+
+def load_cities(file_path: str) -> list[list[str]]:
     """
     Load city configurations from file.
-    
+
     Args:
         file_path: Path to file containing city configurations
-        
+
     Returns:
         List[List[str]]: List of command line argument lists for each city
-        
+
     Raises:
         FileNotFoundError: If cities file doesn't exist
     """
     cities = []
-    
-    with open(file_path, 'r') as f:
+
+    with open(file_path) as f:
         for line_num, line in enumerate(f, 1):
             try:
                 args = parse_city_line(line)
@@ -75,83 +77,80 @@ def load_cities(file_path: str) -> List[List[str]]:
                 logging.warning(f"Invalid configuration at line {line_num}: {line.strip()}")
                 logging.warning(f"Error: {str(e)}")
                 continue
-            
+
     return cities
+
 
 def parse_args() -> argparse.Namespace:
     """
     Parse and validate command line arguments.
-    
+
     Returns:
         argparse.Namespace: Parsed command line arguments
     """
     parser = argparse.ArgumentParser(
-        description='Run GSV Tracker for multiple cities',
+        description="Run GSV Tracker for multiple cities",
         formatter_class=argparse.RawDescriptionHelpFormatter,
-        epilog='''Examples:
+        epilog="""Examples:
   python run_cities.py cities.txt
   python run_cities.py cities.txt --batch-size 200 --connection-limit 100
-  python run_cities.py cities.txt --download-dir ./data --log-level DEBUG'''
+  python run_cities.py cities.txt --download-dir ./data --log-level DEBUG""",
     )
-    
+
     parser.add_argument(
-        'cities_file',
+        "cities_file",
         type=str,
-        help='Path to file containing city configurations (e.g., cities.txt)'
+        help="Path to file containing city configurations (e.g., cities.txt)",
     )
-    
+
     # Global execution parameters
-    exec_group = parser.add_argument_group('Execution Parameters')
+    exec_group = parser.add_argument_group("Execution Parameters")
     exec_group.add_argument(
-        '--batch-size',
+        "--batch-size",
         type=int,
         default=100,
-        help='Number of requests to prepare and queue at once'
+        help="Number of requests to prepare and queue at once",
     )
     exec_group.add_argument(
-        '--connection-limit',
-        type=int,
-        default=50,
-        help='Maximum number of concurrent connections'
+        "--connection-limit", type=int, default=50, help="Maximum number of concurrent connections"
     )
     exec_group.add_argument(
-        '--no-visual',
-        action='store_true',
-        help='Skip generating visualizations'
+        "--no-visual", action="store_true", help="Skip generating visualizations"
     )
     exec_group.add_argument(
-        '--log-level',
-        choices=['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'],
-        default='INFO',
-        help='Set logging level'
+        "--log-level",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
+        default="INFO",
+        help="Set logging level",
     )
     exec_group.add_argument(
-        '--continue-on-error',
-        action='store_true',
-        help='Continue processing remaining cities if one fails'
+        "--continue-on-error",
+        action="store_true",
+        help="Continue processing remaining cities if one fails",
     )
     exec_group.add_argument(
-        '--download-dir',
+        "--download-dir",
         type=str,
-        help='Dir to save downloaded data (defaults to ./data)',
-        default=get_default_data_dir()
+        help="Dir to save downloaded data (defaults to ./data)",
+        default=get_default_data_dir(),
     )
-    
+
     args = parser.parse_args()
-    
+
     # Validate batch_size and connection_limit relationship
     if args.connection_limit > args.batch_size:
         parser.error("connection-limit cannot be larger than batch-size")
-        
+
     return args
+
 
 def setup_logging(args: argparse.Namespace) -> str:
     """
     Set up logging configuration.
-    
+
     Args:
         args: Parsed command line arguments
-        
+
     Returns:
         str: Path to the log file
     """
@@ -160,90 +159,91 @@ def setup_logging(args: argparse.Namespace) -> str:
         Path(args.download_dir).mkdir(parents=True, exist_ok=True)
 
     # Logs go to logs/, never data/ (data/ is synced to the public web server)
-    log_dir = Path(get_project_root()) / 'logs'
+    log_dir = Path(get_project_root()) / "logs"
     log_dir.mkdir(parents=True, exist_ok=True)
-    timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
-    log_path = log_dir / f'gsv_tracker_{timestamp}.log'
-        
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    log_path = log_dir / f"gsv_tracker_{timestamp}.log"
+
     # Configure logging
     logging.basicConfig(
         level=getattr(logging, args.log_level.upper()),
-        format='%(asctime)s - %(levelname)s - %(message)s',
-        handlers=[
-            logging.FileHandler(log_path),
-            logging.StreamHandler(sys.stdout)
-        ]
+        format="%(asctime)s - %(levelname)s - %(message)s",
+        handlers=[logging.FileHandler(log_path), logging.StreamHandler(sys.stdout)],
     )
-    
+
     return str(log_path)
 
-def run_gsv_tracker(city_args: List[str], global_args: argparse.Namespace) -> bool:
+
+def run_gsv_tracker(city_args: list[str], global_args: argparse.Namespace) -> bool:
     """Run the GSV Metadata Tracker for a specific city."""
     # Use the same interpreter (and venv) that launched this script
     cmd = [sys.executable, "gsv_tracker.py"]
-    
+
     # Add city name - join all parts until we hit an argument starting with --
     city_name_parts = []
     other_args = []
     for arg in city_args:
-        if arg.startswith('--'):
+        if arg.startswith("--"):
             other_args.extend([arg])
         else:
             if other_args:  # If we've already seen a --, this is a value for it
                 other_args.extend([arg])
             else:  # Otherwise it's part of the city name
                 city_name_parts.append(arg)
-    
+
     # Add the city name as a single argument
-    cmd.append(' '.join(city_name_parts))
-    
+    cmd.append(" ".join(city_name_parts))
+
     # Add any other city-specific args
     cmd.extend(other_args)
-    
+
     # Add global execution args
-    cmd.extend([
-        '--batch-size', str(global_args.batch_size),
-        '--connection-limit', str(global_args.connection_limit),
-        '--log-level', global_args.log_level,
-        '--download-dir', str(global_args.download_dir)
-    ])
-    
+    cmd.extend(
+        [
+            "--batch-size",
+            str(global_args.batch_size),
+            "--connection-limit",
+            str(global_args.connection_limit),
+            "--log-level",
+            global_args.log_level,
+            "--download-dir",
+            str(global_args.download_dir),
+        ]
+    )
+
     if global_args.no_visual:
-        cmd.append('--no-visual')
-    
+        cmd.append("--no-visual")
+
     try:
         logging.info(f"Processing {cmd[2]}")
         logging.debug(f"Command: {' '.join(cmd)}")
-        
+
         # Remove capture_output=True to allow output to pass through
-        result = subprocess.run(
-            cmd,
-            check=True,
-            text=True
-        )
-            
+        subprocess.run(cmd, check=True, text=True)
+
         return True
-        
-    except subprocess.CalledProcessError as e:
+
+    except subprocess.CalledProcessError:
         logging.error(f"Error processing {cmd[2]}")
         return False
     except Exception as e:
         logging.error(f"Unexpected error processing {cmd[2]}: {e}")
         return False
 
+
 def main() -> int:
     """
     Main entry point for the multi-city GSV Metadata Tracker.
-    
+
     Returns:
         int: Exit code (0 for success, 1 for errors)
     """
     args = parse_args()
-    
+
     # Setup logging
     log_path = setup_logging(args)
     logging.info(f"Log file: {log_path}")
-    
+
     try:
         cities = load_cities(args.cities_file)
     except FileNotFoundError:
@@ -252,38 +252,41 @@ def main() -> int:
     except Exception as e:
         logging.error(f"Error reading cities file: {e}")
         return 1
-    
+
     if not cities:
         logging.error("No valid cities found in input file")
         return 1
-        
+
     logging.info(f"Found {len(cities)} cities to process")
-    
+
     successful = []
     failed = []
-    
+
     for i, city_args in enumerate(cities, 1):
         logging.info(f"\nProcessing city {i}/{len(cities)}")
-        
+
         if run_gsv_tracker(city_args, args):
             successful.append(city_args[0])  # city name is first argument
         else:
             failed.append(city_args[0])
             if not args.continue_on_error:
-                logging.error("\nStopping due to error. Use --continue-on-error to process remaining cities.")
+                logging.error(
+                    "\nStopping due to error. Use --continue-on-error to process remaining cities."
+                )
                 break
-    
+
     # Print summary
     logging.info("\nProcessing complete!")
     logging.info(f"Successful: {len(successful)}/{len(cities)} cities")
-    
+
     if failed:
         logging.error("\nFailed cities:")
         for city in failed:
             logging.error(f"- {city}")
         return 1
-    
+
     return 0
+
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/scripts/apply_decisions.py
+++ b/scripts/apply_decisions.py
@@ -33,7 +33,6 @@ import math
 import os
 import sys
 from dataclasses import dataclass
-from typing import Optional
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
@@ -56,6 +55,7 @@ APPLY_NOTE = "regeom #91: applied reviewed boundary decision"
 @dataclass
 class Current:
     """A city's current frozen geometry, read live from the catalog."""
+
     center_lat: float
     center_lon: float
     width_m: int
@@ -65,22 +65,23 @@ class Current:
 @dataclass
 class Apply:
     """The action to take for one decision row."""
+
     city_id: str
     display_name: str
     decision: str
     action: str  # APPLY | NOCHANGE | SKIP
     reason: str
-    old_center_lat: Optional[float] = None
-    old_center_lon: Optional[float] = None
-    old_width_m: Optional[int] = None
-    old_height_m: Optional[int] = None
-    new_center_lat: Optional[float] = None
-    new_center_lon: Optional[float] = None
-    new_width_m: Optional[int] = None
-    new_height_m: Optional[int] = None
+    old_center_lat: float | None = None
+    old_center_lon: float | None = None
+    old_width_m: int | None = None
+    old_height_m: int | None = None
+    new_center_lat: float | None = None
+    new_center_lon: float | None = None
+    new_width_m: int | None = None
+    new_height_m: int | None = None
 
 
-def _num(row: dict, key: str) -> Optional[float]:
+def _num(row: dict, key: str) -> float | None:
     """Parse a possibly-blank/NaN CSV cell to float, or None."""
     val = row.get(key, "")
     if val is None or val == "":
@@ -101,7 +102,7 @@ def _chosen(row: dict):
     return (lat, lon, int(w), int(h))
 
 
-def plan_row(row: dict, current: Optional[Current]) -> Apply:
+def plan_row(row: dict, current: Current | None) -> Apply:
     """
     Pure policy: map one decision-CSV row + current geometry to an Apply action.
 
@@ -113,14 +114,24 @@ def plan_row(row: dict, current: Optional[Current]) -> Apply:
     decision = (row.get("decision") or "").strip()
 
     def a(action, reason, **kw):
-        return Apply(city_id=city_id, display_name=name, decision=decision,
-                     action=action, reason=reason, **kw)
+        return Apply(
+            city_id=city_id,
+            display_name=name,
+            decision=decision,
+            action=action,
+            reason=reason,
+            **kw,
+        )
 
     if current is None:
         return a("SKIP", "not found in catalog")
 
-    old = dict(old_center_lat=current.center_lat, old_center_lon=current.center_lon,
-               old_width_m=current.width_m, old_height_m=current.height_m)
+    old = dict(
+        old_center_lat=current.center_lat,
+        old_center_lon=current.center_lon,
+        old_width_m=current.width_m,
+        old_height_m=current.height_m,
+    )
 
     chosen = _chosen(row)
     if not decision:
@@ -130,10 +141,12 @@ def plan_row(row: dict, current: Optional[Current]) -> Apply:
         return a("SKIP", f"decision '{decision}' carries no geometry", **old)
 
     lat, lon, w, h = chosen
-    unchanged = (abs(lat - current.center_lat) < _CENTER_EPS_DEG and
-                 abs(lon - current.center_lon) < _CENTER_EPS_DEG and
-                 abs(w - current.width_m) < _SIZE_EPS_M and
-                 abs(h - current.height_m) < _SIZE_EPS_M)
+    unchanged = (
+        abs(lat - current.center_lat) < _CENTER_EPS_DEG
+        and abs(lon - current.center_lon) < _CENTER_EPS_DEG
+        and abs(w - current.width_m) < _SIZE_EPS_M
+        and abs(h - current.height_m) < _SIZE_EPS_M
+    )
     new = dict(new_center_lat=lat, new_center_lon=lon, new_width_m=w, new_height_m=h)
     if unchanged:
         return a("NOCHANGE", f"decision '{decision}': chosen == current", **old, **new)
@@ -143,34 +156,45 @@ def plan_row(row: dict, current: Optional[Current]) -> Apply:
 def load_current_geometry(conn) -> dict:
     """Map city_id -> Current for every city in the catalog."""
     rows = conn.execute(
-        "SELECT city_id, center_lat, center_lon, grid_width_m, grid_height_m "
-        "FROM cities").fetchall()
-    return {r["city_id"]: Current(r["center_lat"], r["center_lon"],
-                                  r["grid_width_m"], r["grid_height_m"])
-            for r in rows}
+        "SELECT city_id, center_lat, center_lon, grid_width_m, grid_height_m FROM cities"
+    ).fetchall()
+    return {
+        r["city_id"]: Current(
+            r["center_lat"], r["center_lon"], r["grid_width_m"], r["grid_height_m"]
+        )
+        for r in rows
+    }
 
 
 def _fmt_geom(lat, lon, w, h) -> str:
     if None in (lat, lon, w, h):
         return "—"
-    return f"({lat:.5f}, {lon:.5f}) {w/1000:.1f}×{h/1000:.1f} km"
+    return f"({lat:.5f}, {lon:.5f}) {w / 1000:.1f}×{h / 1000:.1f} km"
 
 
 def main() -> int:
     parser = argparse.ArgumentParser(
-        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
-    parser.add_argument("--decisions", default=DEFAULT_DECISIONS,
-                        help="exported decisions CSV (default: audit/boundary_decisions.csv)")
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument(
+        "--decisions",
+        default=DEFAULT_DECISIONS,
+        help="exported decisions CSV (default: audit/boundary_decisions.csv)",
+    )
     parser.add_argument("--data-dir", default=get_default_data_dir())
     parser.add_argument("--db-path", default=None, help="default: {data-dir}/gsv_tracker.db")
-    parser.add_argument("--execute", action="store_true",
-                        help="Apply changes (default is a dry run)")
-    parser.add_argument("--log-level", default="WARNING",
-                        choices=["DEBUG", "INFO", "WARNING", "ERROR"])
+    parser.add_argument(
+        "--execute", action="store_true", help="Apply changes (default is a dry run)"
+    )
+    parser.add_argument(
+        "--log-level", default="WARNING", choices=["DEBUG", "INFO", "WARNING", "ERROR"]
+    )
     args = parser.parse_args()
 
-    logging.basicConfig(level=getattr(logging, args.log_level),
-                        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+    logging.basicConfig(
+        level=getattr(logging, args.log_level),
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    )
 
     if not os.path.exists(args.decisions):
         print(f"ERROR: decisions file not found: {args.decisions}", file=sys.stderr)
@@ -186,8 +210,9 @@ def main() -> int:
     current_by_id = load_current_geometry(conn)
 
     with open(args.decisions, newline="") as f:
-        plans = [plan_row(row, current_by_id.get(row.get("city_id", "")))
-                 for row in csv.DictReader(f)]
+        plans = [
+            plan_row(row, current_by_id.get(row.get("city_id", ""))) for row in csv.DictReader(f)
+        ]
 
     apply = [p for p in plans if p.action == "APPLY"]
     nochange = [p for p in plans if p.action == "NOCHANGE"]
@@ -195,8 +220,12 @@ def main() -> int:
 
     for p in apply:
         print(f"  APPLY  {p.display_name} ({p.city_id})")
-        print(f"         {_fmt_geom(p.old_center_lat, p.old_center_lon, p.old_width_m, p.old_height_m)}")
-        print(f"      ->  {_fmt_geom(p.new_center_lat, p.new_center_lon, p.new_width_m, p.new_height_m)}")
+        print(
+            f"         {_fmt_geom(p.old_center_lat, p.old_center_lon, p.old_width_m, p.old_height_m)}"
+        )
+        print(
+            f"      ->  {_fmt_geom(p.new_center_lat, p.new_center_lon, p.new_width_m, p.new_height_m)}"
+        )
 
     print(f"\nApply (recenter/resize): {len(apply)}")
     print(f"No change:               {len(nochange)}")
@@ -209,10 +238,14 @@ def main() -> int:
 
     for p in apply:
         db.update_city_geometry(
-            conn, city_id=p.city_id,
-            center_lat=p.new_center_lat, center_lon=p.new_center_lon,
-            grid_width_m=p.new_width_m, grid_height_m=p.new_height_m,
-            notes=APPLY_NOTE)
+            conn,
+            city_id=p.city_id,
+            center_lat=p.new_center_lat,
+            center_lon=p.new_center_lon,
+            grid_width_m=p.new_width_m,
+            grid_height_m=p.new_height_m,
+            notes=APPLY_NOTE,
+        )
     conn.close()
     print(f"\nApplied {len(apply)} boundary decisions.")
     return 0

--- a/scripts/audit_city_boundaries.py
+++ b/scripts/audit_city_boundaries.py
@@ -35,8 +35,7 @@ import os
 import sys
 import time
 from dataclasses import asdict, fields
-from datetime import datetime, timezone
-from typing import Dict, Optional
+from datetime import UTC, datetime
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
@@ -44,20 +43,35 @@ from geopy.exc import GeocoderServiceError  # noqa: E402
 
 from gsv_metadata_tracker import db  # noqa: E402
 from gsv_metadata_tracker.boundary_audit import (  # noqa: E402
-    AuditResult, OsmBoundary, Thresholds, classify, parse_osm_result)
+    AuditResult,
+    OsmBoundary,
+    Thresholds,
+    classify,
+    parse_osm_result,
+)
 from gsv_metadata_tracker.geoutils import geocode_boundary_raw  # noqa: E402
 from gsv_metadata_tracker.paths import (  # noqa: E402
-    get_default_data_dir, get_project_root)
+    get_default_data_dir,
+    get_project_root,
+)
 
-logging.basicConfig(level=logging.WARNING, format='%(levelname)s %(message)s')
+logging.basicConfig(level=logging.WARNING, format="%(levelname)s %(message)s")
 logger = logging.getLogger(__name__)
 
 # Report verdicts in review-priority order
-VERDICT_ORDER = ['WRONG_PLACE', 'UNDER', 'OVER', 'BBOX_SUSPECT',
-                 'NO_POLYGON', 'NOT_FOUND', 'NOT_FETCHED', 'OK']
+VERDICT_ORDER = [
+    "WRONG_PLACE",
+    "UNDER",
+    "OVER",
+    "BBOX_SUSPECT",
+    "NO_POLYGON",
+    "NOT_FOUND",
+    "NOT_FETCHED",
+    "OK",
+]
 
 
-def load_cache(path: str) -> Dict[str, Optional[OsmBoundary]]:
+def load_cache(path: str) -> dict[str, OsmBoundary | None]:
     """
     Stream the JSONL cache into {city_id: OsmBoundary | None}.
 
@@ -65,24 +79,23 @@ def load_cache(path: str) -> Dict[str, Optional[OsmBoundary]]:
     cache never fully materializes in memory. None means Nominatim found
     nothing (a stable answer, distinct from "not yet fetched").
     """
-    cache: Dict[str, Optional[OsmBoundary]] = {}
+    cache: dict[str, OsmBoundary | None] = {}
     if not os.path.exists(path):
         return cache
-    with open(path, encoding='utf-8') as f:
+    with open(path, encoding="utf-8") as f:
         for line_num, line in enumerate(f, 1):
             line = line.strip()
             if not line:
                 continue
             try:
                 rec = json.loads(line)
-                cache[rec['city_id']] = (parse_osm_result(rec['raw'])
-                                         if rec.get('found') else None)
+                cache[rec["city_id"]] = parse_osm_result(rec["raw"]) if rec.get("found") else None
             except (json.JSONDecodeError, KeyError, TypeError, ValueError) as e:
                 logger.warning(f"Skipping bad cache line {line_num}: {e}")
     return cache
 
 
-def fetch_missing(cities, cache, cache_path: str, limit: Optional[int]) -> int:
+def fetch_missing(cities, cache, cache_path: str, limit: int | None) -> int:
     """
     Geocode cities absent from the cache, appending one flushed JSONL line
     per result. Transient geocoder errors are logged and NOT cached, so a
@@ -95,31 +108,39 @@ def fetch_missing(cities, cache, cache_path: str, limit: Optional[int]) -> int:
         print("Fetch: everything already cached")
         return 0
 
-    print(f"Fetch: {len(todo)} cities to geocode "
-          f"(~{len(todo) * 1.1 / 60:.0f} min at 1 req/sec; resumable)")
+    print(
+        f"Fetch: {len(todo)} cities to geocode "
+        f"(~{len(todo) * 1.1 / 60:.0f} min at 1 req/sec; resumable)"
+    )
     n_errors = 0
     start = time.monotonic()
     os.makedirs(os.path.dirname(cache_path), exist_ok=True)
-    with open(cache_path, 'a', encoding='utf-8') as f:
+    with open(cache_path, "a", encoding="utf-8") as f:
         for i, city in enumerate(todo, 1):
             try:
-                raw = geocode_boundary_raw(city.city_name, city.state_name,
-                                           city.country_name)
+                raw = geocode_boundary_raw(city.city_name, city.state_name, city.country_name)
             except GeocoderServiceError as e:
                 n_errors += 1
                 logger.warning(f"[FETCH_ERROR] {city.city_id}: {e}")
                 continue
-            f.write(json.dumps({
-                'city_id': city.city_id,
-                'query': {'city': city.city_name, 'state': city.state_name,
-                          'country': city.country_name},
-                'fetched_at': datetime.now(timezone.utc).isoformat(),
-                'found': raw is not None,
-                'raw': raw,
-            }) + '\n')
+            f.write(
+                json.dumps(
+                    {
+                        "city_id": city.city_id,
+                        "query": {
+                            "city": city.city_name,
+                            "state": city.state_name,
+                            "country": city.country_name,
+                        },
+                        "fetched_at": datetime.now(UTC).isoformat(),
+                        "found": raw is not None,
+                        "raw": raw,
+                    }
+                )
+                + "\n"
+            )
             f.flush()
-            cache[city.city_id] = (parse_osm_result(raw)
-                                   if raw is not None else None)
+            cache[city.city_id] = parse_osm_result(raw) if raw is not None else None
             if i % 25 == 0 or i == len(todo):
                 rate = (time.monotonic() - start) / i
                 eta_min = rate * (len(todo) - i) / 60
@@ -130,19 +151,37 @@ def fetch_missing(cities, cache, cache_path: str, limit: Optional[int]) -> int:
 def write_report(rows, report_path: str) -> None:
     os.makedirs(os.path.dirname(report_path), exist_ok=True)
     result_fields = [f.name for f in fields(AuditResult)]
-    header = (['city_id', 'display_name', 'frozen_center_lat',
-               'frozen_center_lon', 'frozen_width_m', 'frozen_height_m',
-               'frozen_area_km2'] + result_fields + ['notes'])
-    with open(report_path, 'w', newline='', encoding='utf-8') as f:
+    header = (
+        [
+            "city_id",
+            "display_name",
+            "frozen_center_lat",
+            "frozen_center_lon",
+            "frozen_width_m",
+            "frozen_height_m",
+            "frozen_area_km2",
+        ]
+        + result_fields
+        + ["notes"]
+    )
+    with open(report_path, "w", newline="", encoding="utf-8") as f:
         writer = csv.writer(f)
         writer.writerow(header)
         for city, res in rows:
             r = asdict(res)
             writer.writerow(
-                [city.city_id, city.display_name, city.center_lat,
-                 city.center_lon, city.grid_width_m, city.grid_height_m,
-                 city.grid_width_m * city.grid_height_m / 1e6]
-                + [r[name] for name in result_fields] + [city.notes])
+                [
+                    city.city_id,
+                    city.display_name,
+                    city.center_lat,
+                    city.center_lon,
+                    city.grid_width_m,
+                    city.grid_height_m,
+                    city.grid_width_m * city.grid_height_m / 1e6,
+                ]
+                + [r[name] for name in result_fields]
+                + [city.notes]
+            )
 
 
 def print_summary(rows, top: int) -> None:
@@ -152,29 +191,33 @@ def print_summary(rows, top: int) -> None:
 
     def flagged_line(city, res):
         frozen = f"{city.grid_width_m}x{city.grid_height_m}m"
-        osm = (f"{res.osm_bbox_width_m:.0f}x{res.osm_bbox_height_m:.0f}m"
-               if res.osm_bbox_width_m is not None else "?")
+        osm = (
+            f"{res.osm_bbox_width_m:.0f}x{res.osm_bbox_height_m:.0f}m"
+            if res.osm_bbox_width_m is not None
+            else "?"
+        )
         extra = ""
-        if res.verdict == 'WRONG_PLACE' and res.center_dist_km is not None:
+        if res.verdict == "WRONG_PLACE" and res.center_dist_km is not None:
             extra = f" center {res.center_dist_km:.0f} km away"
-        elif res.verdict == 'UNDER' and res.bbox_coverage_frac is not None:
+        elif res.verdict == "UNDER" and res.bbox_coverage_frac is not None:
             extra = f" coverage={res.bbox_coverage_frac:.2f}"
-        elif res.verdict == 'OVER' and res.over_area_ratio is not None:
+        elif res.verdict == "OVER" and res.over_area_ratio is not None:
             extra = f" area ratio={res.over_area_ratio:.1f}x"
         name = res.osm_display_name or ""
-        return (f"  [{res.verdict}] {city.city_id}: frozen {frozen}, "
-                f"OSM bbox {osm}{extra} — \"{name}\"")
+        return (
+            f'  [{res.verdict}] {city.city_id}: frozen {frozen}, OSM bbox {osm}{extra} — "{name}"'
+        )
 
     for verdict in VERDICT_ORDER:
         group = by_verdict.get(verdict, [])
-        if not group or verdict == 'OK':
+        if not group or verdict == "OK":
             continue
         # Sort worst-first within each verdict
-        if verdict == 'UNDER':
+        if verdict == "UNDER":
             group.sort(key=lambda cr: cr[1].bbox_coverage_frac or 0)
-        elif verdict == 'OVER':
+        elif verdict == "OVER":
             group.sort(key=lambda cr: -(cr[1].over_area_ratio or 0))
-        elif verdict == 'WRONG_PLACE':
+        elif verdict == "WRONG_PLACE":
             group.sort(key=lambda cr: -(cr[1].center_dist_km or 0))
         print(f"\n{verdict} ({len(group)}):")
         for city, res in group[:top]:
@@ -190,38 +233,51 @@ def print_summary(rows, top: int) -> None:
 
 
 def main() -> int:
-    audit_dir = os.path.join(get_project_root(), 'audit')
+    audit_dir = os.path.join(get_project_root(), "audit")
     parser = argparse.ArgumentParser(
-        description='Audit frozen search rectangles against OSM boundaries '
-                    '(issue #91, step 1). Read-only on the catalog.',
-        formatter_class=argparse.RawDescriptionHelpFormatter)
-    parser.add_argument('--data-dir', default=get_default_data_dir())
-    parser.add_argument('--cache',
-                        default=os.path.join(audit_dir,
-                                             'nominatim_boundary_cache.jsonl'))
-    parser.add_argument('--report',
-                        default=os.path.join(audit_dir,
-                                             'boundary_audit_report.csv'))
-    parser.add_argument('--no-fetch', action='store_true',
-                        help='Classify from cache only (no network) — for '
-                             'iterating on thresholds after a full fetch')
-    parser.add_argument('--refetch', action='store_true',
-                        help='Re-query cached cities too (appends; the '
-                             'newest record wins)')
-    parser.add_argument('--city', action='append', default=None,
-                        help='Restrict to this city_id (repeatable)')
-    parser.add_argument('--limit', type=int, default=None,
-                        help='Fetch at most N uncached cities (smoke test)')
-    parser.add_argument('--min-coverage', type=float, default=0.75,
-                        help='UNDER when the frozen rectangle covers less '
-                             'than this fraction of the OSM bbox '
-                             '(default 0.75)')
-    parser.add_argument('--over-ratio', type=float, default=4.0,
-                        help='OVER when frozen area exceeds this multiple '
-                             'of the OSM bbox area (default 4.0)')
-    parser.add_argument('--top', type=int, default=15,
-                        help='Worst offenders printed per verdict '
-                             '(default 15)')
+        description="Audit frozen search rectangles against OSM boundaries "
+        "(issue #91, step 1). Read-only on the catalog.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--data-dir", default=get_default_data_dir())
+    parser.add_argument(
+        "--cache", default=os.path.join(audit_dir, "nominatim_boundary_cache.jsonl")
+    )
+    parser.add_argument("--report", default=os.path.join(audit_dir, "boundary_audit_report.csv"))
+    parser.add_argument(
+        "--no-fetch",
+        action="store_true",
+        help="Classify from cache only (no network) — for "
+        "iterating on thresholds after a full fetch",
+    )
+    parser.add_argument(
+        "--refetch",
+        action="store_true",
+        help="Re-query cached cities too (appends; the newest record wins)",
+    )
+    parser.add_argument(
+        "--city", action="append", default=None, help="Restrict to this city_id (repeatable)"
+    )
+    parser.add_argument(
+        "--limit", type=int, default=None, help="Fetch at most N uncached cities (smoke test)"
+    )
+    parser.add_argument(
+        "--min-coverage",
+        type=float,
+        default=0.75,
+        help="UNDER when the frozen rectangle covers less "
+        "than this fraction of the OSM bbox "
+        "(default 0.75)",
+    )
+    parser.add_argument(
+        "--over-ratio",
+        type=float,
+        default=4.0,
+        help="OVER when frozen area exceeds this multiple of the OSM bbox area (default 4.0)",
+    )
+    parser.add_argument(
+        "--top", type=int, default=15, help="Worst offenders printed per verdict (default 15)"
+    )
     args = parser.parse_args()
 
     conn = db.connect(db.get_default_db_path(args.data_dir))
@@ -243,15 +299,13 @@ def main() -> int:
     if not args.no_fetch:
         n_errors = fetch_missing(cities, cache, args.cache, args.limit)
 
-    thresholds = Thresholds(min_coverage=args.min_coverage,
-                            over_area_ratio=args.over_ratio)
+    thresholds = Thresholds(min_coverage=args.min_coverage, over_area_ratio=args.over_ratio)
     rows = []
     for city in cities:
         if city.city_id in cache:
-            rows.append((city, classify(city, cache[city.city_id],
-                                        thresholds)))
+            rows.append((city, classify(city, cache[city.city_id], thresholds)))
         else:
-            rows.append((city, AuditResult(verdict='NOT_FETCHED')))
+            rows.append((city, AuditResult(verdict="NOT_FETCHED")))
 
     write_report(rows, args.report)
     print_summary(rows, args.top)
@@ -262,5 +316,5 @@ def main() -> int:
     return 0
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     sys.exit(main())

--- a/scripts/build_boundary_review.py
+++ b/scripts/build_boundary_review.py
@@ -39,13 +39,14 @@ import json
 import logging
 import os
 import sys
-from typing import Optional
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from gsv_metadata_tracker import db  # noqa: E402
 from gsv_metadata_tracker.boundary_audit import (  # noqa: E402
-    frozen_rect_bounds, rect_polygon_coverage)
+    frozen_rect_bounds,
+    rect_polygon_coverage,
+)
 from gsv_metadata_tracker.paths import get_default_data_dir  # noqa: E402
 
 logger = logging.getLogger("build_boundary_review")
@@ -60,7 +61,7 @@ META_PLACEHOLDER = "/*__META__*/"
 _COORD_DECIMALS = 5
 
 
-def _num(row: dict, key: str) -> Optional[float]:
+def _num(row: dict, key: str) -> float | None:
     """Parse a possibly-blank/NaN CSV cell to float, or None."""
     val = row.get(key, "")
     if val is None or val == "":
@@ -93,9 +94,15 @@ def _round_coords(obj):
     return obj
 
 
-def build_city_payload(city_id: str, *, group: str, current: Optional[dict],
-                       report: Optional[dict], rec_source: dict,
-                       cache: Optional[dict]) -> dict:
+def build_city_payload(
+    city_id: str,
+    *,
+    group: str,
+    current: dict | None,
+    report: dict | None,
+    rec_source: dict,
+    cache: dict | None,
+) -> dict:
     """
     Pure transform: assemble one city's viewer record from its already-parsed
     inputs. Network- and DB-free (all lookups are passed in), so it is directly
@@ -116,20 +123,25 @@ def build_city_payload(city_id: str, *, group: str, current: Optional[dict],
         A JSON-serializable dict with precomputed Leaflet bounds and overlays.
     """
     report = report or {}
-    display_name = (rec_source.get("display_name")
-                    or report.get("display_name") or city_id)
+    display_name = rec_source.get("display_name") or report.get("display_name") or city_id
     verdict = rec_source.get("verdict") or report.get("verdict") or ""
 
     # Frozen (current) grid rectangle — always from live catalog geometry.
     frozen_bounds = None
     frozen_geom = None
     if current is not None:
-        frozen_bounds = _rect_bounds(current["center_lat"], current["center_lon"],
-                                     current["grid_width_m"], current["grid_height_m"])
-        frozen_geom = {"center_lat": current["center_lat"],
-                       "center_lon": current["center_lon"],
-                       "width_m": current["grid_width_m"],
-                       "height_m": current["grid_height_m"]}
+        frozen_bounds = _rect_bounds(
+            current["center_lat"],
+            current["center_lon"],
+            current["grid_width_m"],
+            current["grid_height_m"],
+        )
+        frozen_geom = {
+            "center_lat": current["center_lat"],
+            "center_lon": current["center_lon"],
+            "width_m": current["grid_width_m"],
+            "height_m": current["grid_height_m"],
+        }
 
     # OSM bounding box — from the audit report's suggested center + bbox size.
     ob_lat, ob_lon = _num(report, "suggested_center_lat"), _num(report, "suggested_center_lon")
@@ -137,9 +149,16 @@ def build_city_payload(city_id: str, *, group: str, current: Optional[dict],
     osm_bbox_bounds = _rect_bounds(ob_lat, ob_lon, ob_w, ob_h)
     # ...and as a selectable center+size geometry (the reviewer can pick the OSM
     # bbox as the new grid), mirroring frozen_geom/rec_geom.
-    osm_bbox_geom = (None if None in (ob_lat, ob_lon, ob_w, ob_h)
-                     else {"center_lat": ob_lat, "center_lon": ob_lon,
-                           "width_m": int(ob_w), "height_m": int(ob_h)})
+    osm_bbox_geom = (
+        None
+        if None in (ob_lat, ob_lon, ob_w, ob_h)
+        else {
+            "center_lat": ob_lat,
+            "center_lon": ob_lon,
+            "width_m": int(ob_w),
+            "height_m": int(ob_h),
+        }
+    )
 
     # The resize group verifies an ALREADY-APPLIED fix: show the OLD (pre-fix)
     # rectangle from the audit report's frozen_* snapshot vs the current
@@ -151,17 +170,31 @@ def build_city_payload(city_id: str, *, group: str, current: Optional[dict],
         o_lat, o_lon = _num(report, "frozen_center_lat"), _num(report, "frozen_center_lon")
         o_w, o_h = _num(report, "frozen_width_m"), _num(report, "frozen_height_m")
         old_bounds = _rect_bounds(o_lat, o_lon, o_w, o_h)
-        old_geom = (None if None in (o_lat, o_lon, o_w, o_h)
-                    else {"center_lat": o_lat, "center_lon": o_lon,
-                          "width_m": int(o_w), "height_m": int(o_h)})
+        old_geom = (
+            None
+            if None in (o_lat, o_lon, o_w, o_h)
+            else {
+                "center_lat": o_lat,
+                "center_lon": o_lon,
+                "width_m": int(o_w),
+                "height_m": int(o_h),
+            }
+        )
         rec_basis = rec_source.get("reason", "")
     else:
         rc_lat, rc_lon = _num(rec_source, "rec_center_lat"), _num(rec_source, "rec_center_lon")
         rc_w, rc_h = _num(rec_source, "rec_width_m"), _num(rec_source, "rec_height_m")
         rec_bounds = _rect_bounds(rc_lat, rc_lon, rc_w, rc_h)
-        rec_geom = (None if None in (rc_lat, rc_lon, rc_w, rc_h)
-                    else {"center_lat": rc_lat, "center_lon": rc_lon,
-                          "width_m": int(rc_w), "height_m": int(rc_h)})
+        rec_geom = (
+            None
+            if None in (rc_lat, rc_lon, rc_w, rc_h)
+            else {
+                "center_lat": rc_lat,
+                "center_lon": rc_lon,
+                "width_m": int(rc_w),
+                "height_m": int(rc_h),
+            }
+        )
         rec_basis = rec_source.get("rec_basis", "")
 
     # OSM boundary polygon + representative point, from the Nominatim cache.
@@ -170,8 +203,10 @@ def build_city_payload(city_id: str, *, group: str, current: Optional[dict],
     raw = (cache or {}).get("raw") or {}
     geojson = raw.get("geojson")
     if isinstance(geojson, dict) and geojson.get("type") in ("Polygon", "MultiPolygon"):
-        osm_polygon = {"type": geojson["type"],
-                       "coordinates": _round_coords(geojson.get("coordinates", []))}
+        osm_polygon = {
+            "type": geojson["type"],
+            "coordinates": _round_coords(geojson.get("coordinates", [])),
+        }
     r_lat, r_lon = raw.get("lat"), raw.get("lon")
     if r_lat is not None and r_lon is not None:
         try:
@@ -186,8 +221,11 @@ def build_city_payload(city_id: str, *, group: str, current: Optional[dict],
         if not geom or not isinstance(geojson, dict):
             return None
         return rect_polygon_coverage(
-            geojson, frozen_rect_bounds(geom["center_lat"], geom["center_lon"],
-                                        geom["width_m"], geom["height_m"]))
+            geojson,
+            frozen_rect_bounds(
+                geom["center_lat"], geom["center_lon"], geom["width_m"], geom["height_m"]
+            ),
+        )
 
     coverage_current = _coverage(frozen_geom)
     coverage_before = _coverage(old_geom) if group == "resize" else None
@@ -224,13 +262,18 @@ def build_city_payload(city_id: str, *, group: str, current: Optional[dict],
 def _load_current_geometry(conn) -> dict:
     """Map city_id -> current frozen geometry dict, read live from the catalog."""
     rows = conn.execute(
-        "SELECT city_id, center_lat, center_lon, grid_width_m, grid_height_m, "
-        "step_m FROM cities").fetchall()
-    return {r["city_id"]: {"center_lat": r["center_lat"], "center_lon": r["center_lon"],
-                           "grid_width_m": r["grid_width_m"],
-                           "grid_height_m": r["grid_height_m"],
-                           "step_m": r["step_m"] or 20}
-            for r in rows}
+        "SELECT city_id, center_lat, center_lon, grid_width_m, grid_height_m, step_m FROM cities"
+    ).fetchall()
+    return {
+        r["city_id"]: {
+            "center_lat": r["center_lat"],
+            "center_lon": r["center_lon"],
+            "grid_width_m": r["grid_width_m"],
+            "grid_height_m": r["grid_height_m"],
+            "step_m": r["step_m"] or 20,
+        }
+        for r in rows
+    }
 
 
 def _estimate_points(geom: dict) -> int:
@@ -274,7 +317,7 @@ _CENTER_EPS_DEG = 1e-7
 _SIZE_EPS_M = 1.0
 
 
-def _resize_changed(report: Optional[dict], current: Optional[dict]) -> bool:
+def _resize_changed(report: dict | None, current: dict | None) -> bool:
     """
     True when a city's current (post-fix) geometry differs from the audit
     report's pre-fix ``frozen_*`` snapshot — i.e. the resize was actually
@@ -287,14 +330,22 @@ def _resize_changed(report: Optional[dict], current: Optional[dict]) -> bool:
     o_w, o_h = _num(report, "frozen_width_m"), _num(report, "frozen_height_m")
     if None in (o_lat, o_lon, o_w, o_h):
         return False
-    return (abs(o_lat - current["center_lat"]) > _CENTER_EPS_DEG or
-            abs(o_lon - current["center_lon"]) > _CENTER_EPS_DEG or
-            abs(o_w - current["grid_width_m"]) > _SIZE_EPS_M or
-            abs(o_h - current["grid_height_m"]) > _SIZE_EPS_M)
+    return (
+        abs(o_lat - current["center_lat"]) > _CENTER_EPS_DEG
+        or abs(o_lon - current["center_lon"]) > _CENTER_EPS_DEG
+        or abs(o_w - current["grid_width_m"]) > _SIZE_EPS_M
+        or abs(o_h - current["grid_height_m"]) > _SIZE_EPS_M
+    )
 
 
-def build_payloads(current_by_id: dict, report_by_id: dict, manual_by_id: dict,
-                   plan_by_id: dict, cache_by_id: dict, include_largest: int = 0):
+def build_payloads(
+    current_by_id: dict,
+    report_by_id: dict,
+    manual_by_id: dict,
+    plan_by_id: dict,
+    cache_by_id: dict,
+    include_largest: int = 0,
+):
     """
     Assemble the ordered list of viewer records for all reviewed cities.
 
@@ -311,10 +362,16 @@ def build_payloads(current_by_id: dict, report_by_id: dict, manual_by_id: dict,
     """
     payloads = []
     for city_id, row in manual_by_id.items():
-        payloads.append(build_city_payload(
-            city_id, group="manual", current=current_by_id.get(city_id),
-            report=report_by_id.get(city_id), rec_source=row,
-            cache=cache_by_id.get(city_id)))
+        payloads.append(
+            build_city_payload(
+                city_id,
+                group="manual",
+                current=current_by_id.get(city_id),
+                report=report_by_id.get(city_id),
+                rec_source=row,
+                cache=cache_by_id.get(city_id),
+            )
+        )
     skipped_resize = 0
     for city_id, row in plan_by_id.items():
         report = report_by_id.get(city_id)
@@ -322,21 +379,33 @@ def build_payloads(current_by_id: dict, report_by_id: dict, manual_by_id: dict,
         if not _resize_changed(report, current):
             skipped_resize += 1
             continue
-        payloads.append(build_city_payload(
-            city_id, group="resize", current=current, report=report,
-            rec_source=row, cache=cache_by_id.get(city_id)))
+        payloads.append(
+            build_city_payload(
+                city_id,
+                group="resize",
+                current=current,
+                report=report,
+                rec_source=row,
+                cache=cache_by_id.get(city_id),
+            )
+        )
 
     if include_largest > 0:
         seen = {p["city_id"] for p in payloads}
         ranked = sorted(
             ((cid, g) for cid, g in current_by_id.items() if cid not in seen),
-            key=lambda kv: _estimate_points(kv[1]), reverse=True)
+            key=lambda kv: _estimate_points(kv[1]),
+            reverse=True,
+        )
         for city_id, geom in ranked[:include_largest]:
             p = build_city_payload(
-                city_id, group="large", current=geom,
+                city_id,
+                group="large",
+                current=geom,
                 report=report_by_id.get(city_id),
                 rec_source=report_by_id.get(city_id) or {},
-                cache=cache_by_id.get(city_id))
+                cache=cache_by_id.get(city_id),
+            )
             p["points"] = _estimate_points(geom)
             payloads.append(p)
     return payloads, skipped_resize
@@ -347,8 +416,9 @@ def _json_for_script(obj) -> str:
     return json.dumps(obj, separators=(",", ":"), allow_nan=False).replace("</", "<\\/")
 
 
-def render_html(payloads: list, template_path: str = TEMPLATE_PATH,
-                meta: Optional[dict] = None) -> str:
+def render_html(
+    payloads: list, template_path: str = TEMPLATE_PATH, meta: dict | None = None
+) -> str:
     """Inject the payload JSON (and optional meta block) into the viewer template."""
     with open(template_path) as f:
         template = f.read()
@@ -362,25 +432,37 @@ def render_html(payloads: list, template_path: str = TEMPLATE_PATH,
 
 def main() -> int:
     parser = argparse.ArgumentParser(
-        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
-    parser.add_argument("--audit-dir", default=DEFAULT_AUDIT_DIR,
-                        help="directory holding the audit CSVs + cache (default: audit/)")
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument(
+        "--audit-dir",
+        default=DEFAULT_AUDIT_DIR,
+        help="directory holding the audit CSVs + cache (default: audit/)",
+    )
     parser.add_argument("--data-dir", default=get_default_data_dir())
-    parser.add_argument("--db-path", default=None,
-                        help="default: {data-dir}/gsv_tracker.db")
+    parser.add_argument("--db-path", default=None, help="default: {data-dir}/gsv_tracker.db")
     parser.add_argument("--template", default=TEMPLATE_PATH)
-    parser.add_argument("--out", default=None,
-                        help="output HTML (default: {audit-dir}/boundary_review.html)")
-    parser.add_argument("--log-level", default="WARNING",
-                        choices=["DEBUG", "INFO", "WARNING", "ERROR"])
-    parser.add_argument("--include-largest", type=int, default=0, metavar="N",
-                        help="also review the N largest-by-grid-points cities not "
-                             "already flagged (a 'LARGE' group), to sanity-check "
-                             "whether the biggest rectangles are justified")
+    parser.add_argument(
+        "--out", default=None, help="output HTML (default: {audit-dir}/boundary_review.html)"
+    )
+    parser.add_argument(
+        "--log-level", default="WARNING", choices=["DEBUG", "INFO", "WARNING", "ERROR"]
+    )
+    parser.add_argument(
+        "--include-largest",
+        type=int,
+        default=0,
+        metavar="N",
+        help="also review the N largest-by-grid-points cities not "
+        "already flagged (a 'LARGE' group), to sanity-check "
+        "whether the biggest rectangles are justified",
+    )
     args = parser.parse_args()
 
-    logging.basicConfig(level=getattr(logging, args.log_level),
-                        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+    logging.basicConfig(
+        level=getattr(logging, args.log_level),
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    )
 
     db_path = args.db_path or db.get_default_db_path(args.data_dir)
     out_path = args.out or os.path.join(args.audit_dir, "boundary_review.html")
@@ -403,7 +485,8 @@ def main() -> int:
         _load_csv_by_id(manual_path),
         _load_csv_by_id(plan_path),
         _load_cache(cache_path),
-        include_largest=args.include_largest)
+        include_largest=args.include_largest,
+    )
 
     n_manual = sum(1 for p in payloads if p["group"] == "manual")
     n_resize = sum(1 for p in payloads if p["group"] == "resize")

--- a/scripts/harvest_gsv_history.py
+++ b/scripts/harvest_gsv_history.py
@@ -36,7 +36,9 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from gsv_metadata_tracker import db  # noqa: E402
 from gsv_metadata_tracker.download_gsv_history import (  # noqa: E402
-    HarvestBlockedError, harvest_gsv_history_async)
+    HarvestBlockedError,
+    harvest_gsv_history_async,
+)
 from gsv_metadata_tracker.naming import generate_history_filename  # noqa: E402
 from gsv_metadata_tracker.paths import get_default_data_dir  # noqa: E402
 
@@ -44,18 +46,29 @@ from gsv_metadata_tracker.paths import get_default_data_dir  # noqa: E402
 def parse_args():
     p = argparse.ArgumentParser(
         description="Harvest full official-Google capture-date history for a "
-                    "city from an unpublished endpoint (issue #2).")
+        "city from an unpublished endpoint (issue #2)."
+    )
     p.add_argument("city", help="City query or slug (must already be registered)")
-    p.add_argument("--data-dir", default=get_default_data_dir(),
-                   help="Directory for the output csv.gz (default: ./data)")
-    p.add_argument("--db-path", default=None,
-                   help="Catalog DB path (default: <data-dir>/gsv_tracker.db)")
-    p.add_argument("--harvest-date", default=None,
-                   help="ISO date recorded for this harvest (default: today)")
-    p.add_argument("--force", action="store_true",
-                   help="Re-harvest even if this date's file already exists")
-    p.add_argument("--connection-limit", type=int, default=2,
-                   help="Max concurrent requests — keep low (default: 2)")
+    p.add_argument(
+        "--data-dir",
+        default=get_default_data_dir(),
+        help="Directory for the output csv.gz (default: ./data)",
+    )
+    p.add_argument(
+        "--db-path", default=None, help="Catalog DB path (default: <data-dir>/gsv_tracker.db)"
+    )
+    p.add_argument(
+        "--harvest-date", default=None, help="ISO date recorded for this harvest (default: today)"
+    )
+    p.add_argument(
+        "--force", action="store_true", help="Re-harvest even if this date's file already exists"
+    )
+    p.add_argument(
+        "--connection-limit",
+        type=int,
+        default=2,
+        help="Max concurrent requests — keep low (default: 2)",
+    )
     p.add_argument("--verbose", action="store_true", help="Debug logging")
     return p.parse_args()
 
@@ -63,38 +76,46 @@ def parse_args():
 async def _run(args) -> int:
     logging.basicConfig(
         level=logging.DEBUG if args.verbose else logging.INFO,
-        format="%(asctime)s %(levelname)s %(name)s: %(message)s")
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
 
-    harvest_date = (date.fromisoformat(args.harvest_date)
-                    if args.harvest_date else date.today())
+    harvest_date = date.fromisoformat(args.harvest_date) if args.harvest_date else date.today()
     db_path = args.db_path or db.get_default_db_path(args.data_dir)
 
     conn = db.connect(db_path)
     city = db.resolve_city(conn, args.city)
     if city is None:
-        print(f"City {args.city!r} is not registered in the catalog. Run a "
-              f"normal collection first (python gsv_tracker.py \"{args.city}\") "
-              f"so its grid geometry is frozen, then harvest history.",
-              file=sys.stderr)
+        print(
+            f"City {args.city!r} is not registered in the catalog. Run a "
+            f'normal collection first (python gsv_tracker.py "{args.city}") '
+            f"so its grid geometry is frozen, then harvest history.",
+            file=sys.stderr,
+        )
         return 2
 
     base = generate_history_filename(
-        city.city_id, city.grid_width_m, city.grid_height_m, city.step_m,
-        harvest_date)
+        city.city_id, city.grid_width_m, city.grid_height_m, city.step_m, harvest_date
+    )
     output_csv_gz_path = os.path.join(args.data_dir, f"{base}.csv.gz")
 
     if os.path.exists(output_csv_gz_path) and not args.force:
-        print(f"A history harvest already exists for {city.city_id} on "
-              f"{harvest_date} ({os.path.basename(output_csv_gz_path)}). "
-              f"Use --force to re-harvest.")
+        print(
+            f"A history harvest already exists for {city.city_id} on "
+            f"{harvest_date} ({os.path.basename(output_csv_gz_path)}). "
+            f"Use --force to re-harvest."
+        )
         return 0
 
     print(f"City: {city.display_name} ({city.city_id})")
-    print(f"Grid: {city.grid_width_m}m x {city.grid_height_m}m, "
-          f"step {city.step_m}m, centered at "
-          f"{city.center_lat:.5f}, {city.center_lon:.5f}")
-    print(f"Harvesting official-Google capture-date history "
-          f"(gentle mode, connection_limit={args.connection_limit})...")
+    print(
+        f"Grid: {city.grid_width_m}m x {city.grid_height_m}m, "
+        f"step {city.step_m}m, centered at "
+        f"{city.center_lat:.5f}, {city.center_lon:.5f}"
+    )
+    print(
+        f"Harvesting official-Google capture-date history "
+        f"(gentle mode, connection_limit={args.connection_limit})..."
+    )
 
     try:
         result = await harvest_gsv_history_async(
@@ -112,19 +133,25 @@ async def _run(args) -> int:
         return 1
 
     db.register_history_harvest(
-        conn, city_id=city.city_id, harvest_date=harvest_date,
+        conn,
+        city_id=city.city_id,
+        harvest_date=harvest_date,
         csv_filename=os.path.basename(output_csv_gz_path),
         grid_points_queried=result["grid_points"],
         unique_panos=result["unique_panos"],
         oldest_capture_date=result["oldest_capture_date"],
         newest_capture_date=result["newest_capture_date"],
         api_requests=result["api_requests"],
-        started_at=result["started_at"], finished_at=result["finished_at"])
+        started_at=result["started_at"],
+        finished_at=result["finished_at"],
+    )
 
-    print(f"Done: {result['unique_panos']} unique official Google panos, "
-          f"capture dates {result['oldest_capture_date']}..."
-          f"{result['newest_capture_date']}, from {result['api_requests']} "
-          f"searches.")
+    print(
+        f"Done: {result['unique_panos']} unique official Google panos, "
+        f"capture dates {result['oldest_capture_date']}..."
+        f"{result['newest_capture_date']}, from {result['api_requests']} "
+        f"searches."
+    )
     print(f"Wrote {output_csv_gz_path}")
     return 0
 

--- a/scripts/import_archival_scrapes.py
+++ b/scripts/import_archival_scrapes.py
@@ -45,7 +45,6 @@ import os
 import sys
 from dataclasses import dataclass
 from datetime import date
-from typing import List, Optional, Tuple
 
 import pandas as pd
 from geopy.distance import geodesic
@@ -57,17 +56,21 @@ from gsv_metadata_tracker.analysis import calculate_run_stats  # noqa: E402
 from gsv_metadata_tracker.config import METADATA_DTYPES  # noqa: E402
 from gsv_metadata_tracker.fileutils import load_city_csv_file  # noqa: E402
 from gsv_metadata_tracker.geoutils import (  # noqa: E402
-    get_city_location_data, get_state_abbreviation, get_country_code)
+    get_city_location_data,
+    get_country_code,
+    get_state_abbreviation,
+)
 from gsv_metadata_tracker.json_summarizer import (  # noqa: E402
-    generate_aggregate_v2, generate_city_metadata_summary_as_json)
+    generate_aggregate_v2,
+    generate_city_metadata_summary_as_json,
+)
 from gsv_metadata_tracker.naming import generate_run_filename  # noqa: E402
 from gsv_metadata_tracker.paths import get_default_data_dir  # noqa: E402
 
 logger = logging.getLogger("archival_import")
 
 ARCHIVAL_STEP_M = 30  # the predecessor scraper's grid step
-DEFAULT_SOURCE_ROOT = os.path.expanduser(
-    "~/Git/gsv-capture-dates/gsv-bias-scraper/data")
+DEFAULT_SOURCE_ROOT = os.path.expanduser("~/Git/gsv-capture-dates/gsv-bias-scraper/data")
 NEW_CITY_STEP_M = 20  # frozen step for freshly registered cities
 
 COLUMNS = list(METADATA_DTYPES.keys())
@@ -76,15 +79,16 @@ COLUMNS = list(METADATA_DTYPES.keys())
 @dataclass(frozen=True)
 class ArchivalDataset:
     """One source CSV to import."""
-    rel_csv: str    # csv path relative to --source-root
-    query: str      # geocodable query string; also the catalog lookup key
+
+    rel_csv: str  # csv path relative to --source-root
+    query: str  # geocodable query string; also the catalog lookup key
     run_date: date  # git first-commit date of the csv (the scrape date)
-    fmt: str        # 'v1' | 'v2' | 'v2_headerless'
+    fmt: str  # 'v1' | 'v2' | 'v2_headerless'
     # (city_name, state_name, country_name) override for locality-grade
     # datasets that Nominatim resolves to their parent city (East Hollywood
     # -> Los Angeles, Reinsletta -> Bodø). Registration then uses these
     # names with the archival extent as the frozen geometry — no geocoding.
-    identity: Optional[Tuple[str, str, str]] = None
+    identity: tuple[str, str, str] | None = None
 
 
 # Run dates are the git first-commit dates of each CSV in the
@@ -92,72 +96,140 @@ class ArchivalDataset:
 # rel_csv from the query: the Washington D.C. basenames carry a trailing
 # period and their two directories share one basename.
 MANIFEST = [
-    ArchivalDataset("Berkeley/Berkeley_30_coords.csv",
-                    "Berkeley, California", date(2023, 11, 5), "v2_headerless"),
-    ArchivalDataset("Burnaby, Canada/Burnaby, Canada_30_coords.csv",
-                    "Burnaby, British Columbia, Canada", date(2023, 11, 3), "v2"),
-    ArchivalDataset("Chicago/Chicago_30_coords.csv",
-                    "Chicago, Illinois", date(2023, 11, 5), "v2_headerless"),
-    ArchivalDataset("Cuenca, Ecuador/Cuenca, Ecuador_30_coords.csv",
-                    "Cuenca, Ecuador", date(2023, 12, 12), "v2"),
-    ArchivalDataset("Denison, Texas/Denison, Texas_30_coords.csv",
-                    "Denison, Texas", date(2023, 12, 5), "v2"),
-    ArchivalDataset("East Hollywood, CA/East Hollywood, CA_30_coords.csv",
-                    "East Hollywood, Los Angeles, CA", date(2023, 11, 3), "v2",
-                    identity=("East Hollywood", "California", "United States")),
-    ArchivalDataset("Hamilton, New Zealand/Hamilton, New Zealand_30_coords.csv",
-                    "Hamilton, New Zealand", date(2023, 11, 3), "v2"),
+    ArchivalDataset(
+        "Berkeley/Berkeley_30_coords.csv",
+        "Berkeley, California",
+        date(2023, 11, 5),
+        "v2_headerless",
+    ),
+    ArchivalDataset(
+        "Burnaby, Canada/Burnaby, Canada_30_coords.csv",
+        "Burnaby, British Columbia, Canada",
+        date(2023, 11, 3),
+        "v2",
+    ),
+    ArchivalDataset(
+        "Chicago/Chicago_30_coords.csv", "Chicago, Illinois", date(2023, 11, 5), "v2_headerless"
+    ),
+    ArchivalDataset(
+        "Cuenca, Ecuador/Cuenca, Ecuador_30_coords.csv", "Cuenca, Ecuador", date(2023, 12, 12), "v2"
+    ),
+    ArchivalDataset(
+        "Denison, Texas/Denison, Texas_30_coords.csv", "Denison, Texas", date(2023, 12, 5), "v2"
+    ),
+    ArchivalDataset(
+        "East Hollywood, CA/East Hollywood, CA_30_coords.csv",
+        "East Hollywood, Los Angeles, CA",
+        date(2023, 11, 3),
+        "v2",
+        identity=("East Hollywood", "California", "United States"),
+    ),
+    ArchivalDataset(
+        "Hamilton, New Zealand/Hamilton, New Zealand_30_coords.csv",
+        "Hamilton, New Zealand",
+        date(2023, 11, 3),
+        "v2",
+    ),
     # Queries below match existing catalog display_names exactly (these
     # cities gained Dec-2024 baselines via the legacy migration; the
     # archival runs become their earlier first runs). La Piedad attaches
     # to the real identity, not the la_piedad_mx junk-slug squatter (#92).
     ArchivalDataset(
         "La Piedad de Cabadas, Mexico/La Piedad de Cabadas, Mexico_30_coords.csv",
-        "La Piedad, Michoacán, Mexico", date(2024, 10, 3), "v2"),
-    ArchivalDataset("Mendota, Illinois/Mendota, Illinois_30_coords.csv",
-                    "Mendota, Illinois, United States", date(2024, 7, 8), "v2"),
-    ArchivalDataset("Mt Vernon, Ohio/Mt Vernon, Ohio_30_coords.csv",
-                    "Mount Vernon, Ohio, United States", date(2024, 5, 8), "v2"),
-    ArchivalDataset("Oradell, New Jersey/Oradell, New Jersey_30_coords.csv",
-                    "Oradell, New Jersey, United States", date(2023, 11, 3), "v2"),
-    ArchivalDataset("Pittsburgh, Pennsylvania/Pittsburgh, Pennsylvania_30_coords.csv",
-                    "Pittsburgh, Pennsylvania, United States", date(2023, 11, 3), "v2"),
-    ArchivalDataset("Point Roberts, WA/Point Roberts, WA_30_coords.csv",
-                    "Point Roberts, WA", date(2023, 11, 5), "v1"),
-    ArchivalDataset("Reinsletta, Norway/Reinsletta, Norway_30_coords.csv",
-                    "Reinsletta, Norway", date(2024, 3, 25), "v2",
-                    identity=("Reinsletta", "Nordland", "Norway")),
-    ArchivalDataset("Riverdale Park, Maryland/Riverdale Park, Maryland_30_coords.csv",
-                    "Riverdale Park, Maryland", date(2024, 2, 14), "v2"),
-    ArchivalDataset("Seattle/Seattle_30_coords.csv",
-                    "Seattle, WA", date(2023, 11, 5), "v1"),
+        "La Piedad, Michoacán, Mexico",
+        date(2024, 10, 3),
+        "v2",
+    ),
+    ArchivalDataset(
+        "Mendota, Illinois/Mendota, Illinois_30_coords.csv",
+        "Mendota, Illinois, United States",
+        date(2024, 7, 8),
+        "v2",
+    ),
+    ArchivalDataset(
+        "Mt Vernon, Ohio/Mt Vernon, Ohio_30_coords.csv",
+        "Mount Vernon, Ohio, United States",
+        date(2024, 5, 8),
+        "v2",
+    ),
+    ArchivalDataset(
+        "Oradell, New Jersey/Oradell, New Jersey_30_coords.csv",
+        "Oradell, New Jersey, United States",
+        date(2023, 11, 3),
+        "v2",
+    ),
+    ArchivalDataset(
+        "Pittsburgh, Pennsylvania/Pittsburgh, Pennsylvania_30_coords.csv",
+        "Pittsburgh, Pennsylvania, United States",
+        date(2023, 11, 3),
+        "v2",
+    ),
+    ArchivalDataset(
+        "Point Roberts, WA/Point Roberts, WA_30_coords.csv",
+        "Point Roberts, WA",
+        date(2023, 11, 5),
+        "v1",
+    ),
+    ArchivalDataset(
+        "Reinsletta, Norway/Reinsletta, Norway_30_coords.csv",
+        "Reinsletta, Norway",
+        date(2024, 3, 25),
+        "v2",
+        identity=("Reinsletta", "Nordland", "Norway"),
+    ),
+    ArchivalDataset(
+        "Riverdale Park, Maryland/Riverdale Park, Maryland_30_coords.csv",
+        "Riverdale Park, Maryland",
+        date(2024, 2, 14),
+        "v2",
+    ),
+    ArchivalDataset("Seattle/Seattle_30_coords.csv", "Seattle, WA", date(2023, 11, 5), "v1"),
     # Query matches the catalog display_name exactly: "St. Louis, Missouri"
     # alone resolves nothing, and re-geocoding risks identity drift
-    ArchivalDataset("St. Louis, Missouri/St. Louis, Missouri_30_coords.csv",
-                    "St. Louis, Missouri, United States", date(2024, 3, 19), "v2"),
-    ArchivalDataset("Swissvale, Pennsylvania/Swissvale, Pennsylvania_30_coords.csv",
-                    "Swissvale, Pennsylvania", date(2024, 2, 21), "v2"),
-    ArchivalDataset("Washington D.C/Washington D.C._30_coords.csv",
-                    "Washington, D.C.", date(2023, 11, 3), "v2"),
-    ArchivalDataset("Washington D.C 10000x10000/Washington D.C._30_coords.csv",
-                    "Washington, D.C.", date(2024, 4, 11), "v2"),
+    ArchivalDataset(
+        "St. Louis, Missouri/St. Louis, Missouri_30_coords.csv",
+        "St. Louis, Missouri, United States",
+        date(2024, 3, 19),
+        "v2",
+    ),
+    ArchivalDataset(
+        "Swissvale, Pennsylvania/Swissvale, Pennsylvania_30_coords.csv",
+        "Swissvale, Pennsylvania",
+        date(2024, 2, 21),
+        "v2",
+    ),
+    ArchivalDataset(
+        "Washington D.C/Washington D.C._30_coords.csv", "Washington, D.C.", date(2023, 11, 3), "v2"
+    ),
+    ArchivalDataset(
+        "Washington D.C 10000x10000/Washington D.C._30_coords.csv",
+        "Washington, D.C.",
+        date(2024, 4, 11),
+        "v2",
+    ),
     # Query matches the catalog display_name exactly: a fresh geocode can
     # return "Zürich" (umlaut) and would mint a duplicate city_id
-    ArchivalDataset("Zurich, Switzerland/Zurich, Switzerland_30_coords.csv",
-                    "Zurich, Zurich, Switzerland", date(2023, 11, 3), "v2"),
+    ArchivalDataset(
+        "Zurich, Switzerland/Zurich, Switzerland_30_coords.csv",
+        "Zurich, Zurich, Switzerland",
+        date(2023, 11, 3),
+        "v2",
+    ),
 ]
 
 # Source datasets deliberately NOT imported (always listed in the report).
 SKIPPED = [
-    ("Burnaby, Canada - Old/Burnaby, Canada_30_coords.csv",
-     "35-row aborted run"),
-    ("East Hollywood, CA - Old/East Hollywood, CA_30_coords.csv",
-     "35-row aborted run"),
-    ("La Piedad de Cabadas, Mexico - 1k x 1k/La Piedad de Cabadas, Mexico_30_coords.csv",
-     "35-row aborted run"),
-    ("Reinsletta, Norway 7500x5000m/Reinsletta, Norway_30_coords.csv",
-     "smaller variant of the imported Reinsletta run, same scrape date "
-     "(runs are unique per city+date)"),
+    ("Burnaby, Canada - Old/Burnaby, Canada_30_coords.csv", "35-row aborted run"),
+    ("East Hollywood, CA - Old/East Hollywood, CA_30_coords.csv", "35-row aborted run"),
+    (
+        "La Piedad de Cabadas, Mexico - 1k x 1k/La Piedad de Cabadas, Mexico_30_coords.csv",
+        "35-row aborted run",
+    ),
+    (
+        "Reinsletta, Norway 7500x5000m/Reinsletta, Norway_30_coords.csv",
+        "smaller variant of the imported Reinsletta run, same scrape date "
+        "(runs are unique per city+date)",
+    ),
 ]
 
 V2_HEADER = ["lat", "lon", "query_lat", "query_lon", "pano_id", "date", "status"]
@@ -165,7 +237,7 @@ V2_HEADER = ["lat", "lon", "query_lat", "query_lon", "pano_id", "date", "status"
 
 def sniff_format(path: str) -> str:
     """Detect the source format from the first line; see MANIFEST fmt."""
-    with open(path, "r", encoding="utf-8") as f:
+    with open(path, encoding="utf-8") as f:
         first = f.readline().strip()
     fields = first.split(",")
     if fields[:3] == V2_HEADER[:3]:
@@ -189,34 +261,45 @@ def read_archival_csv(path: str, fmt: str, run_date: date) -> pd.DataFrame:
     """
     sniffed = sniff_format(path)
     if sniffed != fmt:
-        raise ValueError(
-            f"{path}: manifest says format {fmt!r} but file sniffs as {sniffed!r}")
+        raise ValueError(f"{path}: manifest says format {fmt!r} but file sniffs as {sniffed!r}")
 
     if fmt == "v1":
-        raw = pd.read_csv(path, header=None,
-                          names=["c1", "c2", "pano_id", "capture_date", "status"],
-                          dtype=str, keep_default_na=False)
+        raw = pd.read_csv(
+            path,
+            header=None,
+            names=["c1", "c2", "pano_id", "capture_date", "status"],
+            dtype=str,
+            keep_default_na=False,
+        )
         query_lat, query_lon = raw["c1"], raw["c2"]
         pano_lat, pano_lon = raw["c1"], raw["c2"]
     else:
-        raw = pd.read_csv(path, header=0 if fmt == "v2" else None,
-                          names=V2_HEADER, dtype=str, keep_default_na=False)
+        raw = pd.read_csv(
+            path,
+            header=0 if fmt == "v2" else None,
+            names=V2_HEADER,
+            dtype=str,
+            keep_default_na=False,
+        )
         raw = raw.rename(columns={"date": "capture_date"})
         query_lat, query_lon = raw["query_lat"], raw["query_lon"]
         pano_lat, pano_lon = raw["lat"], raw["lon"]
 
     ok = raw["status"].str.strip() == ""
-    df = pd.DataFrame({
-        "query_lat": query_lat,
-        "query_lon": query_lon,
-        "query_timestamp": f"{run_date.isoformat()}T00:00:00+00:00",
-        "pano_lat": pano_lat.where(ok, ""),
-        "pano_lon": pano_lon.where(ok, ""),
-        "pano_id": raw["pano_id"].replace("None", ""),
-        "capture_date": raw["capture_date"].replace("None", ""),
-        "copyright_info": "",  # never captured; unknown, not blank-Google
-        "status": raw["status"].where(~ok, "OK"),
-    }, columns=COLUMNS)
+    df = pd.DataFrame(
+        {
+            "query_lat": query_lat,
+            "query_lon": query_lon,
+            "query_timestamp": f"{run_date.isoformat()}T00:00:00+00:00",
+            "pano_lat": pano_lat.where(ok, ""),
+            "pano_lon": pano_lon.where(ok, ""),
+            "pano_id": raw["pano_id"].replace("None", ""),
+            "capture_date": raw["capture_date"].replace("None", ""),
+            "copyright_info": "",  # never captured; unknown, not blank-Google
+            "status": raw["status"].where(~ok, "OK"),
+        },
+        columns=COLUMNS,
+    )
 
     # Old scraper wrote YYYY-MM; current convention is first-of-month
     month_only = df["capture_date"].str.match(r"^\d{4}-\d{2}$")
@@ -224,7 +307,7 @@ def read_archival_csv(path: str, fmt: str, run_date: date) -> pd.DataFrame:
     return df
 
 
-def dims_from_extent(csv_path: str, df: pd.DataFrame) -> Tuple[int, int, float, float]:
+def dims_from_extent(csv_path: str, df: pd.DataFrame) -> tuple[int, int, float, float]:
     """
     Grid extent for the output filename: (width_m, height_m, center_lat,
     center_lon). Prefers the sibling bounding_box.json; axis values are
@@ -233,7 +316,7 @@ def dims_from_extent(csv_path: str, df: pd.DataFrame) -> Tuple[int, int, float, 
     """
     bbox_path = os.path.join(os.path.dirname(csv_path), "bounding_box.json")
     if os.path.exists(bbox_path):
-        with open(bbox_path, "r", encoding="utf-8") as f:
+        with open(bbox_path, encoding="utf-8") as f:
             bb = json.load(f)
         south, north = sorted((float(bb["ymin"]), float(bb["ymax"])))
         west, east = sorted((float(bb["xmin"]), float(bb["xmax"])))
@@ -249,7 +332,7 @@ def dims_from_extent(csv_path: str, df: pd.DataFrame) -> Tuple[int, int, float, 
     return max(1, round(width)), max(1, round(height)), mid_lat, (west + east) / 2
 
 
-def dims_from_boundingbox_raw(loc) -> Tuple[int, int]:
+def dims_from_boundingbox_raw(loc) -> tuple[int, int]:
     """
     Frozen-geometry rectangle from a geocoded location's Nominatim
     boundingbox ([south, north, west, east] strings). Mirrors
@@ -267,11 +350,14 @@ def dims_from_boundingbox_raw(loc) -> Tuple[int, int]:
     return max(1, round(width)), max(1, round(height))
 
 
-def resolve_or_register_city(conn, entry: ArchivalDataset,
-                             center: Tuple[float, float],
-                             extent: Tuple[int, int],
-                             use_nominatim: bool,
-                             execute: bool):
+def resolve_or_register_city(
+    conn,
+    entry: ArchivalDataset,
+    center: tuple[float, float],
+    extent: tuple[int, int],
+    use_nominatim: bool,
+    execute: bool,
+):
     """
     Resolve the entry's city in the catalog, registering it if unknown.
     Returns (CityRow | None, note); a None CityRow means not importable
@@ -306,9 +392,10 @@ def resolve_or_register_city(conn, entry: ArchivalDataset,
             grid_height_m=extent[1],
             step_m=NEW_CITY_STEP_M,
         )
-        return (db.resolve_city(conn, city_id),
-                f"NEW city registered from manifest identity "
-                f"({extent[0]}x{extent[1]}m)")
+        return (
+            db.resolve_city(conn, city_id),
+            f"NEW city registered from manifest identity ({extent[0]}x{extent[1]}m)",
+        )
 
     if not use_nominatim:
         return None, "needs geocoding (--no-nominatim)"
@@ -335,43 +422,58 @@ def resolve_or_register_city(conn, entry: ArchivalDataset,
     return db.resolve_city(conn, city_id), f"NEW city registered ({width}x{height}m)"
 
 
-def load_manifest_override(path: str) -> List[ArchivalDataset]:
+def load_manifest_override(path: str) -> list[ArchivalDataset]:
     """Load a manifest override (JSON list of dataset dicts) — for tests."""
-    with open(path, "r", encoding="utf-8") as f:
+    with open(path, encoding="utf-8") as f:
         entries = json.load(f)
-    return [ArchivalDataset(rel_csv=e["rel_csv"], query=e["query"],
-                            run_date=date.fromisoformat(e["run_date"]),
-                            fmt=e["fmt"],
-                            identity=(tuple(e["identity"])
-                                      if e.get("identity") else None))
-            for e in entries]
+    return [
+        ArchivalDataset(
+            rel_csv=e["rel_csv"],
+            query=e["query"],
+            run_date=date.fromisoformat(e["run_date"]),
+            fmt=e["fmt"],
+            identity=(tuple(e["identity"]) if e.get("identity") else None),
+        )
+        for e in entries
+    ]
 
 
 def main() -> int:
-    parser = argparse.ArgumentParser(description=__doc__,
-                                     formatter_class=argparse.RawDescriptionHelpFormatter)
-    parser.add_argument('--source-root', default=DEFAULT_SOURCE_ROOT,
-                        help='gsv-bias-scraper data directory')
-    parser.add_argument('--data-dir', default=get_default_data_dir())
-    parser.add_argument('--db-path', default=None,
-                        help='default: {data-dir}/gsv_tracker.db')
-    parser.add_argument('--manifest', default=None,
-                        help='JSON manifest overriding the embedded one (tests)')
-    parser.add_argument('--execute', action='store_true',
-                        help='Apply changes (default is a dry run)')
-    parser.add_argument('--no-nominatim', action='store_true',
-                        help='Never geocode; unknown cities are reported and skipped')
-    parser.add_argument('--no-publish-json', action='store_true',
-                        help='Skip regenerating the aggregate cities.json.gz')
-    parser.add_argument('--log-level', default='WARNING',
-                        choices=['DEBUG', 'INFO', 'WARNING', 'ERROR'])
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument(
+        "--source-root", default=DEFAULT_SOURCE_ROOT, help="gsv-bias-scraper data directory"
+    )
+    parser.add_argument("--data-dir", default=get_default_data_dir())
+    parser.add_argument("--db-path", default=None, help="default: {data-dir}/gsv_tracker.db")
+    parser.add_argument(
+        "--manifest", default=None, help="JSON manifest overriding the embedded one (tests)"
+    )
+    parser.add_argument(
+        "--execute", action="store_true", help="Apply changes (default is a dry run)"
+    )
+    parser.add_argument(
+        "--no-nominatim",
+        action="store_true",
+        help="Never geocode; unknown cities are reported and skipped",
+    )
+    parser.add_argument(
+        "--no-publish-json",
+        action="store_true",
+        help="Skip regenerating the aggregate cities.json.gz",
+    )
+    parser.add_argument(
+        "--log-level", default="WARNING", choices=["DEBUG", "INFO", "WARNING", "ERROR"]
+    )
     args = parser.parse_args()
 
-    logging.basicConfig(level=getattr(logging, args.log_level),
-                        format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+    logging.basicConfig(
+        level=getattr(logging, args.log_level),
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    )
 
-    manifest = (load_manifest_override(args.manifest) if args.manifest
-                else MANIFEST)
+    manifest = load_manifest_override(args.manifest) if args.manifest else MANIFEST
     db_path = args.db_path or db.get_default_db_path(args.data_dir)
     mode = "EXECUTE" if args.execute else "DRY RUN"
     print(f"=== Archival scrape import ({mode}) ===")
@@ -396,8 +498,13 @@ def main() -> int:
         n_ok = int((df["status"] == "OK").sum())
 
         city_row, note = resolve_or_register_city(
-            conn, entry, (center_lat, center_lon), (width, height),
-            use_nominatim=not args.no_nominatim, execute=args.execute)
+            conn,
+            entry,
+            (center_lat, center_lon),
+            (width, height),
+            use_nominatim=not args.no_nominatim,
+            execute=args.execute,
+        )
         if city_row is None:
             if note.startswith("NEW:"):
                 # Dry run: the canonical city_id (and thus the output
@@ -405,54 +512,62 @@ def main() -> int:
                 # known at execute time. A "new" entry may even resolve to
                 # an existing city once geocoded.
                 report_lines.append(
-                    f"  IMPORT   {label}: {note} "
-                    f"({len(df)} rows, {n_ok} OK, {width}x{height}m)")
+                    f"  IMPORT   {label}: {note} ({len(df)} rows, {n_ok} OK, {width}x{height}m)"
+                )
                 n_imported += 1
             else:
                 report_lines.append(f"  SKIP     {label}: {note}")
                 n_skipped += 1
             continue
 
-        csv_filename = generate_run_filename(
-            city_row.city_id, width, height, ARCHIVAL_STEP_M,
-            entry.run_date) + ".csv.gz"
+        csv_filename = (
+            generate_run_filename(city_row.city_id, width, height, ARCHIVAL_STEP_M, entry.run_date)
+            + ".csv.gz"
+        )
 
-        if conn.execute("SELECT 1 FROM runs WHERE csv_filename = ?",
-                        (csv_filename,)).fetchone():
+        if conn.execute("SELECT 1 FROM runs WHERE csv_filename = ?", (csv_filename,)).fetchone():
             report_lines.append(f"  ALREADY  {label} -> {csv_filename}")
             n_already += 1
             continue
         if conn.execute(
-                "SELECT 1 FROM runs WHERE city_id = ? AND provider = 'gsv' "
-                "AND run_date = ?",
-                (city_row.city_id, entry.run_date.isoformat())).fetchone():
+            "SELECT 1 FROM runs WHERE city_id = ? AND provider = 'gsv' AND run_date = ?",
+            (city_row.city_id, entry.run_date.isoformat()),
+        ).fetchone():
             report_lines.append(
-                f"  SKIP     {label}: {city_row.city_id} already has a gsv "
-                f"run on {entry.run_date}")
+                f"  SKIP     {label}: {city_row.city_id} already has a gsv run on {entry.run_date}"
+            )
             n_skipped += 1
             continue
 
         report_lines.append(
             f"  IMPORT   {label} -> {csv_filename} "
-            f"({len(df)} rows, {n_ok} OK, {width}x{height}m; {note})")
+            f"({len(df)} rows, {n_ok} OK, {width}x{height}m; {note})"
+        )
 
         if not args.execute:
             n_imported += 1
             continue
 
         csv_path = os.path.join(args.data_dir, csv_filename)
-        with gzip.open(csv_path, 'wt', encoding='utf-8', newline='') as f:
+        with gzip.open(csv_path, "wt", encoding="utf-8", newline="") as f:
             df.to_csv(f, index=False)
 
         # Reload through the canonical loader so stats and JSON are computed
         # from the same dtypes as any live run
         df_loaded = load_city_csv_file(csv_path)
         json_path = generate_city_metadata_summary_as_json(
-            csv_path, df_loaded,
-            city_row.city_name, city_row.state_name, city_row.country_name,
-            width, height, ARCHIVAL_STEP_M,
-            force_recreate_file=True, run_date=entry.run_date,
-            is_baseline=True)
+            csv_path,
+            df_loaded,
+            city_row.city_name,
+            city_row.state_name,
+            city_row.country_name,
+            width,
+            height,
+            ARCHIVAL_STEP_M,
+            force_recreate_file=True,
+            run_date=entry.run_date,
+            is_baseline=True,
+        )
         stats = calculate_run_stats(df_loaded, entry.run_date)
         # api_requests stays NULL and no api_usage row: that budget was
         # spent in 2023/24, not today. No diff either — archival runs are
@@ -471,17 +586,18 @@ def main() -> int:
 
     # ── Report ────────────────────────────────────────────────────────────
     verb = "Imported" if args.execute else "Would import"
-    print(f"{verb}: {n_imported}   already registered: {n_already}   "
-          f"skipped: {n_skipped}\n")
+    print(f"{verb}: {n_imported}   already registered: {n_already}   skipped: {n_skipped}\n")
     for line in report_lines:
         print(line)
 
     print("\nSource datasets deliberately not imported:")
     for rel, reason in SKIPPED:
         print(f"  {rel}: {reason}")
-    print("\nCaveat: v1-format files (Seattle, Point Roberts) recorded pano "
-          "coordinates,\nnot query coordinates, on OK rows — grid/coverage "
-          "stats are approximate.")
+    print(
+        "\nCaveat: v1-format files (Seattle, Point Roberts) recorded pano "
+        "coordinates,\nnot query coordinates, on OK rows — grid/coverage "
+        "stats are approximate."
+    )
 
     if not args.execute:
         print("\nDry run complete. Re-run with --execute to apply.")
@@ -495,5 +611,5 @@ def main() -> int:
     return 0
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     sys.exit(main())

--- a/scripts/migrate_to_db.py
+++ b/scripts/migrate_to_db.py
@@ -32,7 +32,6 @@ import os
 import sys
 from collections import defaultdict
 from dataclasses import dataclass, field
-from typing import Dict, List, Optional, Tuple
 
 import pandas as pd
 from tqdm import tqdm
@@ -43,9 +42,13 @@ from gsv_metadata_tracker import db  # noqa: E402
 from gsv_metadata_tracker.analysis import calculate_run_stats  # noqa: E402
 from gsv_metadata_tracker.fileutils import load_city_csv_file  # noqa: E402
 from gsv_metadata_tracker.geoutils import (  # noqa: E402
-    get_city_location_data, get_state_abbreviation, get_country_code)
+    get_city_location_data,
+    get_country_code,
+    get_state_abbreviation,
+)
 from gsv_metadata_tracker.json_summarizer import (  # noqa: E402
-    generate_city_metadata_summary_as_json)
+    generate_city_metadata_summary_as_json,
+)
 from gsv_metadata_tracker.naming import parse_filename, slug_to_query_str  # noqa: E402
 from gsv_metadata_tracker.paths import get_default_data_dir  # noqa: E402
 
@@ -55,55 +58,59 @@ logger = logging.getLogger("migrate")
 @dataclass
 class FileInfo:
     """Everything we learn about one legacy csv.gz file."""
+
     csv_path: str
     slug: str
     width: int
     height: int
     step: int
-    city_name: Optional[str] = None
-    state_name: Optional[str] = None
-    country_name: Optional[str] = None
-    center_lat: Optional[float] = None
-    center_lon: Optional[float] = None
-    run_date: Optional[pd.Timestamp] = None
-    json_path: Optional[str] = None
-    json_ok: bool = False        # sibling json exists and parses strictly
-    identity_source: str = ""    # 'json' | 'nominatim' | 'failed'
-    problems: List[str] = field(default_factory=list)
+    city_name: str | None = None
+    state_name: str | None = None
+    country_name: str | None = None
+    center_lat: float | None = None
+    center_lon: float | None = None
+    run_date: pd.Timestamp | None = None
+    json_path: str | None = None
+    json_ok: bool = False  # sibling json exists and parses strictly
+    identity_source: str = ""  # 'json' | 'nominatim' | 'failed'
+    problems: list[str] = field(default_factory=list)
 
     @property
     def csv_filename(self) -> str:
         return os.path.basename(self.csv_path)
 
     @property
-    def geometry(self) -> Tuple[int, int, int]:
+    def geometry(self) -> tuple[int, int, int]:
         return (self.width, self.height, self.step)
 
 
-def strict_json_load(path: str) -> Optional[dict]:
+def strict_json_load(path: str) -> dict | None:
     """Load JSON, raising on NaN/Infinity tokens (returns None on failure)."""
+
     def _reject(token):
         raise ValueError(f"invalid JSON token {token}")
+
     try:
-        with gzip.open(path, 'rt', encoding='utf-8') as f:
+        with gzip.open(path, "rt", encoding="utf-8") as f:
             return json.load(f, parse_constant=_reject)
     except Exception:
         return None
 
 
-def read_run_date(csv_path: str) -> Optional[pd.Timestamp]:
+def read_run_date(csv_path: str) -> pd.Timestamp | None:
     """Newest query_timestamp in the file (cheap usecols read)."""
     try:
-        ts = pd.read_csv(csv_path, usecols=['query_timestamp'])['query_timestamp']
-        return pd.to_datetime(ts, format='ISO8601', utc=True).max()
+        ts = pd.read_csv(csv_path, usecols=["query_timestamp"])["query_timestamp"]
+        return pd.to_datetime(ts, format="ISO8601", utc=True).max()
     except Exception as e:
         logger.warning(f"Could not read query_timestamp from {csv_path}: {e}")
         return None
 
 
-def scan_files(data_dir: str, use_nominatim_fallback: bool) -> Tuple[List[FileInfo], List[str]]:
+def scan_files(data_dir: str, use_nominatim_fallback: bool) -> tuple[list[FileInfo], list[str]]:
     """Parse + identify every legacy csv.gz in data_dir."""
     import glob
+
     all_csvs = sorted(glob.glob(os.path.join(data_dir, "**/*.csv.gz"), recursive=True))
     infos, unparseable = [], []
 
@@ -116,12 +123,16 @@ def scan_files(data_dir: str, use_nominatim_fallback: bool) -> Tuple[List[FileIn
         if parsed.run_date is not None:
             continue  # already a dated (post-migration) file
 
-        info = FileInfo(csv_path=csv_path, slug=parsed.slug,
-                        width=parsed.width_meters, height=parsed.height_meters,
-                        step=parsed.step_meters)
+        info = FileInfo(
+            csv_path=csv_path,
+            slug=parsed.slug,
+            width=parsed.width_meters,
+            height=parsed.height_meters,
+            step=parsed.step_meters,
+        )
 
         # Identity from the sibling JSON when possible
-        json_path = csv_path.rsplit('.csv.gz', 1)[0] + '.json.gz'
+        json_path = csv_path.rsplit(".csv.gz", 1)[0] + ".json.gz"
         if os.path.exists(json_path):
             info.json_path = json_path
             data = strict_json_load(json_path)
@@ -141,7 +152,7 @@ def scan_files(data_dir: str, use_nominatim_fallback: bool) -> Tuple[List[FileIn
                 # Content is unusable for identity but structure may be fine;
                 # try a lenient read just for the city block
                 try:
-                    with gzip.open(json_path, 'rt', encoding='utf-8') as f:
+                    with gzip.open(json_path, "rt", encoding="utf-8") as f:
                         data = json.load(f)  # lenient: accepts NaN
                     info.city_name = data["city"]["name"]
                     info.state_name = data["city"]["state"]["name"]
@@ -155,7 +166,7 @@ def scan_files(data_dir: str, use_nominatim_fallback: bool) -> Tuple[List[FileIn
             info.problems.append("no sibling json")
 
         if info.city_name is None and use_nominatim_fallback:
-            query = slug_to_query_str(info.slug.replace('_', ', '))
+            query = slug_to_query_str(info.slug.replace("_", ", "))
             loc = get_city_location_data(query)
             if loc and loc.city:
                 info.city_name = loc.city
@@ -177,33 +188,44 @@ def scan_files(data_dir: str, use_nominatim_fallback: bool) -> Tuple[List[FileIn
     return infos, unparseable
 
 
-def choose_baseline(files: List[FileInfo], city_id: str) -> FileInfo:
+def choose_baseline(files: list[FileInfo], city_id: str) -> FileInfo:
     """
     Pick the baseline file for a (city_id, geometry) group: prefer the file
     whose slug is the canonical full-name slug, then the newest data.
     """
+
     def sort_key(f: FileInfo):
-        return (f.slug == city_id,                      # canonical slug wins
-                f.run_date or pd.Timestamp(0, tz='UTC'))  # then newest
+        return (
+            f.slug == city_id,  # canonical slug wins
+            f.run_date or pd.Timestamp(0, tz="UTC"),
+        )  # then newest
+
     return max(files, key=sort_key)
 
 
 def main() -> int:
-    parser = argparse.ArgumentParser(description=__doc__,
-                                     formatter_class=argparse.RawDescriptionHelpFormatter)
-    parser.add_argument('--data-dir', default=get_default_data_dir())
-    parser.add_argument('--db-path', default=None,
-                        help='default: {data-dir}/gsv_tracker.db')
-    parser.add_argument('--execute', action='store_true',
-                        help='Apply changes (default is a dry run)')
-    parser.add_argument('--no-nominatim', action='store_true',
-                        help='Skip the Nominatim fallback for files without JSON')
-    parser.add_argument('--log-level', default='WARNING',
-                        choices=['DEBUG', 'INFO', 'WARNING', 'ERROR'])
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("--data-dir", default=get_default_data_dir())
+    parser.add_argument("--db-path", default=None, help="default: {data-dir}/gsv_tracker.db")
+    parser.add_argument(
+        "--execute", action="store_true", help="Apply changes (default is a dry run)"
+    )
+    parser.add_argument(
+        "--no-nominatim",
+        action="store_true",
+        help="Skip the Nominatim fallback for files without JSON",
+    )
+    parser.add_argument(
+        "--log-level", default="WARNING", choices=["DEBUG", "INFO", "WARNING", "ERROR"]
+    )
     args = parser.parse_args()
 
-    logging.basicConfig(level=getattr(logging, args.log_level),
-                        format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+    logging.basicConfig(
+        level=getattr(logging, args.log_level),
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    )
 
     db_path = args.db_path or db.get_default_db_path(args.data_dir)
     mode = "EXECUTE" if args.execute else "DRY RUN"
@@ -217,20 +239,19 @@ def main() -> int:
     failed = [i for i in infos if i not in resolved]
 
     # Group by canonical identity, then by geometry within each city
-    by_city: Dict[str, List[FileInfo]] = defaultdict(list)
+    by_city: dict[str, list[FileInfo]] = defaultdict(list)
     for info in resolved:
         city_id = db.derive_city_id(info.city_name, info.state_name, info.country_name)
         by_city[city_id].append(info)
 
-    plan_rows = []          # (city_id, baseline FileInfo, aliases, variant files)
+    plan_rows = []  # (city_id, baseline FileInfo, aliases, variant files)
     for city_id, files in sorted(by_city.items()):
         # Canonical geometry: that of the LARGEST capture for this city
         # (by compressed size, tie-break newest). Junk/degenerate test
         # files can be newer and even reverse-geocode to a real city's
         # identity (e.g. a 4-point "balance--tennessee" file resolving to
         # Nashville) — size, not recency, identifies the real capture.
-        biggest = max(files, key=lambda f: (os.path.getsize(f.csv_path),
-                                            f.run_date))
+        biggest = max(files, key=lambda f: (os.path.getsize(f.csv_path), f.run_date))
         canonical_geom = biggest.geometry
         group = [f for f in files if f.geometry == canonical_geom]
         variants = [f for f in files if f.geometry != canonical_geom]
@@ -286,10 +307,12 @@ def main() -> int:
     conn = db.connect(db_path)
     n_cities = n_runs = n_regen = n_skipped = 0
 
-    for city_id, baseline, aliases, dup_files, _ in tqdm(plan_rows, desc="Registering", unit="city"):
+    for city_id, baseline, aliases, _dup_files, _ in tqdm(
+        plan_rows, desc="Registering", unit="city"
+    ):
         already = conn.execute(
-            "SELECT 1 FROM runs WHERE csv_filename = ?",
-            (baseline.csv_filename,)).fetchone()
+            "SELECT 1 FROM runs WHERE csv_filename = ?", (baseline.csv_filename,)
+        ).fetchone()
         if already:
             n_skipped += 1
             continue
@@ -304,8 +327,8 @@ def main() -> int:
             state_code=get_state_abbreviation(baseline.state_name),
             country_name=baseline.country_name,
             country_code=get_country_code(baseline.country_name),
-            center_lat=float(df['query_lat'].mean()),
-            center_lon=float(df['query_lon'].mean()),
+            center_lat=float(df["query_lat"].mean()),
+            center_lon=float(df["query_lon"].mean()),
             grid_width_m=baseline.width,
             grid_height_m=baseline.height,
             step_m=baseline.step,
@@ -321,10 +344,18 @@ def main() -> int:
         json_path = baseline.json_path
         if json_path is None or not baseline.json_ok:
             json_path = generate_city_metadata_summary_as_json(
-                baseline.csv_path, df,
-                baseline.city_name, baseline.state_name, baseline.country_name,
-                baseline.width, baseline.height, baseline.step,
-                force_recreate_file=True, run_date=run_date, is_baseline=True)
+                baseline.csv_path,
+                df,
+                baseline.city_name,
+                baseline.state_name,
+                baseline.country_name,
+                baseline.width,
+                baseline.height,
+                baseline.step,
+                force_recreate_file=True,
+                run_date=run_date,
+                is_baseline=True,
+            )
             n_regen += 1
 
         stats = calculate_run_stats(df, run_date)
@@ -342,13 +373,17 @@ def main() -> int:
 
     db.assign_schedule(conn, cycle_days=90)
 
-    print(f"\nDone. Registered {n_cities} cities, {n_runs} baseline runs "
-          f"({n_skipped} already registered, {n_regen} JSONs regenerated).")
+    print(
+        f"\nDone. Registered {n_cities} cities, {n_runs} baseline runs "
+        f"({n_skipped} already registered, {n_regen} JSONs regenerated)."
+    )
     if n_dupes or n_variants:
-        print("Aliased duplicate and geometry-variant files were left on disk "
-              "unregistered — see the report above to review/remove them.")
+        print(
+            "Aliased duplicate and geometry-variant files were left on disk "
+            "unregistered — see the report above to review/remove them."
+        )
     return 0
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     sys.exit(main())

--- a/scripts/recompute_coverage_rates.py
+++ b/scripts/recompute_coverage_rates.py
@@ -44,19 +44,24 @@ from gsv_metadata_tracker.fileutils import load_city_csv_file  # noqa: E402
 from gsv_metadata_tracker.json_summarizer import generate_aggregate_v2  # noqa: E402
 from gsv_metadata_tracker.paths import get_default_data_dir  # noqa: E402
 
-logging.basicConfig(level=logging.INFO, format='%(levelname)s %(message)s')
+logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
 logger = logging.getLogger(__name__)
 
 
 def main() -> int:
     parser = argparse.ArgumentParser(
-        description='Recompute runs.coverage_rate_pct to the '
-                    'points-with-pano definition (issue #90)')
-    parser.add_argument('--data-dir', default=get_default_data_dir())
-    parser.add_argument('--execute', action='store_true',
-                        help='Apply changes (default is a dry-run report)')
-    parser.add_argument('--no-publish-json', action='store_true',
-                        help='Skip regenerating the aggregate cities.json.gz')
+        description="Recompute runs.coverage_rate_pct to the "
+        "points-with-pano definition (issue #90)"
+    )
+    parser.add_argument("--data-dir", default=get_default_data_dir())
+    parser.add_argument(
+        "--execute", action="store_true", help="Apply changes (default is a dry-run report)"
+    )
+    parser.add_argument(
+        "--no-publish-json",
+        action="store_true",
+        help="Skip regenerating the aggregate cities.json.gz",
+    )
     args = parser.parse_args()
 
     conn = db.connect(db.get_default_db_path(args.data_dir))
@@ -65,8 +70,9 @@ def main() -> int:
     # no longer correct. Refuse rather than silently regress GSV coverage.
     schema_version = conn.execute("PRAGMA user_version").fetchone()[0]
     if schema_version >= 3:
-        print("This script is superseded on schema v3+. "
-              "Use scripts/recompute_run_stats.py instead.")
+        print(
+            "This script is superseded on schema v3+. Use scripts/recompute_run_stats.py instead."
+        )
         return 1
 
     # ── GSV: one row per grid point, recompute from stored counters ──────
@@ -74,18 +80,21 @@ def main() -> int:
         """SELECT run_id, city_id, run_date, coverage_rate_pct,
                   100.0 * status_ok / total_points AS new_rate
            FROM runs
-           WHERE provider = 'gsv' AND total_points > 0""").fetchall()
-    gsv_changed = [r for r in gsv_rows
-                   if r['coverage_rate_pct'] is None
-                   or abs(r['coverage_rate_pct'] - r['new_rate']) > 1e-9]
-    print(f"GSV runs: {len(gsv_rows)} recomputable, "
-          f"{len(gsv_changed)} would change")
+           WHERE provider = 'gsv' AND total_points > 0"""
+    ).fetchall()
+    gsv_changed = [
+        r
+        for r in gsv_rows
+        if r["coverage_rate_pct"] is None or abs(r["coverage_rate_pct"] - r["new_rate"]) > 1e-9
+    ]
+    print(f"GSV runs: {len(gsv_rows)} recomputable, {len(gsv_changed)} would change")
     for r in gsv_changed[:10]:
-        old = r['coverage_rate_pct']
-        print(f"  {r['city_id']} {r['run_date']}: "
-              f"{old:.1f}% -> {r['new_rate']:.1f}%" if old is not None
-              else f"  {r['city_id']} {r['run_date']}: "
-                   f"NULL -> {r['new_rate']:.1f}%")
+        old = r["coverage_rate_pct"]
+        print(
+            f"  {r['city_id']} {r['run_date']}: {old:.1f}% -> {r['new_rate']:.1f}%"
+            if old is not None
+            else f"  {r['city_id']} {r['run_date']}: NULL -> {r['new_rate']:.1f}%"
+        )
     if len(gsv_changed) > 10:
         print(f"  ... and {len(gsv_changed) - 10} more")
 
@@ -93,21 +102,24 @@ def main() -> int:
     other_rows = conn.execute(
         """SELECT run_id, city_id, provider, run_date, csv_filename,
                   coverage_rate_pct
-           FROM runs WHERE provider != 'gsv'""").fetchall()
+           FROM runs WHERE provider != 'gsv'"""
+    ).fetchall()
     other_updates = []
     for r in other_rows:
-        csv_path = os.path.join(args.data_dir, r['csv_filename'])
+        csv_path = os.path.join(args.data_dir, r["csv_filename"])
         if not os.path.exists(csv_path):
             logger.warning(f"CSV missing, skipping: {csv_path}")
             continue
         df = load_city_csv_file(csv_path)
         new_rate = calculate_coverage_stats(df).coverage_rate
-        old = r['coverage_rate_pct']
+        old = r["coverage_rate_pct"]
         if old is None or abs(old - new_rate) > 1e-9:
-            other_updates.append((r['run_id'], new_rate))
-            print(f"  {r['city_id']} [{r['provider']}] {r['run_date']}: "
-                  f"{old if old is None else f'{old:.1f}%'} "
-                  f"-> {new_rate:.1f}%")
+            other_updates.append((r["run_id"], new_rate))
+            print(
+                f"  {r['city_id']} [{r['provider']}] {r['run_date']}: "
+                f"{old if old is None else f'{old:.1f}%'} "
+                f"-> {new_rate:.1f}%"
+            )
     print(f"{len(other_rows)} non-GSV runs, {len(other_updates)} would change")
 
     if not args.execute:
@@ -118,19 +130,19 @@ def main() -> int:
         conn.execute(
             """UPDATE runs
                SET coverage_rate_pct = 100.0 * status_ok / total_points
-               WHERE provider = 'gsv' AND total_points > 0""")
+               WHERE provider = 'gsv' AND total_points > 0"""
+        )
         conn.executemany(
             "UPDATE runs SET coverage_rate_pct = ? WHERE run_id = ?",
-            [(rate, run_id) for run_id, rate in other_updates])
+            [(rate, run_id) for run_id, rate in other_updates],
+        )
 
-    print(f"\nUpdated {len(gsv_changed)} GSV + {len(other_updates)} "
-          f"non-GSV runs.")
+    print(f"\nUpdated {len(gsv_changed)} GSV + {len(other_updates)} non-GSV runs.")
     if not args.no_publish_json:
         generate_aggregate_v2(conn, args.data_dir)
-        print(f"Regenerated aggregate: "
-              f"{os.path.join(args.data_dir, 'cities.json.gz')}")
+        print(f"Regenerated aggregate: {os.path.join(args.data_dir, 'cities.json.gz')}")
     return 0
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     sys.exit(main())

--- a/scripts/recompute_run_stats.py
+++ b/scripts/recompute_run_stats.py
@@ -41,15 +41,22 @@ from gsv_metadata_tracker.fileutils import load_city_csv_file  # noqa: E402
 from gsv_metadata_tracker.json_summarizer import generate_aggregate_v2  # noqa: E402
 from gsv_metadata_tracker.paths import get_default_data_dir  # noqa: E402
 
-logging.basicConfig(level=logging.INFO, format='%(levelname)s %(message)s')
+logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
 logger = logging.getLogger(__name__)
 
 # Stat columns owned by calculate_run_stats that this script refreshes.
 STAT_COLUMNS = (
-    'total_points', 'status_ok', 'status_no_date', 'status_zero_results',
-    'status_other', 'unique_panos', 'unique_google_panos',
-    'coverage_rate_pct', 'oldest_capture_date', 'newest_capture_date',
-    'median_pano_age_years',
+    "total_points",
+    "status_ok",
+    "status_no_date",
+    "status_zero_results",
+    "status_other",
+    "unique_panos",
+    "unique_google_panos",
+    "coverage_rate_pct",
+    "oldest_capture_date",
+    "newest_capture_date",
+    "median_pano_age_years",
 )
 
 
@@ -64,13 +71,18 @@ def _equalish(a, b) -> bool:
 
 def main() -> int:
     parser = argparse.ArgumentParser(
-        description='Recompute stored per-run stats from CSVs (schema v3: '
-                    'NO_DATE counts as present imagery)')
-    parser.add_argument('--data-dir', default=get_default_data_dir())
-    parser.add_argument('--execute', action='store_true',
-                        help='Apply changes (default is a dry-run report)')
-    parser.add_argument('--no-publish-json', action='store_true',
-                        help='Skip regenerating the aggregate cities.json.gz')
+        description="Recompute stored per-run stats from CSVs (schema v3: "
+        "NO_DATE counts as present imagery)"
+    )
+    parser.add_argument("--data-dir", default=get_default_data_dir())
+    parser.add_argument(
+        "--execute", action="store_true", help="Apply changes (default is a dry-run report)"
+    )
+    parser.add_argument(
+        "--no-publish-json",
+        action="store_true",
+        help="Skip regenerating the aggregate cities.json.gz",
+    )
     args = parser.parse_args()
 
     conn = db.connect(db.get_default_db_path(args.data_dir))
@@ -81,34 +93,36 @@ def main() -> int:
                   status_other, unique_panos, unique_google_panos,
                   coverage_rate_pct, oldest_capture_date, newest_capture_date,
                   median_pano_age_years
-           FROM runs ORDER BY city_id, provider, run_date""").fetchall()
+           FROM runs ORDER BY city_id, provider, run_date"""
+    ).fetchall()
 
-    updates = []       # (run_id, {col: value})
+    updates = []  # (run_id, {col: value})
     missing = 0
     for r in rows:
-        csv_path = os.path.join(args.data_dir, r['csv_filename'])
+        csv_path = os.path.join(args.data_dir, r["csv_filename"])
         if not os.path.exists(csv_path):
             logger.warning(f"CSV missing, skipping: {r['csv_filename']}")
             missing += 1
             continue
         df = load_city_csv_file(csv_path)
-        stats = calculate_run_stats(
-            df, date.fromisoformat(r['run_date']), provider=r['provider'])
-        changed = {c: stats[c] for c in STAT_COLUMNS
-                   if not _equalish(r[c], stats[c])}
+        stats = calculate_run_stats(df, date.fromisoformat(r["run_date"]), provider=r["provider"])
+        changed = {c: stats[c] for c in STAT_COLUMNS if not _equalish(r[c], stats[c])}
         if changed:
-            updates.append((r['run_id'], changed))
-            nd = stats['status_no_date']
-            cov_old = r['coverage_rate_pct']
-            cov_new = stats['coverage_rate_pct']
-            print(f"  {r['city_id']} [{r['provider']}] {r['run_date']}: "
-                  f"coverage {('NULL' if cov_old is None else f'{cov_old:.1f}%')}"
-                  f" -> {cov_new:.1f}%, unique_panos "
-                  f"{r['unique_panos']} -> {stats['unique_panos']}, "
-                  f"status_no_date -> {nd}")
+            updates.append((r["run_id"], changed))
+            nd = stats["status_no_date"]
+            cov_old = r["coverage_rate_pct"]
+            cov_new = stats["coverage_rate_pct"]
+            print(
+                f"  {r['city_id']} [{r['provider']}] {r['run_date']}: "
+                f"coverage {('NULL' if cov_old is None else f'{cov_old:.1f}%')}"
+                f" -> {cov_new:.1f}%, unique_panos "
+                f"{r['unique_panos']} -> {stats['unique_panos']}, "
+                f"status_no_date -> {nd}"
+            )
 
-    print(f"\n{len(rows)} runs scanned, {missing} skipped (missing CSV), "
-          f"{len(updates)} would change")
+    print(
+        f"\n{len(rows)} runs scanned, {missing} skipped (missing CSV), {len(updates)} would change"
+    )
 
     if not args.execute:
         print("\nDry run complete. Re-run with --execute to apply.")
@@ -116,18 +130,17 @@ def main() -> int:
 
     with conn:
         for run_id, changed in updates:
-            assignments = ', '.join(f"{c} = ?" for c in changed)
+            assignments = ", ".join(f"{c} = ?" for c in changed)
             conn.execute(
-                f"UPDATE runs SET {assignments} WHERE run_id = ?",
-                (*changed.values(), run_id))
+                f"UPDATE runs SET {assignments} WHERE run_id = ?", (*changed.values(), run_id)
+            )
 
     print(f"\nUpdated {len(updates)} runs.")
     if not args.no_publish_json:
         generate_aggregate_v2(conn, args.data_dir)
-        print(f"Regenerated aggregate: "
-              f"{os.path.join(args.data_dir, 'cities.json.gz')}")
+        print(f"Regenerated aggregate: {os.path.join(args.data_dir, 'cities.json.gz')}")
     return 0
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     sys.exit(main())

--- a/scripts/reregister_boundaries.py
+++ b/scripts/reregister_boundaries.py
@@ -43,14 +43,15 @@ import logging
 import math
 import os
 import sys
-from dataclasses import dataclass, asdict
-from typing import Optional
+from dataclasses import asdict, dataclass
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from gsv_metadata_tracker import db  # noqa: E402
 from gsv_metadata_tracker.boundary_audit import (  # noqa: E402
-    frozen_rect_bounds, bbox_intersection_frac)
+    bbox_intersection_frac,
+    frozen_rect_bounds,
+)
 from gsv_metadata_tracker.paths import get_default_data_dir  # noqa: E402
 
 logger = logging.getLogger("reregister")
@@ -68,8 +69,11 @@ REVIEW_THRESHOLD_M = 30000
 REC_CEILING_M = 80000
 
 # Default locations, relative to the repo root.
-DEFAULT_REPORT = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
-                              "audit", "boundary_audit_report.csv")
+DEFAULT_REPORT = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    "audit",
+    "boundary_audit_report.csv",
+)
 PLAN_CSV = "reregister_plan.csv"
 MANUAL_CSV = "manual_review.csv"
 
@@ -83,6 +87,7 @@ REGEOM_NOTE = "regeom #91: recenter on OSM bbox midpoint + grow to OSM bbox"
 @dataclass
 class Current:
     """A city's current frozen geometry, read live from the catalog."""
+
     center_lat: float
     center_lon: float
     width_m: int
@@ -93,29 +98,30 @@ class Current:
 @dataclass
 class Decision:
     """The action to take for one audited city."""
+
     city_id: str
     display_name: str
     verdict: str
     action: str  # RESIZE | DEFER | NOCHANGE | SKIP
     reason: str
-    old_center_lat: Optional[float] = None
-    old_center_lon: Optional[float] = None
-    old_width_m: Optional[int] = None
-    old_height_m: Optional[int] = None
-    new_center_lat: Optional[float] = None
-    new_center_lon: Optional[float] = None
-    new_width_m: Optional[int] = None
-    new_height_m: Optional[int] = None
-    old_points: Optional[int] = None
-    new_points: Optional[int] = None
-    coverage_before: Optional[float] = None
-    coverage_after: Optional[float] = None
+    old_center_lat: float | None = None
+    old_center_lon: float | None = None
+    old_width_m: int | None = None
+    old_height_m: int | None = None
+    new_center_lat: float | None = None
+    new_center_lon: float | None = None
+    new_width_m: int | None = None
+    new_height_m: int | None = None
+    old_points: int | None = None
+    new_points: int | None = None
+    coverage_before: float | None = None
+    coverage_after: float | None = None
     # Recommendation for the manual-review cases (DEFER) — advisory only.
-    rec_center_lat: Optional[float] = None
-    rec_center_lon: Optional[float] = None
-    rec_width_m: Optional[int] = None
-    rec_height_m: Optional[int] = None
-    rec_basis: Optional[str] = None
+    rec_center_lat: float | None = None
+    rec_center_lon: float | None = None
+    rec_width_m: int | None = None
+    rec_height_m: int | None = None
+    rec_basis: str | None = None
 
 
 # A frozen grid within this fraction of the OSM bbox area is "already the right
@@ -128,7 +134,7 @@ def _grid_points(width_m: float, height_m: float, step_m: float) -> int:
     return (int(width_m / step_m) + 1) * (int(height_m / step_m) + 1)
 
 
-def _num(row: dict, key: str) -> Optional[float]:
+def _num(row: dict, key: str) -> float | None:
     """Parse a possibly-blank/NaN CSV cell to float, or None."""
     val = row.get(key, "")
     if val is None or val == "":
@@ -140,8 +146,7 @@ def _num(row: dict, key: str) -> Optional[float]:
     return None if math.isnan(f) else f
 
 
-def recommend(row: dict, current: Current,
-              ceiling_m: float = REC_CEILING_M) -> dict:
+def recommend(row: dict, current: Current, ceiling_m: float = REC_CEILING_M) -> dict:
     """
     Advisory "best size" for a deferred (manual-review) city.
 
@@ -184,13 +189,17 @@ def recommend(row: dict, current: Current,
                 rc_lat, rc_lon = sug_lat, sug_lon
             capped = " (capped)" if (osm_w > ceiling_m or osm_h > ceiling_m) else ""
             poly = f", polygon ≈{poly_area:.0f}km²" if poly_area else ""
-            basis = (f"grow to full OSM bbox {osm_w/1000:.0f}x{osm_h/1000:.0f}km"
-                     f"{poly} -> {rw/1000:.0f}x{rh/1000:.0f}km{capped}; verify center")
+            basis = (
+                f"grow to full OSM bbox {osm_w / 1000:.0f}x{osm_h / 1000:.0f}km"
+                f"{poly} -> {rw / 1000:.0f}x{rh / 1000:.0f}km{capped}; verify center"
+            )
 
     elif verdict == "WRONG_PLACE":
         cand = int(min(ceiling_m, max(osm_w or 0, osm_h or 0))) if have_bbox else current.width_m
-        basis = (f"verify geocode first — frozen center is OUTSIDE the OSM bbox; "
-                 f"if the match is correct, ~{cand/1000:.0f}km on the OSM bbox")
+        basis = (
+            f"verify geocode first — frozen center is OUTSIDE the OSM bbox; "
+            f"if the match is correct, ~{cand / 1000:.0f}km on the OSM bbox"
+        )
 
     elif verdict == "NO_POLYGON" and have_bbox:
         # Recenter + grow to the full bbox (capped); bigger is safe.
@@ -200,12 +209,16 @@ def recommend(row: dict, current: Current,
         basis = "no polygon, but a usable bbox — recenter + grow to it"
 
     # NOT_FOUND / BBOX_SUSPECT / no-bbox cases fall through to "keep current".
-    return dict(rec_center_lat=round(rc_lat, 6), rec_center_lon=round(rc_lon, 6),
-                rec_width_m=rw, rec_height_m=rh, rec_basis=basis)
+    return dict(
+        rec_center_lat=round(rc_lat, 6),
+        rec_center_lon=round(rc_lon, 6),
+        rec_width_m=rw,
+        rec_height_m=rh,
+        rec_basis=basis,
+    )
 
 
-def decide(row: dict, current: Optional[Current],
-           threshold_m: float = REVIEW_THRESHOLD_M) -> Decision:
+def decide(row: dict, current: Current | None, threshold_m: float = REVIEW_THRESHOLD_M) -> Decision:
     """
     Pure policy: map one audit-report row + current geometry to a Decision.
 
@@ -217,16 +230,22 @@ def decide(row: dict, current: Optional[Current],
     verdict = row["verdict"]
 
     def d(action, reason, **kw):
-        return Decision(city_id=city_id, display_name=name, verdict=verdict,
-                        action=action, reason=reason, **kw)
+        return Decision(
+            city_id=city_id, display_name=name, verdict=verdict, action=action, reason=reason, **kw
+        )
 
     def defer(reason):
         # Deferred cities carry both current geometry and an advisory
         # recommended geometry, for side-by-side human review.
-        return d("DEFER", reason,
-                 old_center_lat=current.center_lat, old_center_lon=current.center_lon,
-                 old_width_m=current.width_m, old_height_m=current.height_m,
-                 **recommend(row, current))
+        return d(
+            "DEFER",
+            reason,
+            old_center_lat=current.center_lat,
+            old_center_lon=current.center_lon,
+            old_width_m=current.width_m,
+            old_height_m=current.height_m,
+            **recommend(row, current),
+        )
 
     if current is None:
         return d("SKIP", "not found in catalog")
@@ -243,8 +262,10 @@ def decide(row: dict, current: Optional[Current],
         return defer("UNDER but OSM bbox/center missing in report")
 
     if osm_w > threshold_m or osm_h > threshold_m:
-        return defer(f"OSM bbox {osm_w/1000:.0f}x{osm_h/1000:.0f}km exceeds "
-                     f"{threshold_m/1000:.0f}km review threshold")
+        return defer(
+            f"OSM bbox {osm_w / 1000:.0f}x{osm_h / 1000:.0f}km exceeds "
+            f"{threshold_m / 1000:.0f}km review threshold"
+        )
 
     # Recenter on the OSM midpoint; grow the grid to at least the OSM bbox.
     new_w = int(max(current.width_m, osm_w))
@@ -254,23 +275,34 @@ def decide(row: dict, current: Optional[Current],
     # coverage before/after — an offline sanity check on the fix.
     osm_bbox = frozen_rect_bounds(sug_lat, sug_lon, osm_w, osm_h)
     cov_before = bbox_intersection_frac(
-        frozen_rect_bounds(current.center_lat, current.center_lon,
-                           current.width_m, current.height_m), osm_bbox)
-    cov_after = bbox_intersection_frac(
-        frozen_rect_bounds(sug_lat, sug_lon, new_w, new_h), osm_bbox)
+        frozen_rect_bounds(
+            current.center_lat, current.center_lon, current.width_m, current.height_m
+        ),
+        osm_bbox,
+    )
+    cov_after = bbox_intersection_frac(frozen_rect_bounds(sug_lat, sug_lon, new_w, new_h), osm_bbox)
 
     common = dict(
-        old_center_lat=current.center_lat, old_center_lon=current.center_lon,
-        old_width_m=current.width_m, old_height_m=current.height_m,
-        new_center_lat=sug_lat, new_center_lon=sug_lon,
-        new_width_m=new_w, new_height_m=new_h,
+        old_center_lat=current.center_lat,
+        old_center_lon=current.center_lon,
+        old_width_m=current.width_m,
+        old_height_m=current.height_m,
+        new_center_lat=sug_lat,
+        new_center_lon=sug_lon,
+        new_width_m=new_w,
+        new_height_m=new_h,
         old_points=_grid_points(current.width_m, current.height_m, current.step_m),
         new_points=_grid_points(new_w, new_h, current.step_m),
-        coverage_before=round(cov_before, 4), coverage_after=round(cov_after, 4))
+        coverage_before=round(cov_before, 4),
+        coverage_after=round(cov_after, 4),
+    )
 
-    already = (abs(current.center_lat - sug_lat) < _CENTER_EPS_DEG and
-               abs(current.center_lon - sug_lon) < _CENTER_EPS_DEG and
-               current.width_m == new_w and current.height_m == new_h)
+    already = (
+        abs(current.center_lat - sug_lat) < _CENTER_EPS_DEG
+        and abs(current.center_lon - sug_lon) < _CENTER_EPS_DEG
+        and current.width_m == new_w
+        and current.height_m == new_h
+    )
     if already:
         return d("NOCHANGE", "already at target geometry", **common)
     return d("RESIZE", "recenter on OSM midpoint + grow to OSM bbox", **common)
@@ -279,21 +311,49 @@ def decide(row: dict, current: Optional[Current],
 def load_current_geometry(conn) -> dict:
     """Map city_id -> Current for every city in the catalog."""
     rows = conn.execute(
-        "SELECT city_id, center_lat, center_lon, grid_width_m, grid_height_m, "
-        "step_m FROM cities").fetchall()
-    return {r["city_id"]: Current(r["center_lat"], r["center_lon"],
-                                  r["grid_width_m"], r["grid_height_m"],
-                                  r["step_m"]) for r in rows}
+        "SELECT city_id, center_lat, center_lon, grid_width_m, grid_height_m, step_m FROM cities"
+    ).fetchall()
+    return {
+        r["city_id"]: Current(
+            r["center_lat"], r["center_lon"], r["grid_width_m"], r["grid_height_m"], r["step_m"]
+        )
+        for r in rows
+    }
 
 
-_PLAN_FIELDS = ["city_id", "display_name", "verdict", "reason",
-                "old_center_lat", "old_center_lon", "old_width_m", "old_height_m",
-                "new_center_lat", "new_center_lon", "new_width_m", "new_height_m",
-                "old_points", "new_points", "coverage_before", "coverage_after"]
-_MANUAL_FIELDS = ["city_id", "display_name", "verdict", "reason",
-                  "old_center_lat", "old_center_lon", "old_width_m", "old_height_m",
-                  "rec_center_lat", "rec_center_lon", "rec_width_m", "rec_height_m",
-                  "rec_basis"]
+_PLAN_FIELDS = [
+    "city_id",
+    "display_name",
+    "verdict",
+    "reason",
+    "old_center_lat",
+    "old_center_lon",
+    "old_width_m",
+    "old_height_m",
+    "new_center_lat",
+    "new_center_lon",
+    "new_width_m",
+    "new_height_m",
+    "old_points",
+    "new_points",
+    "coverage_before",
+    "coverage_after",
+]
+_MANUAL_FIELDS = [
+    "city_id",
+    "display_name",
+    "verdict",
+    "reason",
+    "old_center_lat",
+    "old_center_lon",
+    "old_width_m",
+    "old_height_m",
+    "rec_center_lat",
+    "rec_center_lon",
+    "rec_width_m",
+    "rec_height_m",
+    "rec_basis",
+]
 
 
 def _write_csv(path: str, fields: list, decisions: list) -> None:
@@ -306,23 +366,32 @@ def _write_csv(path: str, fields: list, decisions: list) -> None:
 
 def main() -> int:
     parser = argparse.ArgumentParser(
-        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
-    parser.add_argument("--report", default=DEFAULT_REPORT,
-                        help="boundary audit report CSV (default: audit/boundary_audit_report.csv)")
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument(
+        "--report",
+        default=DEFAULT_REPORT,
+        help="boundary audit report CSV (default: audit/boundary_audit_report.csv)",
+    )
     parser.add_argument("--data-dir", default=get_default_data_dir())
-    parser.add_argument("--db-path", default=None,
-                        help="default: {data-dir}/gsv_tracker.db")
-    parser.add_argument("--out-dir", default=None,
-                        help="where to write the plan/manual-review CSVs "
-                             "(default: alongside the report)")
-    parser.add_argument("--execute", action="store_true",
-                        help="Apply changes (default is a dry run)")
-    parser.add_argument("--log-level", default="WARNING",
-                        choices=["DEBUG", "INFO", "WARNING", "ERROR"])
+    parser.add_argument("--db-path", default=None, help="default: {data-dir}/gsv_tracker.db")
+    parser.add_argument(
+        "--out-dir",
+        default=None,
+        help="where to write the plan/manual-review CSVs (default: alongside the report)",
+    )
+    parser.add_argument(
+        "--execute", action="store_true", help="Apply changes (default is a dry run)"
+    )
+    parser.add_argument(
+        "--log-level", default="WARNING", choices=["DEBUG", "INFO", "WARNING", "ERROR"]
+    )
     args = parser.parse_args()
 
-    logging.basicConfig(level=getattr(logging, args.log_level),
-                        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+    logging.basicConfig(
+        level=getattr(logging, args.log_level),
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    )
 
     db_path = args.db_path or db.get_default_db_path(args.data_dir)
     out_dir = args.out_dir or os.path.dirname(os.path.abspath(args.report))
@@ -335,8 +404,7 @@ def main() -> int:
     current_by_id = load_current_geometry(conn)
 
     with open(args.report, newline="") as f:
-        decisions = [decide(row, current_by_id.get(row["city_id"]))
-                     for row in csv.DictReader(f)]
+        decisions = [decide(row, current_by_id.get(row["city_id"])) for row in csv.DictReader(f)]
 
     resize = [d for d in decisions if d.action == "RESIZE"]
     defer = [d for d in decisions if d.action == "DEFER"]
@@ -351,8 +419,10 @@ def main() -> int:
     print(f"Re-register (recenter + resize): {len(resize)}")
     print(f"Already at target (no change):   {len(nochange)}")
     print(f"Deferred to manual review:       {len(defer)}")
-    print(f"Grid-point delta from resizes:   {point_delta:+,} "
-          f"(one-time; free GSV metadata, ~{point_delta // 90:+,}/day over the 90-day cycle)")
+    print(
+        f"Grid-point delta from resizes:   {point_delta:+,} "
+        f"(one-time; free GSV metadata, ~{point_delta // 90:+,}/day over the 90-day cycle)"
+    )
     print(f"\nPlan written to:          {plan_path}")
     print(f"Manual-review list:       {manual_path}")
 
@@ -363,10 +433,14 @@ def main() -> int:
 
     for d in resize:
         db.update_city_geometry(
-            conn, city_id=d.city_id,
-            center_lat=d.new_center_lat, center_lon=d.new_center_lon,
-            grid_width_m=d.new_width_m, grid_height_m=d.new_height_m,
-            notes=REGEOM_NOTE)
+            conn,
+            city_id=d.city_id,
+            center_lat=d.new_center_lat,
+            center_lon=d.new_center_lon,
+            grid_width_m=d.new_width_m,
+            grid_height_m=d.new_height_m,
+            notes=REGEOM_NOTE,
+        )
     conn.close()
     print(f"\nApplied {len(resize)} re-registrations.")
     return 0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,7 @@
 import gzip
 import os
 import sys
-from datetime import date, datetime, timezone
+from datetime import UTC, date, datetime
 
 import pandas as pd
 import pytest
@@ -12,12 +12,26 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from gsv_metadata_tracker import db  # noqa: E402
 
-COLUMNS = ['query_lat', 'query_lon', 'query_timestamp', 'pano_lat', 'pano_lon',
-           'pano_id', 'capture_date', 'copyright_info', 'status']
+COLUMNS = [
+    "query_lat",
+    "query_lon",
+    "query_timestamp",
+    "pano_lat",
+    "pano_lon",
+    "pano_id",
+    "capture_date",
+    "copyright_info",
+    "status",
+]
 
 
-def make_city_df(panos, run_date=date(2026, 1, 15), grid_origin=(44.0, -121.0),
-                 n_empty=1, copyright_info='© Google'):
+def make_city_df(
+    panos,
+    run_date=date(2026, 1, 15),
+    grid_origin=(44.0, -121.0),
+    n_empty=1,
+    copyright_info="© Google",
+):
     """
     Build a synthetic run DataFrame.
 
@@ -31,22 +45,43 @@ def make_city_df(panos, run_date=date(2026, 1, 15), grid_origin=(44.0, -121.0),
 
     Returns raw (string-typed) DataFrame, like a freshly written CSV.
     """
-    ts = datetime(run_date.year, run_date.month, run_date.day,
-                  12, 0, tzinfo=timezone.utc).isoformat()
+    ts = datetime(run_date.year, run_date.month, run_date.day, 12, 0, tzinfo=UTC).isoformat()
     rows = []
     lat0, lon0 = grid_origin
     for i, (pano_id, capture) in enumerate(panos):
-        rows.append((lat0 + i * 0.001, lon0, ts, lat0 + i * 0.001 + 0.0001,
-                     lon0 + 0.0001, pano_id, capture, copyright_info, 'OK'))
+        rows.append(
+            (
+                lat0 + i * 0.001,
+                lon0,
+                ts,
+                lat0 + i * 0.001 + 0.0001,
+                lon0 + 0.0001,
+                pano_id,
+                capture,
+                copyright_info,
+                "OK",
+            )
+        )
     for j in range(n_empty):
-        rows.append((lat0 + (len(panos) + j) * 0.001, lon0, ts, None, None,
-                     None, None, None, 'ZERO_RESULTS'))
+        rows.append(
+            (
+                lat0 + (len(panos) + j) * 0.001,
+                lon0,
+                ts,
+                None,
+                None,
+                None,
+                None,
+                None,
+                "ZERO_RESULTS",
+            )
+        )
     return pd.DataFrame(rows, columns=COLUMNS)
 
 
-def make_mapillary_city_df(panos, run_date=date(2026, 1, 15),
-                           grid_origin=(44.0, -121.0), n_empty=1,
-                           panos_per_point=1):
+def make_mapillary_city_df(
+    panos, run_date=date(2026, 1, 15), grid_origin=(44.0, -121.0), n_empty=1, panos_per_point=1
+):
     """
     Build a synthetic Mapillary run DataFrame.
 
@@ -60,27 +95,46 @@ def make_mapillary_city_df(panos, run_date=date(2026, 1, 15),
 
     Returns raw (string-typed) DataFrame, like a freshly written CSV.
     """
-    ts = datetime(run_date.year, run_date.month, run_date.day,
-                  12, 0, tzinfo=timezone.utc).isoformat()
+    ts = datetime(run_date.year, run_date.month, run_date.day, 12, 0, tzinfo=UTC).isoformat()
     rows = []
     lat0, lon0 = grid_origin
     n_points_used = 0
     for i, (pano_id, capture) in enumerate(panos):
         point = i // panos_per_point
         n_points_used = point + 1
-        rows.append((lat0 + point * 0.001, lon0, ts,
-                     lat0 + point * 0.001 + 0.0001, lon0 + 0.0001,
-                     pano_id, capture,
-                     f'© Mapillary contributor {100 + i % 3}', 'OK'))
+        rows.append(
+            (
+                lat0 + point * 0.001,
+                lon0,
+                ts,
+                lat0 + point * 0.001 + 0.0001,
+                lon0 + 0.0001,
+                pano_id,
+                capture,
+                f"© Mapillary contributor {100 + i % 3}",
+                "OK",
+            )
+        )
     for j in range(n_empty):
-        rows.append((lat0 + (n_points_used + j) * 0.001, lon0, ts, None, None,
-                     None, None, None, 'ZERO_RESULTS'))
+        rows.append(
+            (
+                lat0 + (n_points_used + j) * 0.001,
+                lon0,
+                ts,
+                None,
+                None,
+                None,
+                None,
+                None,
+                "ZERO_RESULTS",
+            )
+        )
     return pd.DataFrame(rows, columns=COLUMNS)
 
 
 def write_city_csv_gz(df, path):
     """Write a synthetic df the way the downloader does (gzipped CSV)."""
-    with gzip.open(path, 'wt', encoding='utf-8', newline='') as f:
+    with gzip.open(path, "wt", encoding="utf-8", newline="") as f:
         df.to_csv(f, index=False)
     return path
 

--- a/tests/test_apply_decisions.py
+++ b/tests/test_apply_decisions.py
@@ -10,19 +10,24 @@ import os
 
 PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 _spec = importlib.util.spec_from_file_location(
-    "apply_decisions",
-    os.path.join(PROJECT_ROOT, "scripts", "apply_decisions.py"))
+    "apply_decisions", os.path.join(PROJECT_ROOT, "scripts", "apply_decisions.py")
+)
 ad = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(ad)
 
-CURRENT = ad.Current(center_lat=42.35, center_lon=-71.06,
-                     width_m=20000, height_m=20000)
+CURRENT = ad.Current(center_lat=42.35, center_lon=-71.06, width_m=20000, height_m=20000)
 
 
 def row(**kw):
-    base = {"city_id": "boston", "display_name": "Boston", "decision": "accept",
-            "chosen_center_lat": "42.31", "chosen_center_lon": "-71.00",
-            "chosen_width_m": "31885", "chosen_height_m": "18779"}
+    base = {
+        "city_id": "boston",
+        "display_name": "Boston",
+        "decision": "accept",
+        "chosen_center_lat": "42.31",
+        "chosen_center_lon": "-71.00",
+        "chosen_width_m": "31885",
+        "chosen_height_m": "18779",
+    }
     base.update(kw)
     return base
 
@@ -35,8 +40,13 @@ def test_apply_when_chosen_differs():
 
 
 def test_nochange_when_chosen_equals_current():
-    same = row(chosen_center_lat="42.35", chosen_center_lon="-71.06",
-               chosen_width_m="20000", chosen_height_m="20000", decision="keep_current")
+    same = row(
+        chosen_center_lat="42.35",
+        chosen_center_lon="-71.06",
+        chosen_width_m="20000",
+        chosen_height_m="20000",
+        decision="keep_current",
+    )
     p = ad.plan_row(same, CURRENT)
     assert p.action == "NOCHANGE"
 
@@ -49,8 +59,16 @@ def test_skip_when_no_decision():
 
 def test_skip_when_decision_but_blank_geometry():
     # skip/defer/rework export a decision but no chosen_* geometry.
-    p = ad.plan_row(row(decision="skip", chosen_center_lat="", chosen_center_lon="",
-                        chosen_width_m="", chosen_height_m=""), CURRENT)
+    p = ad.plan_row(
+        row(
+            decision="skip",
+            chosen_center_lat="",
+            chosen_center_lon="",
+            chosen_width_m="",
+            chosen_height_m="",
+        ),
+        CURRENT,
+    )
     assert p.action == "SKIP"
     assert "no geometry" in p.reason
 

--- a/tests/test_archival_import.py
+++ b/tests/test_archival_import.py
@@ -6,7 +6,6 @@ import json
 import os
 import subprocess
 import sys
-from datetime import date
 
 import pandas as pd
 import pytest
@@ -15,7 +14,7 @@ from gsv_metadata_tracker import db
 from gsv_metadata_tracker.fileutils import load_city_csv_file
 
 PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-SCRIPT = os.path.join(PROJECT_ROOT, 'scripts', 'import_archival_scrapes.py')
+SCRIPT = os.path.join(PROJECT_ROOT, "scripts", "import_archival_scrapes.py")
 
 
 def _write_v1_csv(path, ok_rows, fail_rows):
@@ -23,7 +22,7 @@ def _write_v1_csv(path, ok_rows, fail_rows):
     os.makedirs(os.path.dirname(path), exist_ok=True)
     lines = [f"{lat},{lon},{pano_id},{capture}," for lat, lon, pano_id, capture in ok_rows]
     lines += [f"{lat},{lon},None,None,ZERO_RESULTS" for lat, lon in fail_rows]
-    with open(path, 'w', encoding='utf-8') as f:
+    with open(path, "w", encoding="utf-8") as f:
         f.write("\n".join(lines) + "\n")
 
 
@@ -31,44 +30,66 @@ def _write_v2_csv(path, ok_rows, fail_rows, header=True):
     """v2 7-col: lat,lon,query_lat,query_lon,pano_id,date,status."""
     os.makedirs(os.path.dirname(path), exist_ok=True)
     lines = ["lat,lon,query_lat,query_lon,pano_id,date,status"] if header else []
-    lines += [f"{lat},{lon},{qlat},{qlon},{pano_id},{capture},"
-              for lat, lon, qlat, qlon, pano_id, capture in ok_rows]
+    lines += [
+        f"{lat},{lon},{qlat},{qlon},{pano_id},{capture},"
+        for lat, lon, qlat, qlon, pano_id, capture in ok_rows
+    ]
     # Failure rows echo the query coords into lat/lon (old scraper behavior)
-    lines += [f"{qlat},{qlon},{qlat},{qlon},None,None,ZERO_RESULTS"
-              for qlat, qlon in fail_rows]
-    with open(path, 'w', encoding='utf-8') as f:
+    lines += [f"{qlat},{qlon},{qlat},{qlon},None,None,ZERO_RESULTS" for qlat, qlon in fail_rows]
+    with open(path, "w", encoding="utf-8") as f:
         f.write("\n".join(lines) + "\n")
 
 
 def _write_bbox(csv_path, ymin, ymax, xmin, xmax):
-    with open(os.path.join(os.path.dirname(csv_path), 'bounding_box.json'),
-              'w', encoding='utf-8') as f:
+    with open(
+        os.path.join(os.path.dirname(csv_path), "bounding_box.json"), "w", encoding="utf-8"
+    ) as f:
         json.dump({"ymin": ymin, "ymax": ymax, "xmin": xmin, "xmax": xmax}, f)
 
 
 def _write_manifest(path, entries):
-    with open(path, 'w', encoding='utf-8') as f:
+    with open(path, "w", encoding="utf-8") as f:
         json.dump(entries, f)
     return path
 
 
 def _register_city(data_dir, city_name, state_name, country_name):
-    conn = db.connect(os.path.join(data_dir, 'gsv_tracker.db'))
+    conn = db.connect(os.path.join(data_dir, "gsv_tracker.db"))
     city_id = db.register_city(
-        conn, city_name=city_name, state_name=state_name, state_code=None,
-        country_name=country_name, country_code=None,
-        center_lat=44.0, center_lon=-121.0,
-        grid_width_m=5000, grid_height_m=5000, step_m=20)
+        conn,
+        city_name=city_name,
+        state_name=state_name,
+        state_code=None,
+        country_name=country_name,
+        country_code=None,
+        center_lat=44.0,
+        center_lon=-121.0,
+        grid_width_m=5000,
+        grid_height_m=5000,
+        step_m=20,
+    )
     conn.close()
     return city_id
 
 
 def _run_import(source_root, data_dir, manifest_path, *extra):
     return subprocess.run(
-        [sys.executable, SCRIPT, '--source-root', source_root,
-         '--data-dir', data_dir, '--manifest', manifest_path,
-         '--no-nominatim', *extra],
-        capture_output=True, text=True, cwd=PROJECT_ROOT)
+        [
+            sys.executable,
+            SCRIPT,
+            "--source-root",
+            source_root,
+            "--data-dir",
+            data_dir,
+            "--manifest",
+            manifest_path,
+            "--no-nominatim",
+            *extra,
+        ],
+        capture_output=True,
+        text=True,
+        cwd=PROJECT_ROOT,
+    )
 
 
 @pytest.fixture
@@ -80,38 +101,46 @@ def source_root(tmp_path):
 
 def test_v1_import_end_to_end(source_root, data_dir, tmp_path):
     csv_path = os.path.join(source_root, "Oldtown/Oldtown_30_coords.csv")
-    _write_v1_csv(csv_path,
-                  ok_rows=[(44.001, -121.001, 'pA', '2021-08'),
-                           (44.002, -121.001, 'pB', '2022-03')],
-                  fail_rows=[(44.003, -121.001)])
-    city_id = _register_city(data_dir, 'Oldtown', None, 'Testland')
-    manifest = _write_manifest(str(tmp_path / "m.json"), [
-        {"rel_csv": "Oldtown/Oldtown_30_coords.csv", "query": "Oldtown, Testland",
-         "run_date": "2023-11-05", "fmt": "v1"},
-    ])
+    _write_v1_csv(
+        csv_path,
+        ok_rows=[(44.001, -121.001, "pA", "2021-08"), (44.002, -121.001, "pB", "2022-03")],
+        fail_rows=[(44.003, -121.001)],
+    )
+    city_id = _register_city(data_dir, "Oldtown", None, "Testland")
+    manifest = _write_manifest(
+        str(tmp_path / "m.json"),
+        [
+            {
+                "rel_csv": "Oldtown/Oldtown_30_coords.csv",
+                "query": "Oldtown, Testland",
+                "run_date": "2023-11-05",
+                "fmt": "v1",
+            },
+        ],
+    )
 
     # Dry run: reports the plan, writes no run files and registers nothing
     result = _run_import(source_root, data_dir, manifest)
     assert result.returncode == 0, result.stderr
-    assert 'Would import: 1' in result.stdout
-    assert 'Dry run complete' in result.stdout
-    assert not [f for f in os.listdir(data_dir) if f.endswith('.csv.gz')]
-    conn = db.connect(os.path.join(data_dir, 'gsv_tracker.db'))
+    assert "Would import: 1" in result.stdout
+    assert "Dry run complete" in result.stdout
+    assert not [f for f in os.listdir(data_dir) if f.endswith(".csv.gz")]
+    conn = db.connect(os.path.join(data_dir, "gsv_tracker.db"))
     assert db.get_runs_for_city(conn, city_id) == []
     conn.close()
 
     # Execute
-    result = _run_import(source_root, data_dir, manifest, '--execute')
+    result = _run_import(source_root, data_dir, manifest, "--execute")
     assert result.returncode == 0, result.stderr
-    assert '1 baseline runs registered' in result.stdout
+    assert "1 baseline runs registered" in result.stdout
 
-    conn = db.connect(os.path.join(data_dir, 'gsv_tracker.db'))
+    conn = db.connect(os.path.join(data_dir, "gsv_tracker.db"))
     run = db.get_latest_run(conn, city_id)
     assert run.is_baseline
-    assert run.run_date == '2023-11-05'
-    assert run.provider == 'gsv'
-    assert run.csv_filename.startswith(f'{city_id}_width_')
-    assert '_step_30_2023-11-05' in run.csv_filename
+    assert run.run_date == "2023-11-05"
+    assert run.provider == "gsv"
+    assert run.csv_filename.startswith(f"{city_id}_width_")
+    assert "_step_30_2023-11-05" in run.csv_filename
     assert run.unique_panos == 2
     assert run.unique_google_panos is None  # copyright never captured
     assert run.status_ok == 2 and run.status_zero_results == 1
@@ -120,30 +149,35 @@ def test_v1_import_end_to_end(source_root, data_dir, tmp_path):
 
     # The written artifact round-trips through the canonical loader
     df = load_city_csv_file(os.path.join(data_dir, run.csv_filename))
-    assert list(df.columns) == ['query_lat', 'query_lon', 'query_timestamp',
-                                'pano_lat', 'pano_lon', 'pano_id',
-                                'capture_date', 'copyright_info', 'status']
-    assert df['copyright_info'].isna().all()
-    ok = df[df['status'] == 'OK']
+    assert list(df.columns) == [
+        "query_lat",
+        "query_lon",
+        "query_timestamp",
+        "pano_lat",
+        "pano_lon",
+        "pano_id",
+        "capture_date",
+        "copyright_info",
+        "status",
+    ]
+    assert df["copyright_info"].isna().all()
+    ok = df[df["status"] == "OK"]
     # YYYY-MM source dates land as first-of-month (loader parses to datetime)
-    assert sorted(ok['capture_date']) == [pd.Timestamp('2021-08-01'),
-                                          pd.Timestamp('2022-03-01')]
-    assert set(df['status']) == {'OK', 'ZERO_RESULTS'}
-    assert df['query_timestamp'].eq('2023-11-05T00:00:00+00:00').all()
+    assert sorted(ok["capture_date"]) == [pd.Timestamp("2021-08-01"), pd.Timestamp("2022-03-01")]
+    assert set(df["status"]) == {"OK", "ZERO_RESULTS"}
+    assert df["query_timestamp"].eq("2023-11-05T00:00:00+00:00").all()
 
     # Per-run JSON: baseline + copyright flag, google_panos omitted
-    with gzip.open(os.path.join(data_dir, run.json_filename), 'rt') as f:
-        summary = json.load(f, parse_constant=lambda t: (_ for _ in ()).throw(
-            ValueError(t)))
-    assert summary['run'] == {'run_date': '2023-11-05', 'is_baseline': True}
-    assert summary['copyright_info_available'] is False
-    assert 'google_panos' not in summary
+    with gzip.open(os.path.join(data_dir, run.json_filename), "rt") as f:
+        summary = json.load(f, parse_constant=lambda t: (_ for _ in ()).throw(ValueError(t)))
+    assert summary["run"] == {"run_date": "2023-11-05", "is_baseline": True}
+    assert summary["copyright_info_available"] is False
+    assert "google_panos" not in summary
     conn.close()
 
 
-def test_v2_headered_and_headerless_translate_identically(
-        source_root, data_dir, tmp_path):
-    ok = [(44.0011, -121.0011, 44.001, -121.001, 'pA', '2020-05')]
+def test_v2_headered_and_headerless_translate_identically(source_root, data_dir, tmp_path):
+    ok = [(44.0011, -121.0011, 44.001, -121.001, "pA", "2020-05")]
     fail = [(44.002, -121.001)]
     h_path = os.path.join(source_root, "Htown/Htown_30_coords.csv")
     n_path = os.path.join(source_root, "Ntown/Ntown_30_coords.csv")
@@ -152,37 +186,48 @@ def test_v2_headered_and_headerless_translate_identically(
     _write_bbox(h_path, 44.0, 44.01, -121.01, -121.0)
     # Ntown's bbox has deliberately swapped extents (seen in real sidecars)
     _write_bbox(n_path, 44.01, 44.0, -121.0, -121.01)
-    h_id = _register_city(data_dir, 'Htown', None, 'Testland')
-    n_id = _register_city(data_dir, 'Ntown', None, 'Testland')
-    manifest = _write_manifest(str(tmp_path / "m.json"), [
-        {"rel_csv": "Htown/Htown_30_coords.csv", "query": "Htown, Testland",
-         "run_date": "2024-02-14", "fmt": "v2"},
-        {"rel_csv": "Ntown/Ntown_30_coords.csv", "query": "Ntown, Testland",
-         "run_date": "2024-02-14", "fmt": "v2_headerless"},
-    ])
+    h_id = _register_city(data_dir, "Htown", None, "Testland")
+    n_id = _register_city(data_dir, "Ntown", None, "Testland")
+    manifest = _write_manifest(
+        str(tmp_path / "m.json"),
+        [
+            {
+                "rel_csv": "Htown/Htown_30_coords.csv",
+                "query": "Htown, Testland",
+                "run_date": "2024-02-14",
+                "fmt": "v2",
+            },
+            {
+                "rel_csv": "Ntown/Ntown_30_coords.csv",
+                "query": "Ntown, Testland",
+                "run_date": "2024-02-14",
+                "fmt": "v2_headerless",
+            },
+        ],
+    )
 
-    result = _run_import(source_root, data_dir, manifest, '--execute')
+    result = _run_import(source_root, data_dir, manifest, "--execute")
     assert result.returncode == 0, result.stderr
 
-    conn = db.connect(os.path.join(data_dir, 'gsv_tracker.db'))
+    conn = db.connect(os.path.join(data_dir, "gsv_tracker.db"))
     dfs = {}
     for city_id in (h_id, n_id):
         run = db.get_latest_run(conn, city_id)
         # min/max-normalized bboxes -> identical geometry in both filenames
-        assert '_step_30_2024-02-14' in run.csv_filename
+        assert "_step_30_2024-02-14" in run.csv_filename
         dfs[city_id] = load_city_csv_file(os.path.join(data_dir, run.csv_filename))
     conn.close()
 
     a, b = dfs[h_id], dfs[n_id]
     pd.testing.assert_frame_equal(a, b)
-    ok_rows = a[a['status'] == 'OK']
-    fail_rows = a[a['status'] == 'ZERO_RESULTS']
+    ok_rows = a[a["status"] == "OK"]
+    fail_rows = a[a["status"] == "ZERO_RESULTS"]
     # OK rows keep distinct pano vs query coords; failure rows only echoed
     # the query coords, so their pano fields must be null
-    assert float(ok_rows.iloc[0]['pano_lat']) == 44.0011
-    assert float(ok_rows.iloc[0]['query_lat']) == 44.001
-    assert fail_rows['pano_lat'].isna().all()
-    assert fail_rows['pano_id'].isna().all()
+    assert float(ok_rows.iloc[0]["pano_lat"]) == 44.0011
+    assert float(ok_rows.iloc[0]["query_lat"]) == 44.001
+    assert fail_rows["pano_lat"].isna().all()
+    assert fail_rows["pano_id"].isna().all()
 
 
 def test_two_runs_one_city_different_geometry(source_root, data_dir, tmp_path):
@@ -190,121 +235,165 @@ def test_two_runs_one_city_different_geometry(source_root, data_dir, tmp_path):
     # extents and dates -> one city, two baseline runs, no diff
     small = os.path.join(source_root, "DC/DC_30_coords.csv")
     big = os.path.join(source_root, "DC 10k/DC_30_coords.csv")
-    _write_v2_csv(small, [(44.0011, -121.0011, 44.001, -121.001, 'p1', '2020-05')],
-                  [(44.002, -121.001)])
-    _write_v2_csv(big, [(44.0011, -121.0011, 44.001, -121.001, 'p1', '2020-05'),
-                        (44.0021, -121.0011, 44.002, -121.001, 'p2', '2021-06')],
-                  [(44.003, -121.001)])
+    _write_v2_csv(
+        small, [(44.0011, -121.0011, 44.001, -121.001, "p1", "2020-05")], [(44.002, -121.001)]
+    )
+    _write_v2_csv(
+        big,
+        [
+            (44.0011, -121.0011, 44.001, -121.001, "p1", "2020-05"),
+            (44.0021, -121.0011, 44.002, -121.001, "p2", "2021-06"),
+        ],
+        [(44.003, -121.001)],
+    )
     _write_bbox(small, 44.0, 44.01, -121.01, -121.0)
     _write_bbox(big, 44.0, 44.09, -121.09, -121.0)
-    city_id = _register_city(data_dir, 'Deecee', None, 'Testland')
-    manifest = _write_manifest(str(tmp_path / "m.json"), [
-        {"rel_csv": "DC/DC_30_coords.csv", "query": "Deecee, Testland",
-         "run_date": "2023-11-03", "fmt": "v2"},
-        {"rel_csv": "DC 10k/DC_30_coords.csv", "query": "Deecee, Testland",
-         "run_date": "2024-04-11", "fmt": "v2"},
-    ])
+    city_id = _register_city(data_dir, "Deecee", None, "Testland")
+    manifest = _write_manifest(
+        str(tmp_path / "m.json"),
+        [
+            {
+                "rel_csv": "DC/DC_30_coords.csv",
+                "query": "Deecee, Testland",
+                "run_date": "2023-11-03",
+                "fmt": "v2",
+            },
+            {
+                "rel_csv": "DC 10k/DC_30_coords.csv",
+                "query": "Deecee, Testland",
+                "run_date": "2024-04-11",
+                "fmt": "v2",
+            },
+        ],
+    )
 
-    result = _run_import(source_root, data_dir, manifest, '--execute')
+    result = _run_import(source_root, data_dir, manifest, "--execute")
     assert result.returncode == 0, result.stderr
 
-    conn = db.connect(os.path.join(data_dir, 'gsv_tracker.db'))
+    conn = db.connect(os.path.join(data_dir, "gsv_tracker.db"))
     runs = db.get_runs_for_city(conn, city_id)
-    assert [r.run_date for r in runs] == ['2023-11-03', '2024-04-11']
+    assert [r.run_date for r in runs] == ["2023-11-03", "2024-04-11"]
     assert all(r.is_baseline for r in runs)
     assert runs[0].csv_filename != runs[1].csv_filename
     assert conn.execute("SELECT COUNT(*) FROM run_diffs").fetchone()[0] == 0
 
     # Aggregate regenerated with both runs and the copyright flag
-    with gzip.open(os.path.join(data_dir, 'cities.json.gz'), 'rt') as f:
+    with gzip.open(os.path.join(data_dir, "cities.json.gz"), "rt") as f:
         agg = json.load(f)
-    rec = next(c for c in agg['cities'] if c['city_id'] == city_id)
-    gsv = rec['providers']['gsv']
-    assert len(gsv['runs']) == 2
-    assert gsv['latest']['copyright_info_available'] is False
-    assert 'unique_google_panos' not in gsv['latest']['panorama_counts']
+    rec = next(c for c in agg["cities"] if c["city_id"] == city_id)
+    gsv = rec["providers"]["gsv"]
+    assert len(gsv["runs"]) == 2
+    assert gsv["latest"]["copyright_info_available"] is False
+    assert "unique_google_panos" not in gsv["latest"]["panorama_counts"]
     conn.close()
 
 
 def test_idempotent_rerun(source_root, data_dir, tmp_path):
     csv_path = os.path.join(source_root, "Oldtown/Oldtown_30_coords.csv")
-    _write_v1_csv(csv_path, ok_rows=[(44.001, -121.001, 'pA', '2021-08')],
-                  fail_rows=[])
-    _register_city(data_dir, 'Oldtown', None, 'Testland')
-    manifest = _write_manifest(str(tmp_path / "m.json"), [
-        {"rel_csv": "Oldtown/Oldtown_30_coords.csv", "query": "Oldtown, Testland",
-         "run_date": "2023-11-05", "fmt": "v1"},
-    ])
+    _write_v1_csv(csv_path, ok_rows=[(44.001, -121.001, "pA", "2021-08")], fail_rows=[])
+    _register_city(data_dir, "Oldtown", None, "Testland")
+    manifest = _write_manifest(
+        str(tmp_path / "m.json"),
+        [
+            {
+                "rel_csv": "Oldtown/Oldtown_30_coords.csv",
+                "query": "Oldtown, Testland",
+                "run_date": "2023-11-05",
+                "fmt": "v1",
+            },
+        ],
+    )
 
-    result = _run_import(source_root, data_dir, manifest, '--execute')
+    result = _run_import(source_root, data_dir, manifest, "--execute")
     assert result.returncode == 0, result.stderr
-    assert '1 baseline runs registered' in result.stdout
+    assert "1 baseline runs registered" in result.stdout
 
-    result = _run_import(source_root, data_dir, manifest, '--execute')
+    result = _run_import(source_root, data_dir, manifest, "--execute")
     assert result.returncode == 0, result.stderr
-    assert 'Imported: 0   already registered: 1' in result.stdout
+    assert "Imported: 0   already registered: 1" in result.stdout
 
 
 def test_unresolved_city_skipped_without_nominatim(source_root, data_dir, tmp_path):
     csv_path = os.path.join(source_root, "Ghost/Ghost_30_coords.csv")
-    _write_v1_csv(csv_path, ok_rows=[(44.001, -121.001, 'pA', '2021-08')],
-                  fail_rows=[])
-    manifest = _write_manifest(str(tmp_path / "m.json"), [
-        {"rel_csv": "Ghost/Ghost_30_coords.csv", "query": "Ghost, Nowhere",
-         "run_date": "2023-11-05", "fmt": "v1"},
-    ])
+    _write_v1_csv(csv_path, ok_rows=[(44.001, -121.001, "pA", "2021-08")], fail_rows=[])
+    manifest = _write_manifest(
+        str(tmp_path / "m.json"),
+        [
+            {
+                "rel_csv": "Ghost/Ghost_30_coords.csv",
+                "query": "Ghost, Nowhere",
+                "run_date": "2023-11-05",
+                "fmt": "v1",
+            },
+        ],
+    )
 
-    result = _run_import(source_root, data_dir, manifest, '--execute')
+    result = _run_import(source_root, data_dir, manifest, "--execute")
     assert result.returncode == 0, result.stderr
-    assert 'needs geocoding' in result.stdout
-    assert '0 baseline runs registered' in result.stdout
-    assert not [f for f in os.listdir(data_dir) if f.endswith('.csv.gz')]
+    assert "needs geocoding" in result.stdout
+    assert "0 baseline runs registered" in result.stdout
+    assert not [f for f in os.listdir(data_dir) if f.endswith(".csv.gz")]
 
 
-def test_manifest_identity_registers_without_geocoding(
-        source_root, data_dir, tmp_path):
+def test_manifest_identity_registers_without_geocoding(source_root, data_dir, tmp_path):
     # Locality-grade datasets (East Hollywood, Reinsletta) carry an explicit
     # identity so no Nominatim call happens even without --no-nominatim
     csv_path = os.path.join(source_root, "Quarter/Quarter_30_coords.csv")
-    _write_v2_csv(csv_path, [(44.0011, -121.0011, 44.001, -121.001, 'p1', '2020-05')],
-                  [(44.002, -121.001)])
+    _write_v2_csv(
+        csv_path, [(44.0011, -121.0011, 44.001, -121.001, "p1", "2020-05")], [(44.002, -121.001)]
+    )
     _write_bbox(csv_path, 44.0, 44.01, -121.01, -121.0)
-    manifest = _write_manifest(str(tmp_path / "m.json"), [
-        {"rel_csv": "Quarter/Quarter_30_coords.csv",
-         "query": "Quarter, Big City, Testland", "run_date": "2023-11-03",
-         "fmt": "v2", "identity": ["Quarter", None, "Testland"]},
-    ])
+    manifest = _write_manifest(
+        str(tmp_path / "m.json"),
+        [
+            {
+                "rel_csv": "Quarter/Quarter_30_coords.csv",
+                "query": "Quarter, Big City, Testland",
+                "run_date": "2023-11-03",
+                "fmt": "v2",
+                "identity": ["Quarter", None, "Testland"],
+            },
+        ],
+    )
 
     result = _run_import(source_root, data_dir, manifest)
     assert result.returncode == 0, result.stderr
-    assert 'would register from manifest identity (quarter--testland)' in result.stdout
+    assert "would register from manifest identity (quarter--testland)" in result.stdout
 
-    result = _run_import(source_root, data_dir, manifest, '--execute')
+    result = _run_import(source_root, data_dir, manifest, "--execute")
     assert result.returncode == 0, result.stderr
-    assert '1 baseline runs registered' in result.stdout
+    assert "1 baseline runs registered" in result.stdout
 
-    conn = db.connect(os.path.join(data_dir, 'gsv_tracker.db'))
-    city = db.resolve_city(conn, 'quarter--testland')
+    conn = db.connect(os.path.join(data_dir, "gsv_tracker.db"))
+    city = db.resolve_city(conn, "quarter--testland")
     assert city is not None
     assert city.step_m == 20  # frozen at the default step, not the archival 30
     assert (city.grid_width_m, city.grid_height_m) > (0, 0)
     run = db.get_latest_run(conn, city.city_id)
-    assert run.is_baseline and '_step_30_' in run.csv_filename
+    assert run.is_baseline and "_step_30_" in run.csv_filename
     conn.close()
 
 
 def test_format_mismatch_is_reported_not_fatal(source_root, data_dir, tmp_path):
     csv_path = os.path.join(source_root, "Mix/Mix_30_coords.csv")
-    _write_v2_csv(csv_path, [(44.0011, -121.0011, 44.001, -121.001, 'p1', '2020-05')],
-                  [], header=True)
-    _register_city(data_dir, 'Mix', None, 'Testland')
-    manifest = _write_manifest(str(tmp_path / "m.json"), [
-        {"rel_csv": "Mix/Mix_30_coords.csv", "query": "Mix, Testland",
-         "run_date": "2023-11-05", "fmt": "v1"},  # wrong on purpose
-    ])
+    _write_v2_csv(
+        csv_path, [(44.0011, -121.0011, 44.001, -121.001, "p1", "2020-05")], [], header=True
+    )
+    _register_city(data_dir, "Mix", None, "Testland")
+    manifest = _write_manifest(
+        str(tmp_path / "m.json"),
+        [
+            {
+                "rel_csv": "Mix/Mix_30_coords.csv",
+                "query": "Mix, Testland",
+                "run_date": "2023-11-05",
+                "fmt": "v1",
+            },  # wrong on purpose
+        ],
+    )
 
-    result = _run_import(source_root, data_dir, manifest, '--execute')
+    result = _run_import(source_root, data_dir, manifest, "--execute")
     assert result.returncode == 0, result.stderr
-    assert 'ERROR' in result.stdout
+    assert "ERROR" in result.stdout
     assert "sniffs as 'v2'" in result.stdout
-    assert '0 baseline runs registered' in result.stdout
+    assert "0 baseline runs registered" in result.stdout

--- a/tests/test_boundary_audit.py
+++ b/tests/test_boundary_audit.py
@@ -10,7 +10,6 @@ import math
 import pytest
 
 from gsv_metadata_tracker.boundary_audit import (
-    OsmBoundary,
     Thresholds,
     bbox_dims_m,
     bbox_intersection_frac,
@@ -23,37 +22,55 @@ from gsv_metadata_tracker.boundary_audit import (
 from gsv_metadata_tracker.db import CityRow
 
 
-def make_city(center_lat=47.6, center_lon=-122.33,
-              grid_width_m=10_000, grid_height_m=10_000):
+def make_city(center_lat=47.6, center_lon=-122.33, grid_width_m=10_000, grid_height_m=10_000):
     return CityRow(
-        city_id='test--city', display_name='Test City',
-        city_name='Test', state_name='Washington', state_code='WA',
-        country_name='United States', country_code='US',
-        center_lat=center_lat, center_lon=center_lon,
-        grid_width_m=grid_width_m, grid_height_m=grid_height_m,
-        step_m=20, created_at='2026-07-06T00:00:00+00:00',
-        enabled=True, notes=None)
+        city_id="test--city",
+        display_name="Test City",
+        city_name="Test",
+        state_name="Washington",
+        state_code="WA",
+        country_name="United States",
+        country_code="US",
+        center_lat=center_lat,
+        center_lon=center_lon,
+        grid_width_m=grid_width_m,
+        grid_height_m=grid_height_m,
+        step_m=20,
+        created_at="2026-07-06T00:00:00+00:00",
+        enabled=True,
+        notes=None,
+    )
 
 
-def make_raw(south, north, west, east, geojson='polygon', lat=None, lon=None,
-             display_name='Test, Washington, United States'):
+def make_raw(
+    south,
+    north,
+    west,
+    east,
+    geojson="polygon",
+    lat=None,
+    lon=None,
+    display_name="Test, Washington, United States",
+):
     """Synthetic Nominatim raw dict — boundingbox strings, like the API."""
     raw = {
-        'display_name': display_name,
-        'osm_type': 'relation',
-        'class': 'boundary',
-        'type': 'administrative',
-        'lat': str(lat if lat is not None else (south + north) / 2),
-        'lon': str(lon if lon is not None else (west + east) / 2),
-        'boundingbox': [str(south), str(north), str(west), str(east)],
+        "display_name": display_name,
+        "osm_type": "relation",
+        "class": "boundary",
+        "type": "administrative",
+        "lat": str(lat if lat is not None else (south + north) / 2),
+        "lon": str(lon if lon is not None else (west + east) / 2),
+        "boundingbox": [str(south), str(north), str(west), str(east)],
     }
-    if geojson == 'polygon':
-        raw['geojson'] = {'type': 'Polygon', 'coordinates': [[
-            [west, south], [east, south], [east, north], [west, north],
-            [west, south]]]}
-    elif geojson == 'point':
-        raw['geojson'] = {'type': 'Point',
-                          'coordinates': [raw['lon'], raw['lat']]}
+    if geojson == "polygon":
+        raw["geojson"] = {
+            "type": "Polygon",
+            "coordinates": [
+                [[west, south], [east, south], [east, north], [west, north], [west, south]]
+            ],
+        }
+    elif geojson == "point":
+        raw["geojson"] = {"type": "Point", "coordinates": [raw["lon"], raw["lat"]]}
     return raw
 
 
@@ -61,15 +78,16 @@ def square_ring(center_lat, center_lon, side_m):
     """Closed GeoJSON ring approximating a side_m × side_m square."""
     half_lat = (side_m / 2) / 110_540.0
     half_lon = (side_m / 2) / (111_320.0 * math.cos(math.radians(center_lat)))
-    return [[center_lon - half_lon, center_lat - half_lat],
-            [center_lon + half_lon, center_lat - half_lat],
-            [center_lon + half_lon, center_lat + half_lat],
-            [center_lon - half_lon, center_lat + half_lat],
-            [center_lon - half_lon, center_lat - half_lat]]
+    return [
+        [center_lon - half_lon, center_lat - half_lat],
+        [center_lon + half_lon, center_lat - half_lat],
+        [center_lon + half_lon, center_lat + half_lat],
+        [center_lon - half_lon, center_lat + half_lat],
+        [center_lon - half_lon, center_lat - half_lat],
+    ]
 
 
 class TestBboxMath:
-
     def test_bbox_dims_at_equator(self):
         # 1 degree of longitude at the equator ~ 111.3 km
         w, h = bbox_dims_m((-0.5, 0.5, 10.0, 11.0))
@@ -79,10 +97,9 @@ class TestBboxMath:
     def test_bbox_width_shrinks_at_high_latitude(self):
         w_eq, _ = bbox_dims_m((-0.5, 0.5, 10.0, 11.0))
         w_60, _ = bbox_dims_m((59.5, 60.5, 10.0, 11.0))
-        assert w_60 == pytest.approx(w_eq * math.cos(math.radians(60)),
-                                     rel=0.02)
+        assert w_60 == pytest.approx(w_eq * math.cos(math.radians(60)), rel=0.02)
 
-    @pytest.mark.parametrize('lat', [0.0, 47.6, -45.0])
+    @pytest.mark.parametrize("lat", [0.0, 47.6, -45.0])
     def test_frozen_rect_roundtrip(self, lat):
         rect = frozen_rect_bounds(lat, 10.0, 8_000, 6_000)
         w, h = bbox_dims_m(rect)
@@ -93,43 +110,42 @@ class TestBboxMath:
         target = (0.0, 1.0, 0.0, 1.0)
         assert bbox_intersection_frac((-1, 2, -1, 2), target) == 1.0
         assert bbox_intersection_frac((5, 6, 5, 6), target) == 0.0
-        assert bbox_intersection_frac((0.0, 0.5, 0.0, 1.0), target) == \
-            pytest.approx(0.5)
+        assert bbox_intersection_frac((0.0, 0.5, 0.0, 1.0), target) == pytest.approx(0.5)
 
     def test_intersection_degenerate_target_is_zero(self):
         assert bbox_intersection_frac((0, 1, 0, 1), (2.0, 2.0, 5.0, 5.0)) == 0.0
 
 
 class TestPolygonArea:
-
-    @pytest.mark.parametrize('lat', [0.0, 60.0])
+    @pytest.mark.parametrize("lat", [0.0, 60.0])
     def test_square_km_area(self, lat):
-        geom = {'type': 'Polygon',
-                'coordinates': [square_ring(lat, 10.0, 1_000)]}
+        geom = {"type": "Polygon", "coordinates": [square_ring(lat, 10.0, 1_000)]}
         assert polygon_area_m2(geom) == pytest.approx(1e6, rel=0.03)
 
     def test_hole_is_subtracted_and_winding_agnostic(self):
         outer = square_ring(0.0, 10.0, 1_000)
         hole = square_ring(0.0, 10.0, 500)
-        geom = {'type': 'Polygon', 'coordinates': [outer, hole]}
+        geom = {"type": "Polygon", "coordinates": [outer, hole]}
         assert polygon_area_m2(geom) == pytest.approx(1e6 - 0.25e6, rel=0.03)
-        geom_rev = {'type': 'Polygon',
-                    'coordinates': [outer[::-1], hole[::-1]]}
-        assert polygon_area_m2(geom_rev) == pytest.approx(
-            polygon_area_m2(geom))
+        geom_rev = {"type": "Polygon", "coordinates": [outer[::-1], hole[::-1]]}
+        assert polygon_area_m2(geom_rev) == pytest.approx(polygon_area_m2(geom))
 
     def test_multipolygon_sums(self):
-        geom = {'type': 'MultiPolygon', 'coordinates': [
-            [square_ring(0.0, 10.0, 1_000)],
-            [square_ring(0.0, 12.0, 1_000)]]}
+        geom = {
+            "type": "MultiPolygon",
+            "coordinates": [[square_ring(0.0, 10.0, 1_000)], [square_ring(0.0, 12.0, 1_000)]],
+        }
         assert polygon_area_m2(geom) == pytest.approx(2e6, rel=0.03)
 
-    @pytest.mark.parametrize('geom', [
-        None,
-        {'type': 'Point', 'coordinates': [10.0, 0.0]},
-        {'type': 'LineString', 'coordinates': [[10.0, 0.0], [11.0, 0.0]]},
-        {'type': 'GeometryCollection', 'geometries': []},
-    ])
+    @pytest.mark.parametrize(
+        "geom",
+        [
+            None,
+            {"type": "Point", "coordinates": [10.0, 0.0]},
+            {"type": "LineString", "coordinates": [[10.0, 0.0], [11.0, 0.0]]},
+            {"type": "GeometryCollection", "geometries": []},
+        ],
+    )
     def test_non_areal_geometry_is_none(self, geom):
         assert polygon_area_m2(geom) is None
 
@@ -138,7 +154,7 @@ class TestRectPolygonCoverage:
     """rect_polygon_coverage: fraction of a boundary polygon inside a grid."""
 
     def _poly(self, lat=0.0, lon=10.0, side_m=1_000):
-        return {'type': 'Polygon', 'coordinates': [square_ring(lat, lon, side_m)]}
+        return {"type": "Polygon", "coordinates": [square_ring(lat, lon, side_m)]}
 
     def test_rect_fully_contains_polygon_is_one(self):
         poly = self._poly(side_m=1_000)
@@ -160,34 +176,39 @@ class TestRectPolygonCoverage:
 
     def test_multipolygon_partial(self):
         # Two 1 km² squares; a rect over only one covers half the total area.
-        geom = {'type': 'MultiPolygon', 'coordinates': [
-            [square_ring(0.0, 10.0, 1_000)],
-            [square_ring(0.0, 12.0, 1_000)]]}
+        geom = {
+            "type": "MultiPolygon",
+            "coordinates": [[square_ring(0.0, 10.0, 1_000)], [square_ring(0.0, 12.0, 1_000)]],
+        }
         over_one = frozen_rect_bounds(0.0, 10.0, 3_000, 3_000)
         assert rect_polygon_coverage(geom, over_one) == pytest.approx(0.5, abs=0.02)
 
-    @pytest.mark.parametrize('geom,bbox', [
-        (None, frozen_rect_bounds(0.0, 10.0, 1_000, 1_000)),
-        ({'type': 'Point', 'coordinates': [10.0, 0.0]},
-         frozen_rect_bounds(0.0, 10.0, 1_000, 1_000)),
-    ])
+    @pytest.mark.parametrize(
+        "geom,bbox",
+        [
+            (None, frozen_rect_bounds(0.0, 10.0, 1_000, 1_000)),
+            (
+                {"type": "Point", "coordinates": [10.0, 0.0]},
+                frozen_rect_bounds(0.0, 10.0, 1_000, 1_000),
+            ),
+        ],
+    )
     def test_no_polygon_or_bbox_is_none(self, geom, bbox):
         assert rect_polygon_coverage(geom, bbox) is None
         assert rect_polygon_coverage(self._poly(), None) is None
 
 
 class TestParseOsmResult:
-
     def test_string_bbox_is_coerced(self):
         osm = parse_osm_result(make_raw(47.5, 47.7, -122.4, -122.2))
         assert osm.bbox == (47.5, 47.7, -122.4, -122.2)
-        assert osm.geometry_type == 'Polygon'
+        assert osm.geometry_type == "Polygon"
         assert osm.polygon_area_m2 is not None and osm.polygon_area_m2 > 0
-        assert osm.place_class == 'boundary'
+        assert osm.place_class == "boundary"
 
     def test_missing_bbox_and_geojson_tolerated(self):
         raw = make_raw(47.5, 47.7, -122.4, -122.2)
-        del raw['boundingbox'], raw['geojson']
+        del raw["boundingbox"], raw["geojson"]
         osm = parse_osm_result(raw)
         assert osm.bbox is None
         assert osm.geometry_type is None
@@ -201,17 +222,17 @@ class TestClassify:
 
     def test_ok_when_rect_matches_osm_bbox(self):
         osm = parse_osm_result(make_raw(*self.MATCHING))
-        assert classify(make_city(), osm).verdict == 'OK'
+        assert classify(make_city(), osm).verdict == "OK"
 
     def test_not_found(self):
-        assert classify(make_city(), None).verdict == 'NOT_FOUND'
+        assert classify(make_city(), None).verdict == "NOT_FOUND"
 
     def test_under_when_osm_bbox_much_larger(self):
         # Neighborhood-sized frozen rect inside a 3x-per-axis city bbox
         big = frozen_rect_bounds(47.6, -122.33, 30_000, 30_000)
         osm = parse_osm_result(make_raw(*big))
         res = classify(make_city(), osm)
-        assert res.verdict == 'UNDER'
+        assert res.verdict == "UNDER"
         assert res.bbox_coverage_frac == pytest.approx(1 / 9, rel=0.05)
         assert res.suggested_width_m == pytest.approx(30_000, rel=0.01)
         assert res.suggested_height_m == pytest.approx(30_000, rel=0.01)
@@ -219,43 +240,40 @@ class TestClassify:
     def test_over_when_rect_is_admin_region_sized(self):
         # Frozen rect 40x40 km over a 10x10 km municipality
         osm = parse_osm_result(make_raw(*self.MATCHING))
-        res = classify(make_city(grid_width_m=40_000, grid_height_m=40_000),
-                       osm)
-        assert res.verdict == 'OVER'
+        res = classify(make_city(grid_width_m=40_000, grid_height_m=40_000), osm)
+        assert res.verdict == "OVER"
         assert res.over_area_ratio == pytest.approx(16.0, rel=0.05)
 
     def test_wrong_place_beats_size_verdicts(self):
         # Bancroft-style: frozen center hundreds of km from the OSM city
         osm = parse_osm_result(make_raw(44.0, 44.1, -94.0, -93.9))
         res = classify(make_city(center_lat=47.6, center_lon=-122.33), osm)
-        assert res.verdict == 'WRONG_PLACE'
+        assert res.verdict == "WRONG_PLACE"
         assert res.center_in_osm_bbox is False
         assert res.center_dist_km > 1_000
 
     def test_no_polygon_for_point_result(self):
-        osm = parse_osm_result(make_raw(*self.MATCHING, geojson='point'))
-        assert classify(make_city(), osm).verdict == 'NO_POLYGON'
+        osm = parse_osm_result(make_raw(*self.MATCHING, geojson="point"))
+        assert classify(make_city(), osm).verdict == "NO_POLYGON"
 
     def test_bbox_suspect_when_inverted_or_missing(self):
         # west > east (antimeridian-style artifact)
         osm = parse_osm_result(make_raw(47.5, 47.7, 170.0, -170.0))
-        assert classify(make_city(), osm).verdict == 'BBOX_SUSPECT'
+        assert classify(make_city(), osm).verdict == "BBOX_SUSPECT"
         raw = make_raw(47.5, 47.7, -122.4, -122.2)
-        del raw['boundingbox']
-        assert classify(make_city(), parse_osm_result(raw)).verdict == \
-            'BBOX_SUSPECT'
+        del raw["boundingbox"]
+        assert classify(make_city(), parse_osm_result(raw)).verdict == "BBOX_SUSPECT"
 
     def test_thresholds_are_tunable(self):
         big = frozen_rect_bounds(47.6, -122.33, 12_000, 12_000)
         osm = parse_osm_result(make_raw(*big))
         # coverage ~0.69: UNDER at the default 0.75, OK at 0.5
-        assert classify(make_city(), osm).verdict == 'UNDER'
-        assert classify(make_city(), osm,
-                        Thresholds(min_coverage=0.5)).verdict == 'OK'
+        assert classify(make_city(), osm).verdict == "UNDER"
+        assert classify(make_city(), osm, Thresholds(min_coverage=0.5)).verdict == "OK"
 
     def test_degenerate_frozen_rect_is_under(self):
         # Real catalog case: an 8 m-wide junk rectangle
         osm = parse_osm_result(make_raw(*self.MATCHING))
         res = classify(make_city(grid_width_m=8, grid_height_m=8), osm)
-        assert res.verdict == 'UNDER'
+        assert res.verdict == "UNDER"
         assert res.bbox_coverage_frac == pytest.approx(0.0, abs=1e-6)

--- a/tests/test_build_boundary_review.py
+++ b/tests/test_build_boundary_review.py
@@ -9,20 +9,16 @@ delegated to boundary_audit.frozen_rect_bounds, so we assert the two agree.
 import importlib.util
 import os
 
-import pytest
-
 PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 _spec = importlib.util.spec_from_file_location(
-    "build_boundary_review",
-    os.path.join(PROJECT_ROOT, "scripts", "build_boundary_review.py"))
+    "build_boundary_review", os.path.join(PROJECT_ROOT, "scripts", "build_boundary_review.py")
+)
 bbr = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(bbr)
 
-from gsv_metadata_tracker.boundary_audit import frozen_rect_bounds
+from gsv_metadata_tracker.boundary_audit import frozen_rect_bounds  # noqa: E402
 
-
-CURRENT = {"center_lat": 42.35, "center_lon": -71.06,
-           "grid_width_m": 20000, "grid_height_m": 20000}
+CURRENT = {"center_lat": 42.35, "center_lon": -71.06, "grid_width_m": 20000, "grid_height_m": 20000}
 
 
 def _expected_bounds(lat, lon, w, h):
@@ -31,35 +27,59 @@ def _expected_bounds(lat, lon, w, h):
 
 
 def manual_row(**kw):
-    base = {"city_id": "boston", "display_name": "Boston", "verdict": "UNDER",
-            "reason": "recenter only", "rec_center_lat": "42.31",
-            "rec_center_lon": "-71.00", "rec_width_m": "31885",
-            "rec_height_m": "18779", "rec_basis": "recenter only — grid ≈ OSM bbox",
-            "coverage_before": "0.62"}
+    base = {
+        "city_id": "boston",
+        "display_name": "Boston",
+        "verdict": "UNDER",
+        "reason": "recenter only",
+        "rec_center_lat": "42.31",
+        "rec_center_lon": "-71.00",
+        "rec_width_m": "31885",
+        "rec_height_m": "18779",
+        "rec_basis": "recenter only — grid ≈ OSM bbox",
+        "coverage_before": "0.62",
+    }
     base.update(kw)
     return base
 
 
 def plan_row(**kw):
-    base = {"city_id": "boston", "display_name": "Boston", "verdict": "UNDER",
-            "reason": "recenter on OSM midpoint + grow to OSM bbox",
-            "old_center_lat": "42.35", "old_center_lon": "-71.06",
-            "old_width_m": "20000", "old_height_m": "20000",
-            "new_center_lat": "42.31", "new_center_lon": "-71.00",
-            "new_width_m": "31885", "new_height_m": "18779",
-            "coverage_before": "0.62"}
+    base = {
+        "city_id": "boston",
+        "display_name": "Boston",
+        "verdict": "UNDER",
+        "reason": "recenter on OSM midpoint + grow to OSM bbox",
+        "old_center_lat": "42.35",
+        "old_center_lon": "-71.06",
+        "old_width_m": "20000",
+        "old_height_m": "20000",
+        "new_center_lat": "42.31",
+        "new_center_lon": "-71.00",
+        "new_width_m": "31885",
+        "new_height_m": "18779",
+        "coverage_before": "0.62",
+    }
     base.update(kw)
     return base
 
 
 def report_row(**kw):
-    base = {"city_id": "boston", "display_name": "Boston", "verdict": "UNDER",
-            # pre-fix frozen snapshot — differs from CURRENT so a resize is detected
-            "frozen_center_lat": "42.20", "frozen_center_lon": "-71.20",
-            "frozen_width_m": "20000", "frozen_height_m": "20000",
-            "suggested_center_lat": "42.31", "suggested_center_lon": "-71.00",
-            "osm_bbox_width_m": "31885", "osm_bbox_height_m": "18779",
-            "center_dist_km": "5.2", "osm_polygon_area_km2": "125"}
+    base = {
+        "city_id": "boston",
+        "display_name": "Boston",
+        "verdict": "UNDER",
+        # pre-fix frozen snapshot — differs from CURRENT so a resize is detected
+        "frozen_center_lat": "42.20",
+        "frozen_center_lon": "-71.20",
+        "frozen_width_m": "20000",
+        "frozen_height_m": "20000",
+        "suggested_center_lat": "42.31",
+        "suggested_center_lon": "-71.00",
+        "osm_bbox_width_m": "31885",
+        "osm_bbox_height_m": "18779",
+        "center_dist_km": "5.2",
+        "osm_polygon_area_km2": "125",
+    }
     base.update(kw)
     return base
 
@@ -73,68 +93,115 @@ def cache_rec(geojson=None, lat="42.30", lon="-71.05"):
 
 # --- frozen rectangle: always from live catalog geometry ---
 
+
 def test_frozen_bounds_match_audit_math():
-    p = bbr.build_city_payload("boston", group="manual", current=CURRENT,
-                               report=report_row(), rec_source=manual_row(),
-                               cache=None)
+    p = bbr.build_city_payload(
+        "boston",
+        group="manual",
+        current=CURRENT,
+        report=report_row(),
+        rec_source=manual_row(),
+        cache=None,
+    )
     assert p["frozen_bounds"] == _expected_bounds(42.35, -71.06, 20000, 20000)
     assert p["frozen_geom"]["width_m"] == 20000
 
 
 def test_no_current_geometry_yields_null_frozen():
-    p = bbr.build_city_payload("ghost", group="manual", current=None,
-                               report=report_row(), rec_source=manual_row(),
-                               cache=None)
+    p = bbr.build_city_payload(
+        "ghost",
+        group="manual",
+        current=None,
+        report=report_row(),
+        rec_source=manual_row(),
+        cache=None,
+    )
     assert p["frozen_bounds"] is None
     assert p["frozen_geom"] is None
 
 
 # --- OSM bbox from the report ---
 
+
 def test_osm_bbox_bounds_from_report():
-    p = bbr.build_city_payload("boston", group="manual", current=CURRENT,
-                               report=report_row(), rec_source=manual_row(),
-                               cache=None)
+    p = bbr.build_city_payload(
+        "boston",
+        group="manual",
+        current=CURRENT,
+        report=report_row(),
+        rec_source=manual_row(),
+        cache=None,
+    )
     assert p["osm_bbox_bounds"] == _expected_bounds(42.31, -71.00, 31885, 18779)
 
 
 def test_osm_bbox_null_when_report_missing_fields():
     r = report_row(osm_bbox_width_m="", suggested_center_lat="")
-    p = bbr.build_city_payload("boston", group="manual", current=CURRENT,
-                               report=r, rec_source=manual_row(), cache=None)
+    p = bbr.build_city_payload(
+        "boston", group="manual", current=CURRENT, report=r, rec_source=manual_row(), cache=None
+    )
     assert p["osm_bbox_bounds"] is None
     assert p["osm_bbox_geom"] is None
 
 
 def test_osm_bbox_geom_is_selectable_center_size():
     # The OSM bbox is exposed as a center+size geom so a reviewer can pick it.
-    p = bbr.build_city_payload("boston", group="manual", current=CURRENT,
-                               report=report_row(), rec_source=manual_row(), cache=None)
-    assert p["osm_bbox_geom"] == {"center_lat": 42.31, "center_lon": -71.00,
-                                  "width_m": 31885, "height_m": 18779}
+    p = bbr.build_city_payload(
+        "boston",
+        group="manual",
+        current=CURRENT,
+        report=report_row(),
+        rec_source=manual_row(),
+        cache=None,
+    )
+    assert p["osm_bbox_geom"] == {
+        "center_lat": 42.31,
+        "center_lon": -71.00,
+        "width_m": 31885,
+        "height_m": 18779,
+    }
 
 
 # --- recommendation sourcing differs by group ---
 
+
 def test_manual_rec_from_rec_fields():
-    p = bbr.build_city_payload("boston", group="manual", current=CURRENT,
-                               report=report_row(), rec_source=manual_row(),
-                               cache=None)
+    p = bbr.build_city_payload(
+        "boston",
+        group="manual",
+        current=CURRENT,
+        report=report_row(),
+        rec_source=manual_row(),
+        cache=None,
+    )
     assert p["rec_bounds"] == _expected_bounds(42.31, -71.00, 31885, 18779)
-    assert p["rec_geom"] == {"center_lat": 42.31, "center_lon": -71.00,
-                             "width_m": 31885, "height_m": 18779}
+    assert p["rec_geom"] == {
+        "center_lat": 42.31,
+        "center_lon": -71.00,
+        "width_m": 31885,
+        "height_m": 18779,
+    }
     assert "recenter only" in p["rec_basis"]
-    assert p["old_bounds"] is None   # manual cities are untouched — no before/after
+    assert p["old_bounds"] is None  # manual cities are untouched — no before/after
 
 
 def test_resize_shows_old_from_report_frozen():
     # An already-applied resize verifies OLD (report frozen_*) vs current; no rec.
-    p = bbr.build_city_payload("boston", group="resize", current=CURRENT,
-                               report=report_row(), rec_source=plan_row(),
-                               cache=None)
+    p = bbr.build_city_payload(
+        "boston",
+        group="resize",
+        current=CURRENT,
+        report=report_row(),
+        rec_source=plan_row(),
+        cache=None,
+    )
     assert p["old_bounds"] == _expected_bounds(42.20, -71.20, 20000, 20000)
-    assert p["old_geom"] == {"center_lat": 42.20, "center_lon": -71.20,
-                             "width_m": 20000, "height_m": 20000}
+    assert p["old_geom"] == {
+        "center_lat": 42.20,
+        "center_lon": -71.20,
+        "width_m": 20000,
+        "height_m": 20000,
+    }
     assert p["rec_bounds"] is None and p["rec_geom"] is None
     assert p["frozen_bounds"] == _expected_bounds(42.35, -71.06, 20000, 20000)
     assert "grow to OSM bbox" in p["rec_basis"]
@@ -142,48 +209,79 @@ def test_resize_shows_old_from_report_frozen():
 
 # --- polygon + representative point from the cache ---
 
+
 def test_polygon_passthrough_and_rounding():
-    poly = {"type": "Polygon",
-            "coordinates": [[[-71.123456789, 42.987654321], [-71.1, 42.9], [-71.2, 42.8]]]}
-    p = bbr.build_city_payload("boston", group="manual", current=CURRENT,
-                               report=report_row(), rec_source=manual_row(),
-                               cache=cache_rec(geojson=poly))
+    poly = {
+        "type": "Polygon",
+        "coordinates": [[[-71.123456789, 42.987654321], [-71.1, 42.9], [-71.2, 42.8]]],
+    }
+    p = bbr.build_city_payload(
+        "boston",
+        group="manual",
+        current=CURRENT,
+        report=report_row(),
+        rec_source=manual_row(),
+        cache=cache_rec(geojson=poly),
+    )
     assert p["osm_polygon"]["type"] == "Polygon"
     assert p["osm_polygon"]["coordinates"][0][0] == [-71.12346, 42.98765]
     assert p["osm_center"] == [42.30, -71.05]
 
 
 def test_multipolygon_supported():
-    poly = {"type": "MultiPolygon",
-            "coordinates": [[[[-71.1, 42.9], [-71.0, 42.9], [-71.0, 42.8]]]]}
-    p = bbr.build_city_payload("boston", group="manual", current=CURRENT,
-                               report=report_row(), rec_source=manual_row(),
-                               cache=cache_rec(geojson=poly))
+    poly = {
+        "type": "MultiPolygon",
+        "coordinates": [[[[-71.1, 42.9], [-71.0, 42.9], [-71.0, 42.8]]]],
+    }
+    p = bbr.build_city_payload(
+        "boston",
+        group="manual",
+        current=CURRENT,
+        report=report_row(),
+        rec_source=manual_row(),
+        cache=cache_rec(geojson=poly),
+    )
     assert p["osm_polygon"]["type"] == "MultiPolygon"
 
 
 def test_missing_cache_yields_null_polygon_and_center():
-    p = bbr.build_city_payload("boston", group="manual", current=CURRENT,
-                               report=report_row(), rec_source=manual_row(),
-                               cache=None)
+    p = bbr.build_city_payload(
+        "boston",
+        group="manual",
+        current=CURRENT,
+        report=report_row(),
+        rec_source=manual_row(),
+        cache=None,
+    )
     assert p["osm_polygon"] is None
     assert p["osm_center"] is None
 
 
 def test_non_polygon_geojson_ignored():
     pt = {"type": "Point", "coordinates": [-71.05, 42.30]}
-    p = bbr.build_city_payload("boston", group="manual", current=CURRENT,
-                               report=report_row(), rec_source=manual_row(),
-                               cache=cache_rec(geojson=pt))
+    p = bbr.build_city_payload(
+        "boston",
+        group="manual",
+        current=CURRENT,
+        report=report_row(),
+        rec_source=manual_row(),
+        cache=cache_rec(geojson=pt),
+    )
     assert p["osm_polygon"] is None
 
 
 # --- info panel metrics ---
 
+
 def test_info_metrics_populated():
-    p = bbr.build_city_payload("boston", group="manual", current=CURRENT,
-                               report=report_row(), rec_source=manual_row(),
-                               cache=None)
+    p = bbr.build_city_payload(
+        "boston",
+        group="manual",
+        current=CURRENT,
+        report=report_row(),
+        rec_source=manual_row(),
+        cache=None,
+    )
     assert p["info"]["center_dist_km"] == 5.2
     assert p["info"]["coverage_before"] == 0.62
     assert p["info"]["osm_polygon_area_km2"] == 125.0
@@ -191,13 +289,15 @@ def test_info_metrics_populated():
 
 # --- assembling the full list ---
 
+
 def test_build_payloads_groups_and_orders():
     payloads, skipped = bbr.build_payloads(
         current_by_id={"boston": CURRENT, "seattle": CURRENT},
         report_by_id={"boston": report_row(), "seattle": report_row(city_id="seattle")},
         manual_by_id={"boston": manual_row()},
         plan_by_id={"seattle": plan_row(city_id="seattle")},
-        cache_by_id={})
+        cache_by_id={},
+    )
     groups = {p["city_id"]: p["group"] for p in payloads}
     assert groups == {"boston": "manual", "seattle": "resize"}
     assert skipped == 0
@@ -206,20 +306,32 @@ def test_build_payloads_groups_and_orders():
 def test_build_payloads_skips_unchanged_resizes():
     # If the current geometry still equals the pre-fix frozen snapshot, no resize
     # was actually applied — nothing to verify, so the city is dropped but counted.
-    unchanged = report_row(city_id="nc", frozen_center_lat="42.35",
-                           frozen_center_lon="-71.06", frozen_width_m="20000",
-                           frozen_height_m="20000")
+    unchanged = report_row(
+        city_id="nc",
+        frozen_center_lat="42.35",
+        frozen_center_lon="-71.06",
+        frozen_width_m="20000",
+        frozen_height_m="20000",
+    )
     payloads, skipped = bbr.build_payloads(
-        current_by_id={"nc": CURRENT}, report_by_id={"nc": unchanged},
-        manual_by_id={}, plan_by_id={"nc": plan_row(city_id="nc")}, cache_by_id={})
+        current_by_id={"nc": CURRENT},
+        report_by_id={"nc": unchanged},
+        manual_by_id={},
+        plan_by_id={"nc": plan_row(city_id="nc")},
+        cache_by_id={},
+    )
     assert payloads == []
     assert skipped == 1
 
 
 def test_resize_changed():
-    assert bbr._resize_changed(report_row(), CURRENT) is True   # frozen 42.20 != 42.35
-    same = report_row(frozen_center_lat="42.35", frozen_center_lon="-71.06",
-                      frozen_width_m="20000", frozen_height_m="20000")
+    assert bbr._resize_changed(report_row(), CURRENT) is True  # frozen 42.20 != 42.35
+    same = report_row(
+        frozen_center_lat="42.35",
+        frozen_center_lon="-71.06",
+        frozen_width_m="20000",
+        frozen_height_m="20000",
+    )
     assert bbr._resize_changed(same, CURRENT) is False
     assert bbr._resize_changed(None, CURRENT) is False
     assert bbr._resize_changed(report_row(), None) is False
@@ -227,10 +339,18 @@ def test_resize_changed():
 
 # --- HTML injection ---
 
+
 def test_render_html_injects_and_escapes():
-    payloads = [bbr.build_city_payload("boston", group="manual", current=CURRENT,
-                                       report=report_row(), rec_source=manual_row(),
-                                       cache=None)]
+    payloads = [
+        bbr.build_city_payload(
+            "boston",
+            group="manual",
+            current=CURRENT,
+            report=report_row(),
+            rec_source=manual_row(),
+            cache=None,
+        )
+    ]
     html = bbr.render_html(payloads)
     assert bbr.DATA_PLACEHOLDER not in html
     assert '"city_id":"boston"' in html
@@ -238,7 +358,15 @@ def test_render_html_injects_and_escapes():
 
 def test_render_html_neutralizes_close_tag():
     row = manual_row(rec_basis="danger </script> tag")
-    payloads = [bbr.build_city_payload("boston", group="manual", current=CURRENT,
-                                       report=report_row(), rec_source=row, cache=None)]
+    payloads = [
+        bbr.build_city_payload(
+            "boston",
+            group="manual",
+            current=CURRENT,
+            report=report_row(),
+            rec_source=row,
+            cache=None,
+        )
+    ]
     html = bbr.render_html(payloads)
     assert "danger <\\/script> tag" in html

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -20,12 +20,12 @@ from tests.conftest import COLUMNS, make_city_df, make_mapillary_city_df
 
 
 class TestCalculateCoverageStats:
-
     def test_gsv_duplicate_panos_do_not_reduce_coverage(self):
         # 3 OK points but only 2 unique panos (adjacent points snapped to
         # the same pano) + 2 empty points: coverage is 3/5, not 2/5
-        df = make_city_df([('a', '2020-01-01'), ('a', '2020-01-01'),
-                           ('b', '2021-01-01')], n_empty=2)
+        df = make_city_df(
+            [("a", "2020-01-01"), ("a", "2020-01-01"), ("b", "2021-01-01")], n_empty=2
+        )
         cov = calculate_coverage_stats(df)
         assert cov.num_points_with_panos == 3
         assert cov.num_points_without_panos == 2
@@ -36,29 +36,27 @@ class TestCalculateCoverageStats:
     def test_error_rows_count_as_error_points(self):
         # A NO_DATE-only point holds present-but-dateless imagery, so it
         # counts as covered; only genuine errors (REQUEST_DENIED) are errors.
-        ts = '2026-01-15T12:00:00+00:00'
-        df = pd.DataFrame([
-            (44.000, -121.0, ts, 44.0001, -121.0001, 'a', '2020-01-01',
-             '© Google', 'OK'),
-            (44.001, -121.0, ts, None, None, None, None, None,
-             'ZERO_RESULTS'),
-            (44.002, -121.0, ts, None, None, None, None, None,
-             'REQUEST_DENIED'),
-            (44.003, -121.0, ts, 44.0031, -121.0031, 'd', None,
-             '© Google', 'NO_DATE'),
-        ], columns=COLUMNS)
+        ts = "2026-01-15T12:00:00+00:00"
+        df = pd.DataFrame(
+            [
+                (44.000, -121.0, ts, 44.0001, -121.0001, "a", "2020-01-01", "© Google", "OK"),
+                (44.001, -121.0, ts, None, None, None, None, None, "ZERO_RESULTS"),
+                (44.002, -121.0, ts, None, None, None, None, None, "REQUEST_DENIED"),
+                (44.003, -121.0, ts, 44.0031, -121.0031, "d", None, "© Google", "NO_DATE"),
+            ],
+            columns=COLUMNS,
+        )
         cov = calculate_coverage_stats(df)
-        assert cov.num_points_with_panos == 2   # OK + NO_DATE
+        assert cov.num_points_with_panos == 2  # OK + NO_DATE
         assert cov.num_points_without_panos == 1  # ZERO_RESULTS
-        assert cov.num_points_with_errors == 1    # REQUEST_DENIED
+        assert cov.num_points_with_errors == 1  # REQUEST_DENIED
         assert cov.num_points_with_unique_pano_ids == 2  # dateless pano counts
         assert abs(cov.coverage_rate - 50.0) < 1e-9
 
     def test_mapillary_census_rows_count_grid_points_once(self):
         # 6 panos on 2 grid points (3 rows each) + 1 empty point:
         # coverage is 2/3 points, while unique panos stays a census count
-        df = make_mapillary_city_df(
-            [(f'm{i}', '2022-01-01') for i in range(6)], panos_per_point=3)
+        df = make_mapillary_city_df([(f"m{i}", "2022-01-01") for i in range(6)], panos_per_point=3)
         cov = calculate_coverage_stats(df)
         assert cov.num_points_with_panos == 2
         assert cov.num_points_without_panos == 1
@@ -68,15 +66,15 @@ class TestCalculateCoverageStats:
     def test_mapillary_point_with_both_ok_and_no_date_rows_is_covered(self):
         # A grid point holding an OK pano and a NO_DATE pano is covered,
         # not an error point
-        ts = '2026-01-15T12:00:00+00:00'
-        df = pd.DataFrame([
-            (44.0, -121.0, ts, 44.0001, -121.0001, 'm1', '2022-01-01',
-             '© contributor', 'OK'),
-            (44.0, -121.0, ts, 44.0002, -121.0002, 'm2', None,
-             '© contributor', 'NO_DATE'),
-            (44.001, -121.0, ts, None, None, None, None, None,
-             'ZERO_RESULTS'),
-        ], columns=COLUMNS)
+        ts = "2026-01-15T12:00:00+00:00"
+        df = pd.DataFrame(
+            [
+                (44.0, -121.0, ts, 44.0001, -121.0001, "m1", "2022-01-01", "© contributor", "OK"),
+                (44.0, -121.0, ts, 44.0002, -121.0002, "m2", None, "© contributor", "NO_DATE"),
+                (44.001, -121.0, ts, None, None, None, None, None, "ZERO_RESULTS"),
+            ],
+            columns=COLUMNS,
+        )
         cov = calculate_coverage_stats(df)
         assert cov.num_points_with_panos == 1
         assert cov.num_points_without_panos == 1
@@ -91,27 +89,29 @@ class TestCalculateCoverageStats:
 
 
 class TestCatalogedCoverageRate:
-
     def test_run_stats_store_point_coverage_for_gsv(self):
-        df = make_city_df([('a', '2020-01-01'), ('a', '2020-01-01'),
-                           ('b', '2021-01-01')], n_empty=2)
+        df = make_city_df(
+            [("a", "2020-01-01"), ("a", "2020-01-01"), ("b", "2021-01-01")], n_empty=2
+        )
         stats = calculate_run_stats(df, date(2026, 1, 15))
         # For GSV (one row per point) with no NO_DATE panos this equals
         # (status_ok + status_no_date) / total_points == status_ok / total.
-        assert abs(stats['coverage_rate_pct'] - 60.0) < 1e-9
-        assert abs(stats['coverage_rate_pct']
-                   - 100.0 * (stats['status_ok'] + stats['status_no_date'])
-                   / stats['total_points']) < 1e-9
+        assert abs(stats["coverage_rate_pct"] - 60.0) < 1e-9
+        assert (
+            abs(
+                stats["coverage_rate_pct"]
+                - 100.0 * (stats["status_ok"] + stats["status_no_date"]) / stats["total_points"]
+            )
+            < 1e-9
+        )
 
     def test_run_stats_store_point_coverage_for_mapillary(self):
-        df = make_mapillary_city_df(
-            [(f'm{i}', '2022-01-01') for i in range(6)], panos_per_point=3)
-        stats = calculate_run_stats(df, date(2026, 1, 15),
-                                    provider='mapillary')
+        df = make_mapillary_city_df([(f"m{i}", "2022-01-01") for i in range(6)], panos_per_point=3)
+        stats = calculate_run_stats(df, date(2026, 1, 15), provider="mapillary")
         # Rows are per-pano here, so the point rate must NOT be the row
         # rate (6 OK rows / 7 rows)
-        assert stats['status_ok'] == 6 and stats['total_points'] == 7
-        assert abs(stats['coverage_rate_pct'] - 100 * 2 / 3) < 1e-9
+        assert stats["status_ok"] == 6 and stats["total_points"] == 7
+        assert abs(stats["coverage_rate_pct"] - 100 * 2 / 3) < 1e-9
 
 
 class TestNoDateCountsAsPresent:
@@ -121,38 +121,36 @@ class TestNoDateCountsAsPresent:
 
     def _gsv_df_with_no_date(self):
         # 1 dated OK pano, 1 dateless NO_DATE pano (both © Google), 1 empty
-        ts = '2026-01-15T12:00:00+00:00'
-        return pd.DataFrame([
-            (44.000, -121.0, ts, 44.0001, -121.0001, 'ok1', '2020-06-01',
-             '© Google', 'OK'),
-            (44.001, -121.0, ts, 44.0011, -121.0011, 'nd1', None,
-             '© Google', 'NO_DATE'),
-            (44.002, -121.0, ts, None, None, None, None, None, 'ZERO_RESULTS'),
-        ], columns=COLUMNS)
+        ts = "2026-01-15T12:00:00+00:00"
+        return pd.DataFrame(
+            [
+                (44.000, -121.0, ts, 44.0001, -121.0001, "ok1", "2020-06-01", "© Google", "OK"),
+                (44.001, -121.0, ts, 44.0011, -121.0011, "nd1", None, "© Google", "NO_DATE"),
+                (44.002, -121.0, ts, None, None, None, None, None, "ZERO_RESULTS"),
+            ],
+            columns=COLUMNS,
+        )
 
     def test_run_stats_counts_no_date_as_pano_and_coverage(self):
-        stats = calculate_run_stats(self._gsv_df_with_no_date(),
-                                    date(2026, 1, 15))
-        assert stats['status_ok'] == 1
-        assert stats['status_no_date'] == 1
-        assert stats['status_zero_results'] == 1
-        assert stats['status_other'] == 0
-        assert stats['unique_panos'] == 2         # OK + NO_DATE both counted
-        assert stats['unique_google_panos'] == 2  # both © Google
-        assert abs(stats['coverage_rate_pct'] - 100 * 2 / 3) < 1e-9
+        stats = calculate_run_stats(self._gsv_df_with_no_date(), date(2026, 1, 15))
+        assert stats["status_ok"] == 1
+        assert stats["status_no_date"] == 1
+        assert stats["status_zero_results"] == 1
+        assert stats["status_other"] == 0
+        assert stats["unique_panos"] == 2  # OK + NO_DATE both counted
+        assert stats["unique_google_panos"] == 2  # both © Google
+        assert abs(stats["coverage_rate_pct"] - 100 * 2 / 3) < 1e-9
 
     def test_no_date_pano_excluded_from_age_stats(self):
-        stats = calculate_run_stats(self._gsv_df_with_no_date(),
-                                    date(2026, 1, 15))
+        stats = calculate_run_stats(self._gsv_df_with_no_date(), date(2026, 1, 15))
         # Age reflects only the single dated pano (2020-06-01); the dateless
         # pano must not skew or nullify it.
-        assert stats['median_pano_age_years'] is not None
-        assert stats['oldest_capture_date'] == stats['newest_capture_date']
-        assert stats['oldest_capture_date'].startswith('2020-06-01')
+        assert stats["median_pano_age_years"] is not None
+        assert stats["oldest_capture_date"] == stats["newest_capture_date"]
+        assert stats["oldest_capture_date"].startswith("2020-06-01")
 
     def test_pano_stats_total_and_histogram(self):
-        results = calculate_pano_stats(self._gsv_df_with_no_date(),
-                                       pd.Timestamp('2026-01-15'))
+        results = calculate_pano_stats(self._gsv_df_with_no_date(), pd.Timestamp("2026-01-15"))
         # Website headline pano count is sourced from here — must include the
         # dateless pano.
         assert results.duplicate_stats.total_unique_panos == 2
@@ -161,12 +159,14 @@ class TestNoDateCountsAsPresent:
 
     def test_point_with_only_no_date_is_covered_not_error(self):
         # A grid point whose sole pano is dateless is covered, not an error.
-        ts = '2026-01-15T12:00:00+00:00'
-        df = pd.DataFrame([
-            (44.000, -121.0, ts, 44.0001, -121.0001, 'nd1', None,
-             '© Google', 'NO_DATE'),
-            (44.001, -121.0, ts, None, None, None, None, None, 'ZERO_RESULTS'),
-        ], columns=COLUMNS)
+        ts = "2026-01-15T12:00:00+00:00"
+        df = pd.DataFrame(
+            [
+                (44.000, -121.0, ts, 44.0001, -121.0001, "nd1", None, "© Google", "NO_DATE"),
+                (44.001, -121.0, ts, None, None, None, None, None, "ZERO_RESULTS"),
+            ],
+            columns=COLUMNS,
+        )
         cov = calculate_coverage_stats(df)
         assert cov.num_points_with_panos == 1
         assert cov.num_points_with_errors == 0
@@ -176,29 +176,47 @@ class TestNoDateCountsAsPresent:
     def test_dateless_mapillary_pano_counts_in_census(self):
         # Mapillary census: a point with 2 panos, one of them dateless, still
         # contributes both panos to the unique count and is covered.
-        ts = '2026-01-15T12:00:00+00:00'
-        df = pd.DataFrame([
-            (44.0, -121.0, ts, 44.0001, -121.0001, 'm1', '2022-01-01',
-             '© Mapillary contributor 1', 'OK'),
-            (44.0, -121.0, ts, 44.0002, -121.0002, 'm2', None,
-             '© Mapillary contributor 2', 'NO_DATE'),
-        ], columns=COLUMNS)
-        stats = calculate_run_stats(df, date(2026, 1, 15), provider='mapillary')
-        assert stats['unique_panos'] == 2
-        assert stats['status_no_date'] == 1
-        assert stats['unique_google_panos'] is None  # non-GSV
-        assert abs(stats['coverage_rate_pct'] - 100.0) < 1e-9
+        ts = "2026-01-15T12:00:00+00:00"
+        df = pd.DataFrame(
+            [
+                (
+                    44.0,
+                    -121.0,
+                    ts,
+                    44.0001,
+                    -121.0001,
+                    "m1",
+                    "2022-01-01",
+                    "© Mapillary contributor 1",
+                    "OK",
+                ),
+                (
+                    44.0,
+                    -121.0,
+                    ts,
+                    44.0002,
+                    -121.0002,
+                    "m2",
+                    None,
+                    "© Mapillary contributor 2",
+                    "NO_DATE",
+                ),
+            ],
+            columns=COLUMNS,
+        )
+        stats = calculate_run_stats(df, date(2026, 1, 15), provider="mapillary")
+        assert stats["unique_panos"] == 2
+        assert stats["status_no_date"] == 1
+        assert stats["unique_google_panos"] is None  # non-GSV
+        assert abs(stats["coverage_rate_pct"] - 100.0) < 1e-9
 
 
 class TestPanoStatsCoverage:
-
     def test_google_only_summary_keeps_run_level_coverage(self):
         # The google_only filter drops ZERO_RESULTS rows (null copyright);
         # coverage must still describe the whole sampled grid
-        df = make_city_df([('a', '2020-01-01'), ('b', '2021-01-01')],
-                          n_empty=1)
-        results = calculate_pano_stats(df, pd.Timestamp('2026-01-15'),
-                                       google_only=True)
+        df = make_city_df([("a", "2020-01-01"), ("b", "2021-01-01")], n_empty=1)
+        results = calculate_pano_stats(df, pd.Timestamp("2026-01-15"), google_only=True)
         cov = results.coverage_stats
         assert cov.num_points_without_panos == 1
         assert abs(cov.coverage_rate - 100 * 2 / 3) < 1e-9

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -11,103 +11,149 @@ from gsv_metadata_tracker import db
 @pytest.fixture
 def city(conn):
     return db.register_city(
-        conn, city_name='Bend', state_name='Oregon', state_code='OR',
-        country_name='United States', country_code='US',
-        center_lat=44.05, center_lon=-121.31,
-        grid_width_m=5000, grid_height_m=5000, step_m=20)
+        conn,
+        city_name="Bend",
+        state_name="Oregon",
+        state_code="OR",
+        country_name="United States",
+        country_code="US",
+        center_lat=44.05,
+        center_lon=-121.31,
+        grid_width_m=5000,
+        grid_height_m=5000,
+        step_m=20,
+    )
 
 
 def test_register_city_derives_canonical_id(conn, city):
-    assert city == 'bend--oregon--united-states'
-    row = db.resolve_city(conn, 'Bend, Oregon, United States')
+    assert city == "bend--oregon--united-states"
+    row = db.resolve_city(conn, "Bend, Oregon, United States")
     assert row.grid_width_m == 5000 and row.enabled
 
 
 def test_register_city_is_idempotent_and_freezes_geometry(conn, city):
     again = db.register_city(
-        conn, city_name='Bend', state_name='Oregon', state_code='OR',
-        country_name='United States', country_code='US',
-        center_lat=99.9, center_lon=99.9,          # different geometry...
-        grid_width_m=1, grid_height_m=1, step_m=1)
+        conn,
+        city_name="Bend",
+        state_name="Oregon",
+        state_code="OR",
+        country_name="United States",
+        country_code="US",
+        center_lat=99.9,
+        center_lon=99.9,  # different geometry...
+        grid_width_m=1,
+        grid_height_m=1,
+        step_m=1,
+    )
     assert again == city
     row = db.resolve_city(conn, city)
     assert row.center_lat == 44.05 and row.grid_width_m == 5000  # ...must not overwrite
 
 
 def test_alias_resolution(conn, city):
-    db.add_alias(conn, 'bend--or', city)
-    assert db.resolve_city(conn, 'Bend, OR').city_id == city
-    assert db.resolve_city(conn, 'Nowhere, KS') is None
+    db.add_alias(conn, "bend--or", city)
+    assert db.resolve_city(conn, "Bend, OR").city_id == city
+    assert db.resolve_city(conn, "Nowhere, KS") is None
 
 
 def test_update_city_geometry_overwrites_and_appends_note(conn, city):
     db.update_city_geometry(
-        conn, city_id=city, center_lat=44.10, center_lon=-121.40,
-        grid_width_m=18000, grid_height_m=20000, notes='regeom #91')
+        conn,
+        city_id=city,
+        center_lat=44.10,
+        center_lon=-121.40,
+        grid_width_m=18000,
+        grid_height_m=20000,
+        notes="regeom #91",
+    )
     row = db.resolve_city(conn, city)
     assert (row.center_lat, row.center_lon) == (44.10, -121.40)
     assert row.grid_width_m == 18000 and row.grid_height_m == 20000
-    assert row.step_m == 20                       # step is untouched
-    assert row.notes == 'regeom #91'
+    assert row.step_m == 20  # step is untouched
+    assert row.notes == "regeom #91"
     # A second correction appends to (does not clobber) the audit-trail note.
     db.update_city_geometry(
-        conn, city_id=city, center_lat=44.11, center_lon=-121.41,
-        grid_width_m=18000, grid_height_m=20000, notes='regeom #91 again')
-    assert db.resolve_city(conn, city).notes == 'regeom #91\nregeom #91 again'
+        conn,
+        city_id=city,
+        center_lat=44.11,
+        center_lon=-121.41,
+        grid_width_m=18000,
+        grid_height_m=20000,
+        notes="regeom #91 again",
+    )
+    assert db.resolve_city(conn, city).notes == "regeom #91\nregeom #91 again"
 
 
 def test_update_city_geometry_unknown_city_raises(conn):
     with pytest.raises(KeyError):
         db.update_city_geometry(
-            conn, city_id='nope', center_lat=1.0, center_lon=2.0,
-            grid_width_m=100, grid_height_m=100)
+            conn,
+            city_id="nope",
+            center_lat=1.0,
+            center_lon=2.0,
+            grid_width_m=100,
+            grid_height_m=100,
+        )
 
 
 def test_runs_ordering_and_uniqueness(conn, city):
-    r1 = db.register_run(conn, city_id=city, run_date=date(2026, 4, 1),
-                         csv_filename='a.csv.gz')
-    r2 = db.register_run(conn, city_id=city, run_date=date(2026, 7, 1),
-                         csv_filename='b.csv.gz')
+    r1 = db.register_run(conn, city_id=city, run_date=date(2026, 4, 1), csv_filename="a.csv.gz")
+    r2 = db.register_run(conn, city_id=city, run_date=date(2026, 7, 1), csv_filename="b.csv.gz")
     assert db.get_latest_run(conn, city).run_id == r2
     assert db.get_previous_run(conn, city, date(2026, 7, 1)).run_id == r1
     assert [r.run_id for r in db.get_runs_for_city(conn, city)] == [r1, r2]
     with pytest.raises(sqlite3.IntegrityError):  # same city+date rejected
-        db.register_run(conn, city_id=city, run_date=date(2026, 7, 1),
-                        csv_filename='c.csv.gz')
+        db.register_run(conn, city_id=city, run_date=date(2026, 7, 1), csv_filename="c.csv.gz")
 
 
 def test_register_run_round_trips_status_no_date(conn, city):
-    rid = db.register_run(conn, city_id=city, run_date=date(2026, 4, 1),
-                          csv_filename='a.csv.gz', total_points=10,
-                          status_ok=6, status_no_date=2, status_zero_results=2,
-                          status_other=0, unique_panos=8, unique_google_panos=8,
-                          coverage_rate_pct=80.0)
+    rid = db.register_run(
+        conn,
+        city_id=city,
+        run_date=date(2026, 4, 1),
+        csv_filename="a.csv.gz",
+        total_points=10,
+        status_ok=6,
+        status_no_date=2,
+        status_zero_results=2,
+        status_other=0,
+        unique_panos=8,
+        unique_google_panos=8,
+        coverage_rate_pct=80.0,
+    )
     run = db.get_latest_run(conn, city)
     assert run.run_id == rid
-    assert run.status_no_date == 2          # new v4 column persists
+    assert run.status_no_date == 2  # new v4 column persists
     assert run.status_ok == 6 and run.unique_panos == 8
     assert abs(run.coverage_rate_pct - 80.0) < 1e-9
 
 
 def test_register_run_status_no_date_defaults_null(conn, city):
     # Callers that omit status_no_date (e.g. legacy paths) store NULL, not 0.
-    db.register_run(conn, city_id=city, run_date=date(2026, 4, 1),
-                    csv_filename='a.csv.gz')
+    db.register_run(conn, city_id=city, run_date=date(2026, 4, 1), csv_filename="a.csv.gz")
     assert db.get_latest_run(conn, city).status_no_date is None
 
 
 def test_diff_storage(conn, city):
-    r1 = db.register_run(conn, city_id=city, run_date=date(2026, 4, 1),
-                         csv_filename='a.csv.gz')
-    r2 = db.register_run(conn, city_id=city, run_date=date(2026, 7, 1),
-                         csv_filename='b.csv.gz')
-    db.record_diff(conn, city_id=city, from_run_id=r1, to_run_id=r2,
-                   grid_aligned=True, panos_added=5, panos_removed=2,
-                   panos_persisted=93, capture_date_changed=1,
-                   points_gained_coverage=3, points_lost_coverage=1,
-                   coverage_delta_pct=0.5, detail_filename='d.csv.gz')
+    r1 = db.register_run(conn, city_id=city, run_date=date(2026, 4, 1), csv_filename="a.csv.gz")
+    r2 = db.register_run(conn, city_id=city, run_date=date(2026, 7, 1), csv_filename="b.csv.gz")
+    db.record_diff(
+        conn,
+        city_id=city,
+        from_run_id=r1,
+        to_run_id=r2,
+        grid_aligned=True,
+        panos_added=5,
+        panos_removed=2,
+        panos_persisted=93,
+        capture_date_changed=1,
+        points_gained_coverage=3,
+        points_lost_coverage=1,
+        coverage_delta_pct=0.5,
+        detail_filename="d.csv.gz",
+    )
     row = db.get_diff_for_run(conn, r2)
-    assert row['panos_added'] == 5 and row['grid_aligned'] == 1
+    assert row["panos_added"] == 5 and row["grid_aligned"] == 1
 
 
 def test_api_usage_ledger(conn):
@@ -119,8 +165,7 @@ def test_api_usage_ledger(conn):
 
 
 def test_due_selection_lifecycle(conn, city):
-    kw = dict(today=date(2026, 7, 2), cycle_days=90, grace_days=7,
-              max_consecutive_failures=5)
+    kw = dict(today=date(2026, 7, 2), cycle_days=90, grace_days=7, max_consecutive_failures=5)
     db.assign_schedule(conn, 90)
     assert [c.city_id for c in db.get_due_cities(conn, **kw)] == [city]  # never run
 
@@ -129,79 +174,90 @@ def test_due_selection_lifecycle(conn, city):
 
     # Failure cap: repeated failures eventually remove the city from `due`
     for _ in range(5):
-        db.record_attempt(conn, city, success=False, error='boom')
-    row = conn.execute("SELECT consecutive_failures, last_error FROM schedule_state "
-                       "WHERE city_id = ?", (city,)).fetchone()
-    assert row['consecutive_failures'] == 5 and row['last_error'] == 'boom'
+        db.record_attempt(conn, city, success=False, error="boom")
+    row = conn.execute(
+        "SELECT consecutive_failures, last_error FROM schedule_state WHERE city_id = ?", (city,)
+    ).fetchone()
+    assert row["consecutive_failures"] == 5 and row["last_error"] == "boom"
 
 
 def test_stagger_is_stable_and_spread():
-    days = [db.compute_day_of_cycle(f'city-{i}', 90) for i in range(900)]
-    assert days == [db.compute_day_of_cycle(f'city-{i}', 90) for i in range(900)]
+    days = [db.compute_day_of_cycle(f"city-{i}", 90) for i in range(900)]
+    assert days == [db.compute_day_of_cycle(f"city-{i}", 90) for i in range(900)]
     assert len(set(days)) == 90  # every day of the cycle gets cities
 
 
 # ── Provider dimension (schema v2) ─────────────────────────────────────────
 
+
 def test_runs_per_provider_series(conn, city):
-    g1 = db.register_run(conn, city_id=city, run_date=date(2026, 4, 1),
-                         csv_filename='g1.csv.gz')
-    m1 = db.register_run(conn, city_id=city, run_date=date(2026, 4, 1),
-                         csv_filename='m1.csv.gz', provider='mapillary')
-    m2 = db.register_run(conn, city_id=city, run_date=date(2026, 7, 1),
-                         csv_filename='m2.csv.gz', provider='mapillary')
+    g1 = db.register_run(conn, city_id=city, run_date=date(2026, 4, 1), csv_filename="g1.csv.gz")
+    m1 = db.register_run(
+        conn,
+        city_id=city,
+        run_date=date(2026, 4, 1),
+        csv_filename="m1.csv.gz",
+        provider="mapillary",
+    )
+    m2 = db.register_run(
+        conn,
+        city_id=city,
+        run_date=date(2026, 7, 1),
+        csv_filename="m2.csv.gz",
+        provider="mapillary",
+    )
     # Same city+date is fine across providers, rejected within one
     with pytest.raises(sqlite3.IntegrityError):
-        db.register_run(conn, city_id=city, run_date=date(2026, 4, 1),
-                        csv_filename='m1b.csv.gz', provider='mapillary')
+        db.register_run(
+            conn,
+            city_id=city,
+            run_date=date(2026, 4, 1),
+            csv_filename="m1b.csv.gz",
+            provider="mapillary",
+        )
     # Lookups are per-provider series
     assert db.get_latest_run(conn, city).run_id == g1
-    assert db.get_latest_run(conn, city, provider='mapillary').run_id == m2
-    assert db.get_previous_run(conn, city, date(2026, 7, 1),
-                               provider='mapillary').run_id == m1
+    assert db.get_latest_run(conn, city, provider="mapillary").run_id == m2
+    assert db.get_previous_run(conn, city, date(2026, 7, 1), provider="mapillary").run_id == m1
     # gsv series is independent: nothing before its own first run
     assert db.get_previous_run(conn, city, date(2026, 4, 1)) is None
     assert [r.run_id for r in db.get_runs_for_city(conn, city)] == [g1]
-    assert [r.run_id for r in
-            db.get_runs_for_city(conn, city, provider='mapillary')] == [m1, m2]
-    assert [r.run_id for r in
-            db.get_runs_for_city(conn, city, provider=None)] == [g1, m1, m2]
+    assert [r.run_id for r in db.get_runs_for_city(conn, city, provider="mapillary")] == [m1, m2]
+    assert [r.run_id for r in db.get_runs_for_city(conn, city, provider=None)] == [g1, m1, m2]
 
 
 def test_api_usage_ledger_per_provider(conn):
     d = date(2026, 7, 1)
     db.add_api_usage(conn, d, 100)
-    db.add_api_usage(conn, d, 30, provider='mapillary')
-    db.add_api_usage(conn, d, 30, provider='mapillary')
+    db.add_api_usage(conn, d, 30, provider="mapillary")
+    db.add_api_usage(conn, d, 30, provider="mapillary")
     assert db.get_api_usage(conn, d) == 100
-    assert db.get_api_usage(conn, d, provider='mapillary') == 60
+    assert db.get_api_usage(conn, d, provider="mapillary") == 60
 
 
 def test_schedule_state_per_provider(conn, city):
-    kw = dict(today=date(2026, 7, 2), cycle_days=90, grace_days=7,
-              max_consecutive_failures=5)
-    db.assign_schedule(conn, 90, providers=('gsv', 'mapillary'))
+    kw = dict(today=date(2026, 7, 2), cycle_days=90, grace_days=7, max_consecutive_failures=5)
+    db.assign_schedule(conn, 90, providers=("gsv", "mapillary"))
     # Both providers land on the same cycle day (paired snapshots)
     days = conn.execute(
-        "SELECT DISTINCT day_of_cycle FROM schedule_state WHERE city_id = ?",
-        (city,)).fetchall()
+        "SELECT DISTINCT day_of_cycle FROM schedule_state WHERE city_id = ?", (city,)
+    ).fetchall()
     assert len(days) == 1
 
     # A gsv success leaves the city due for mapillary, and vice versa
     db.record_attempt(conn, city, success=True)
     assert db.get_due_cities(conn, **kw) == []
-    assert [c.city_id for c in
-            db.get_due_cities(conn, provider='mapillary', **kw)] == [city]
+    assert [c.city_id for c in db.get_due_cities(conn, provider="mapillary", **kw)] == [city]
 
     # Failures accrue per provider
     for _ in range(5):
-        db.record_attempt(conn, city, success=False, error='boom',
-                          provider='mapillary')
-    assert db.get_due_cities(conn, provider='mapillary', **kw) == []
+        db.record_attempt(conn, city, success=False, error="boom", provider="mapillary")
+    assert db.get_due_cities(conn, provider="mapillary", **kw) == []
     row = conn.execute(
-        "SELECT consecutive_failures FROM schedule_state "
-        "WHERE city_id = ? AND provider = 'gsv'", (city,)).fetchone()
-    assert row['consecutive_failures'] == 0
+        "SELECT consecutive_failures FROM schedule_state WHERE city_id = ? AND provider = 'gsv'",
+        (city,),
+    ).fetchone()
+    assert row["consecutive_failures"] == 0
 
 
 # The v1 schema verbatim (pre-provider), for migration testing.
@@ -284,26 +340,30 @@ CREATE TABLE schedule_state (
 
 
 def test_migrate_v1_to_v2(tmp_path):
-    db_path = str(tmp_path / 'v1.db')
+    db_path = str(tmp_path / "v1.db")
     raw = sqlite3.connect(db_path)
     raw.executescript(_V1_SCHEMA)
     raw.execute(
         """INSERT INTO cities (city_id, display_name, city_name, center_lat,
            center_lon, grid_width_m, grid_height_m, step_m, created_at)
            VALUES ('bend--or', 'Bend, OR', 'Bend', 44.05, -121.31,
-                   5000, 5000, 20, '2026-01-01T00:00:00+00:00')""")
+                   5000, 5000, 20, '2026-01-01T00:00:00+00:00')"""
+    )
     raw.execute(
         """INSERT INTO runs (run_id, city_id, run_date, csv_filename,
            unique_panos, unique_google_panos)
-           VALUES (7, 'bend--or', '2026-04-01', 'a.csv.gz', 100, 90)""")
+           VALUES (7, 'bend--or', '2026-04-01', 'a.csv.gz', 100, 90)"""
+    )
     raw.execute(
         """INSERT INTO run_diffs (city_id, from_run_id, to_run_id,
            grid_aligned, computed_at)
-           VALUES ('bend--or', 7, 7, 1, '2026-04-01T00:00:00+00:00')""")
+           VALUES ('bend--or', 7, 7, 1, '2026-04-01T00:00:00+00:00')"""
+    )
     raw.execute("INSERT INTO api_usage VALUES ('2026-04-01', 12345)")
     raw.execute(
         """INSERT INTO schedule_state (city_id, day_of_cycle, last_success_at)
-           VALUES ('bend--or', 42, '2026-04-01T00:00:00+00:00')""")
+           VALUES ('bend--or', 42, '2026-04-01T00:00:00+00:00')"""
+    )
     raw.execute("PRAGMA user_version = 1")
     raw.commit()
     raw.close()
@@ -312,20 +372,19 @@ def test_migrate_v1_to_v2(tmp_path):
     assert conn.execute("PRAGMA user_version").fetchone()[0] == db.SCHEMA_VERSION
     # v4 added status_no_date; a migrated legacy run has it as NULL (unknown)
     cols = {r[1] for r in conn.execute("PRAGMA table_info(runs)").fetchall()}
-    assert 'status_no_date' in cols
+    assert "status_no_date" in cols
 
-    run = db.get_latest_run(conn, 'bend--or')
-    assert run.run_id == 7 and run.provider == 'gsv'
+    run = db.get_latest_run(conn, "bend--or")
+    assert run.run_id == 7 and run.provider == "gsv"
     assert run.unique_panos == 100 and run.unique_google_panos == 90
     assert run.status_no_date is None
     assert db.get_api_usage(conn, date(2026, 4, 1)) == 12345
-    row = conn.execute(
-        "SELECT provider, day_of_cycle FROM schedule_state").fetchone()
-    assert (row['provider'], row['day_of_cycle']) == ('gsv', 42)
-    assert db.get_diff_for_run(conn, 7)['grid_aligned'] == 1
+    row = conn.execute("SELECT provider, day_of_cycle FROM schedule_state").fetchone()
+    assert (row["provider"], row["day_of_cycle"]) == ("gsv", 42)
+    assert db.get_diff_for_run(conn, 7)["grid_aligned"] == 1
 
     # Idempotent: reopening must not migrate again or lose anything
     conn.close()
     conn2 = db.connect(db_path)
-    assert db.get_latest_run(conn2, 'bend--or').run_id == 7
+    assert db.get_latest_run(conn2, "bend--or").run_id == 7
     conn2.close()

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -1,7 +1,5 @@
 """Diff engine tests: pano set algebra, date changes, coverage transitions."""
 
-from datetime import date
-
 import pandas as pd
 
 from gsv_metadata_tracker.diff import compute_run_diff, generate_diff_filename
@@ -10,20 +8,29 @@ from tests.conftest import COLUMNS, make_city_df
 
 def _two_point_df(point_b_status, point_b_pano, point_b_date):
     """Grid of two points: A always holds an OK pano; B varies by status."""
-    ts = '2026-01-15T12:00:00+00:00'
-    rows = [(44.000, -121.0, ts, 44.0001, -121.0001, 'a', '2020-01-01',
-             '© Google', 'OK')]
-    if point_b_status == 'ZERO_RESULTS':
-        rows.append((44.001, -121.0, ts, None, None, None, None, None,
-                     'ZERO_RESULTS'))
+    ts = "2026-01-15T12:00:00+00:00"
+    rows = [(44.000, -121.0, ts, 44.0001, -121.0001, "a", "2020-01-01", "© Google", "OK")]
+    if point_b_status == "ZERO_RESULTS":
+        rows.append((44.001, -121.0, ts, None, None, None, None, None, "ZERO_RESULTS"))
     else:
-        rows.append((44.001, -121.0, ts, 44.0011, -121.0011, point_b_pano,
-                     point_b_date, '© Google', point_b_status))
+        rows.append(
+            (
+                44.001,
+                -121.0,
+                ts,
+                44.0011,
+                -121.0011,
+                point_b_pano,
+                point_b_date,
+                "© Google",
+                point_b_status,
+            )
+        )
     return pd.DataFrame(rows, columns=COLUMNS)
 
 
 def test_no_changes_between_identical_runs():
-    df = make_city_df([('p1', '2020-05-01'), ('p2', '2021-06-01')])
+    df = make_city_df([("p1", "2020-05-01"), ("p2", "2021-06-01")])
     d = compute_run_diff(df, df.copy())
     assert not d.has_changes
     assert d.panos_persisted == 2
@@ -32,24 +39,28 @@ def test_no_changes_between_identical_runs():
 
 
 def test_added_removed_and_date_changed():
-    old = make_city_df([('p1', '2020-05-01'), ('p2', '2021-06-01')])
-    new = make_city_df([('p1', '2024-08-01'),   # re-dated
-                        ('p3', '2025-01-01')])  # p2 removed, p3 added
+    old = make_city_df([("p1", "2020-05-01"), ("p2", "2021-06-01")])
+    new = make_city_df(
+        [
+            ("p1", "2024-08-01"),  # re-dated
+            ("p3", "2025-01-01"),
+        ]
+    )  # p2 removed, p3 added
     d = compute_run_diff(old, new)
     assert (d.panos_added, d.panos_removed, d.panos_persisted) == (1, 1, 1)
     assert d.capture_date_changed == 1
-    assert set(d.detail['change_type']) == {'pano_added', 'pano_removed',
-                                            'capture_date_changed'}
-    row = d.detail[d.detail['change_type'] == 'capture_date_changed'].iloc[0]
-    assert row['old_capture_date'] == '2020-05-01'
-    assert row['new_capture_date'] == '2024-08-01'
+    assert set(d.detail["change_type"]) == {"pano_added", "pano_removed", "capture_date_changed"}
+    row = d.detail[d.detail["change_type"] == "capture_date_changed"].iloc[0]
+    assert row["old_capture_date"] == "2020-05-01"
+    assert row["new_capture_date"] == "2024-08-01"
 
 
 def test_coverage_transitions_on_aligned_grid():
     # 2 panos + 1 empty point vs 3 panos + 0 empty on the same 3-point grid
-    old = make_city_df([('p1', '2020-05-01'), ('p2', '2021-06-01')], n_empty=1)
-    new = make_city_df([('p1', '2020-05-01'), ('p2', '2021-06-01'),
-                        ('p3', '2025-01-01')], n_empty=0)
+    old = make_city_df([("p1", "2020-05-01"), ("p2", "2021-06-01")], n_empty=1)
+    new = make_city_df(
+        [("p1", "2020-05-01"), ("p2", "2021-06-01"), ("p3", "2025-01-01")], n_empty=0
+    )
     d = compute_run_diff(old, new)
     assert d.grid_aligned
     assert d.points_gained_coverage == 1 and d.points_lost_coverage == 0
@@ -59,8 +70,8 @@ def test_coverage_transitions_on_aligned_grid():
 def test_no_date_point_gains_coverage():
     # Point B goes ZERO_RESULTS -> NO_DATE: dateless imagery appeared, so the
     # point is now covered (schema v3).
-    old = _two_point_df('ZERO_RESULTS', None, None)
-    new = _two_point_df('NO_DATE', 'b', None)
+    old = _two_point_df("ZERO_RESULTS", None, None)
+    new = _two_point_df("NO_DATE", "b", None)
     d = compute_run_diff(old, new)
     assert d.grid_aligned
     assert d.points_gained_coverage == 1 and d.points_lost_coverage == 0
@@ -69,16 +80,16 @@ def test_no_date_point_gains_coverage():
 
 def test_no_date_point_lost_coverage():
     # Reverse: NO_DATE -> ZERO_RESULTS is a loss of coverage.
-    old = _two_point_df('NO_DATE', 'b', None)
-    new = _two_point_df('ZERO_RESULTS', None, None)
+    old = _two_point_df("NO_DATE", "b", None)
+    new = _two_point_df("ZERO_RESULTS", None, None)
     d = compute_run_diff(old, new)
     assert d.points_gained_coverage == 0 and d.points_lost_coverage == 1
     assert abs(d.coverage_delta_pct + 50.0) < 1e-9
 
 
 def test_misaligned_grid_skips_point_stats():
-    old = make_city_df([('p1', '2020-05-01')])
-    new = make_city_df([('p1', '2020-05-01')], grid_origin=(45.0, -120.0))
+    old = make_city_df([("p1", "2020-05-01")])
+    new = make_city_df([("p1", "2020-05-01")], grid_origin=(45.0, -120.0))
     d = compute_run_diff(old, new)
     assert not d.grid_aligned
     assert d.points_gained_coverage is None
@@ -88,23 +99,27 @@ def test_misaligned_grid_skips_point_stats():
 
 
 def test_duplicate_pano_ids_deduped_keeping_newest_date():
-    old = make_city_df([('p1', '2020-05-01'), ('p1', '2022-03-01')])
-    new = make_city_df([('p1', '2022-03-01')])
+    old = make_city_df([("p1", "2020-05-01"), ("p1", "2022-03-01")])
+    new = make_city_df([("p1", "2022-03-01")])
     d = compute_run_diff(old, new)
     assert d.panos_persisted == 1
     assert d.capture_date_changed == 0  # newest old date matches new date
 
 
 def test_diff_filename():
-    assert generate_diff_filename('bend--or', '2026-04-01', '2026-07-01') == \
-        'bend--or_diff_2026-04-01_to_2026-07-01.csv.gz'
+    assert (
+        generate_diff_filename("bend--or", "2026-04-01", "2026-07-01")
+        == "bend--or_diff_2026-04-01_to_2026-07-01.csv.gz"
+    )
 
 
 def test_diff_filename_provider():
     # gsv keeps the tokenless legacy form; other providers get a token
-    assert generate_diff_filename('bend--or', '2026-04-01', '2026-07-01',
-                                  provider='gsv') == \
-        'bend--or_diff_2026-04-01_to_2026-07-01.csv.gz'
-    assert generate_diff_filename('bend--or', '2026-04-01', '2026-07-01',
-                                  provider='mapillary') == \
-        'bend--or_diff_mapillary_2026-04-01_to_2026-07-01.csv.gz'
+    assert (
+        generate_diff_filename("bend--or", "2026-04-01", "2026-07-01", provider="gsv")
+        == "bend--or_diff_2026-04-01_to_2026-07-01.csv.gz"
+    )
+    assert (
+        generate_diff_filename("bend--or", "2026-04-01", "2026-07-01", provider="mapillary")
+        == "bend--or_diff_mapillary_2026-04-01_to_2026-07-01.csv.gz"
+    )

--- a/tests/test_geoutils.py
+++ b/tests/test_geoutils.py
@@ -13,10 +13,11 @@ def _location(raw):
 def test_bbox_center_is_bounding_box_midpoint():
     # Nominatim boundingbox is [south, north, west, east]; the geocoder's own
     # point (0,0) is deliberately off-center to prove we don't use it.
-    loc = EnhancedLocation("Somewhere", _location(
-        {"boundingbox": ["10.0", "20.0", "30.0", "40.0"], "address": {}}))
-    assert loc.bbox_center == (15.0, 35.0)      # ((10+20)/2, (30+40)/2)
-    assert loc.latitude == 0.0                  # not the source of the center
+    loc = EnhancedLocation(
+        "Somewhere", _location({"boundingbox": ["10.0", "20.0", "30.0", "40.0"], "address": {}})
+    )
+    assert loc.bbox_center == (15.0, 35.0)  # ((10+20)/2, (30+40)/2)
+    assert loc.latitude == 0.0  # not the source of the center
 
 
 def test_bbox_center_none_without_bounding_box():

--- a/tests/test_gsv_history.py
+++ b/tests/test_gsv_history.py
@@ -5,7 +5,6 @@ mocked), so there is no network access.
 """
 
 import asyncio
-import gzip
 import json
 import os
 import sys
@@ -20,9 +19,11 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from gsv_metadata_tracker import db  # noqa: E402
 from gsv_metadata_tracker import download_gsv_history as dgh  # noqa: E402
 from gsv_metadata_tracker.naming import (  # noqa: E402
-    ParsedHistoryFilename, generate_history_filename, parse_filename,
-    parse_history_filename)
-
+    ParsedHistoryFilename,
+    generate_history_filename,
+    parse_filename,
+    parse_history_filename,
+)
 
 # ── Response-fixture builder ───────────────────────────────────────────────
 #
@@ -31,6 +32,7 @@ from gsv_metadata_tracker.naming import (  # noqa: E402
 # pano list and subset[8] is the date list. Per the endpoint's quirk, the date
 # list covers only the LAST n panos, so undated (user) panos must lead and
 # dated (official Google) panos must trail.
+
 
 def _pano_node(pano_id, lat, lon):
     return [[None, pano_id], None, [[None, None, lat, lon]]]
@@ -56,12 +58,16 @@ def make_response(undated, dated):
 
 # ── Parsing ────────────────────────────────────────────────────────────────
 
+
 def test_parse_keeps_only_dated_official_panos():
     text = make_response(
         undated=[("userA", 45.0, -122.0), ("userB", 45.0, -122.0)],
-        dated=[("g2007", 45.31, -122.94, (2007, 10)),
-               ("g2012", 45.31, -122.94, (2012, 6)),
-               ("g2023", 45.31, -122.94, (2023, 6))])
+        dated=[
+            ("g2007", 45.31, -122.94, (2007, 10)),
+            ("g2012", 45.31, -122.94, (2012, 6)),
+            ("g2023", 45.31, -122.94, (2023, 6)),
+        ],
+    )
     panos = dgh.parse_search_response(text)
 
     assert {p.pano_id for p in panos} == {"g2007", "g2012", "g2023"}
@@ -78,18 +84,22 @@ def test_parse_no_images_sentinel_returns_empty():
     assert dgh.parse_search_response(text) == []
 
 
-@pytest.mark.parametrize("text", [
-    "",
-    "not javascript at all",
-    "callbackfunc( {not json} )",
-    "callbackfunc( [1,2,3] )",  # right wrapper, wrong shape
-])
+@pytest.mark.parametrize(
+    "text",
+    [
+        "",
+        "not javascript at all",
+        "callbackfunc( {not json} )",
+        "callbackfunc( [1,2,3] )",  # right wrapper, wrong shape
+    ],
+)
 def test_parse_malformed_is_swallowed(text):
     # A shape change in the undocumented endpoint must not raise mid-sweep.
     assert dgh.parse_search_response(text) == []
 
 
 # ── Circuit breaker ────────────────────────────────────────────────────────
+
 
 def test_circuit_breaker_trips_on_consecutive_failures():
     cb = dgh._CircuitBreaker(limit=3)
@@ -104,7 +114,7 @@ def test_circuit_breaker_resets_on_success():
     cb = dgh._CircuitBreaker(limit=3)
     cb.record(ok=False)
     cb.record(ok=False)
-    cb.record(ok=True)          # an empty-but-valid result resets the streak
+    cb.record(ok=True)  # an empty-but-valid result resets the streak
     cb.record(ok=False)
     assert not cb.tripped
     assert cb.total_failures == 3
@@ -112,11 +122,14 @@ def test_circuit_breaker_resets_on_success():
 
 # ── Filename contract ──────────────────────────────────────────────────────
 
+
 def test_history_filename_round_trip():
     base = generate_history_filename(
-        "bend--oregon--united-states", 5000, 5000, 20, date(2026, 7, 8))
-    assert base == ("bend--oregon--united-states_width_5000_height_5000"
-                    "_step_20_gsv_history_2026-07-08")
+        "bend--oregon--united-states", 5000, 5000, 20, date(2026, 7, 8)
+    )
+    assert base == (
+        "bend--oregon--united-states_width_5000_height_5000_step_20_gsv_history_2026-07-08"
+    )
     parsed = parse_history_filename(base + ".csv.gz")
     assert isinstance(parsed, ParsedHistoryFilename)
     assert (parsed.width_meters, parsed.step_meters) == (5000, 20)
@@ -125,8 +138,7 @@ def test_history_filename_round_trip():
 
 
 def test_history_and_run_filenames_do_not_cross_parse():
-    history = ("bend--or_width_5000_height_5000_step_20_gsv_history"
-               "_2026-07-08.csv.gz")
+    history = "bend--or_width_5000_height_5000_step_20_gsv_history_2026-07-08.csv.gz"
     run = "bend--or_width_5000_height_5000_step_20_2026-07-08.csv.gz"
     # A run parser must reject a history file...
     with pytest.raises(ValueError):
@@ -138,12 +150,21 @@ def test_history_and_run_filenames_do_not_cross_parse():
 
 # ── Catalog table ──────────────────────────────────────────────────────────
 
+
 def _register_city(conn):
     return db.register_city(
-        conn, city_name="Bend", state_name="Oregon", state_code="OR",
-        country_name="United States", country_code="US",
-        center_lat=44.05, center_lon=-121.31,
-        grid_width_m=40, grid_height_m=40, step_m=20)
+        conn,
+        city_name="Bend",
+        state_name="Oregon",
+        state_code="OR",
+        country_name="United States",
+        country_code="US",
+        center_lat=44.05,
+        center_lon=-121.31,
+        grid_width_m=40,
+        grid_height_m=40,
+        step_m=20,
+    )
 
 
 def test_register_and_get_history_harvest(tmp_path):
@@ -152,11 +173,16 @@ def test_register_and_get_history_harvest(tmp_path):
     city_id = _register_city(conn)
 
     hid = db.register_history_harvest(
-        conn, city_id=city_id, harvest_date=date(2026, 7, 8),
+        conn,
+        city_id=city_id,
+        harvest_date=date(2026, 7, 8),
         csv_filename="bend_gsv_history_2026-07-08.csv.gz",
-        grid_points_queried=9, unique_panos=3,
-        oldest_capture_date="2007-10-01", newest_capture_date="2023-06-01",
-        api_requests=9)
+        grid_points_queried=9,
+        unique_panos=3,
+        oldest_capture_date="2007-10-01",
+        newest_capture_date="2023-06-01",
+        api_requests=9,
+    )
     assert hid > 0
 
     latest = db.get_latest_history_harvest(conn, city_id)
@@ -169,15 +195,22 @@ def test_register_history_harvest_is_idempotent_per_date(tmp_path):
     city_id = _register_city(conn)
 
     first = db.register_history_harvest(
-        conn, city_id=city_id, harvest_date=date(2026, 7, 8),
-        csv_filename="a.csv.gz", unique_panos=3)
+        conn,
+        city_id=city_id,
+        harvest_date=date(2026, 7, 8),
+        csv_filename="a.csv.gz",
+        unique_panos=3,
+    )
     second = db.register_history_harvest(  # same city + date -> replace
-        conn, city_id=city_id, harvest_date=date(2026, 7, 8),
-        csv_filename="a.csv.gz", unique_panos=5)
+        conn,
+        city_id=city_id,
+        harvest_date=date(2026, 7, 8),
+        csv_filename="a.csv.gz",
+        unique_panos=5,
+    )
     assert first == second
     assert db.get_latest_history_harvest(conn, city_id)["unique_panos"] == 5
-    assert conn.execute(
-        "SELECT COUNT(*) FROM history_harvests").fetchone()[0] == 1
+    assert conn.execute("SELECT COUNT(*) FROM history_harvests").fetchone()[0] == 1
 
 
 def test_v2_catalog_gains_history_table_on_connect(tmp_path):
@@ -186,6 +219,7 @@ def test_v2_catalog_gains_history_table_on_connect(tmp_path):
     # without losing anything. Simulated by building a full DB, then reverting
     # it to look like v2 (drop the new table, stamp user_version=2).
     import sqlite3
+
     db_path = str(tmp_path / "v2.db")
     conn = db.connect(db_path)
     city_id = _register_city(conn)
@@ -199,19 +233,26 @@ def test_v2_catalog_gains_history_table_on_connect(tmp_path):
 
     conn2 = db.connect(db_path)  # additive v2 -> v3 upgrade
     assert conn2.execute("PRAGMA user_version").fetchone()[0] == db.SCHEMA_VERSION
-    assert db.resolve_city(conn2, city_id) is not None      # data preserved
-    hid = db.register_history_harvest(                       # new table usable
-        conn2, city_id=city_id, harvest_date=date(2026, 7, 8),
-        csv_filename="x.csv.gz", unique_panos=2)
+    assert db.resolve_city(conn2, city_id) is not None  # data preserved
+    hid = db.register_history_harvest(  # new table usable
+        conn2,
+        city_id=city_id,
+        harvest_date=date(2026, 7, 8),
+        csv_filename="x.csv.gz",
+        unique_panos=2,
+    )
     assert hid > 0
 
 
 # ── End-to-end sweep (endpoint mocked) ─────────────────────────────────────
 
+
 def _patch_fetch(monkeypatch, responder):
     """Replace the network fetch with an in-memory responder(url) -> text."""
+
     async def fake_fetch(session, url, timeout):
         return responder(url)
+
     monkeypatch.setattr(dgh, "_fetch_search", fake_fetch)
 
 
@@ -220,19 +261,30 @@ def test_harvest_end_to_end_dedups_across_grid(monkeypatch, tmp_path):
     # census must dedup them to 3 unique rows regardless of grid size.
     response = make_response(
         undated=[("user1", 44.05, -121.31)],
-        dated=[("g2007", 44.05, -121.31, (2007, 10)),
-               ("g2012", 44.05, -121.31, (2012, 6)),
-               ("g2023", 44.05, -121.31, (2023, 6))])
+        dated=[
+            ("g2007", 44.05, -121.31, (2007, 10)),
+            ("g2012", 44.05, -121.31, (2012, 6)),
+            ("g2023", 44.05, -121.31, (2023, 6)),
+        ],
+    )
     _patch_fetch(monkeypatch, lambda url: response)
 
     out = str(tmp_path / "bend_gsv_history_2026-07-08.csv.gz")
-    result = asyncio.run(dgh.harvest_gsv_history_async(
-        city_name="Bend", center_lat=44.05, center_lon=-121.31,
-        grid_width=40, grid_height=40, step_length=20,
-        output_csv_gz_path=out, jitter_seconds=(0.0, 0.0)))
+    result = asyncio.run(
+        dgh.harvest_gsv_history_async(
+            city_name="Bend",
+            center_lat=44.05,
+            center_lon=-121.31,
+            grid_width=40,
+            grid_height=40,
+            step_length=20,
+            output_csv_gz_path=out,
+            jitter_seconds=(0.0, 0.0),
+        )
+    )
 
-    assert result["grid_points"] == 9           # (2+1)*(2+1)
-    assert result["api_requests"] == 9          # one search per point
+    assert result["grid_points"] == 9  # (2+1)*(2+1)
+    assert result["api_requests"] == 9  # one search per point
     assert result["unique_panos"] == 3
     assert result["oldest_capture_date"] == "2007-10-01"
     assert result["newest_capture_date"] == "2023-06-01"
@@ -250,10 +302,18 @@ def test_harvest_writes_empty_file_when_no_history(monkeypatch, tmp_path):
     _patch_fetch(monkeypatch, lambda url: empty)
 
     out = str(tmp_path / "nowhere_gsv_history_2026-07-08.csv.gz")
-    result = asyncio.run(dgh.harvest_gsv_history_async(
-        city_name="Nowhere", center_lat=0.0, center_lon=0.0,
-        grid_width=40, grid_height=40, step_length=20,
-        output_csv_gz_path=out, jitter_seconds=(0.0, 0.0)))
+    result = asyncio.run(
+        dgh.harvest_gsv_history_async(
+            city_name="Nowhere",
+            center_lat=0.0,
+            center_lon=0.0,
+            grid_width=40,
+            grid_height=40,
+            step_length=20,
+            output_csv_gz_path=out,
+            jitter_seconds=(0.0, 0.0),
+        )
+    )
 
     assert result["unique_panos"] == 0
     assert result["oldest_capture_date"] is None
@@ -269,23 +329,30 @@ def test_harvest_unions_distinct_panos_across_grid(monkeypatch, tmp_path):
     def responder(url):
         lat, lon = _re.search(r"!3d([-\d.]+)!4d([-\d.]+)", url).groups()
         pid = f"g_{lat}_{lon}"
-        return make_response(undated=[], dated=[(pid, float(lat), float(lon),
-                                                 (2018, 5))])
+        return make_response(undated=[], dated=[(pid, float(lat), float(lon), (2018, 5))])
+
     _patch_fetch(monkeypatch, responder)
 
     out = str(tmp_path / "bend_gsv_history_2026-07-08.csv.gz")
-    result = asyncio.run(dgh.harvest_gsv_history_async(
-        city_name="Bend", center_lat=44.05, center_lon=-121.31,
-        grid_width=40, grid_height=40, step_length=20,
-        output_csv_gz_path=out, jitter_seconds=(0.0, 0.0)))
+    result = asyncio.run(
+        dgh.harvest_gsv_history_async(
+            city_name="Bend",
+            center_lat=44.05,
+            center_lon=-121.31,
+            grid_width=40,
+            grid_height=40,
+            step_length=20,
+            output_csv_gz_path=out,
+            jitter_seconds=(0.0, 0.0),
+        )
+    )
 
     assert result["grid_points"] == 9
-    assert result["unique_panos"] == 9        # every point contributed one
+    assert result["unique_panos"] == 9  # every point contributed one
     assert len(set(pd.read_csv(out)["pano_id"])) == 9
 
 
-def test_harvest_resume_skips_done_points_and_keeps_earliest_date(
-        monkeypatch, tmp_path):
+def test_harvest_resume_skips_done_points_and_keeps_earliest_date(monkeypatch, tmp_path):
     # Pre-seed a checkpoint as if 8 of 9 points were already harvested (with one
     # pano gOLD@2010), leaving a single point (1, 1) to do. The resume must
     # query ONLY that point and must keep the earlier checkpoint date for gOLD
@@ -294,10 +361,15 @@ def test_harvest_resume_skips_done_points_and_keeps_earliest_date(
     done = [[i, j] for i in (-1, 0, 1) for j in (-1, 0, 1) if (i, j) != (1, 1)]
     seed = {
         "done": done,
-        "panos": {"gOLD": {"capture_date": "2010-01-01",
-                           "pano_lat": 44.0, "pano_lon": -121.0,
-                           "nearest_query_lat": 44.0,
-                           "nearest_query_lon": -121.0}},
+        "panos": {
+            "gOLD": {
+                "capture_date": "2010-01-01",
+                "pano_lat": 44.0,
+                "pano_lon": -121.0,
+                "nearest_query_lat": 44.0,
+                "nearest_query_lon": -121.0,
+            }
+        },
         "api_requests": 8,
     }
     with open(out + ".harvesting", "w", encoding="utf-8") as f:
@@ -307,18 +379,31 @@ def test_harvest_resume_skips_done_points_and_keeps_earliest_date(
 
     def responder(url):
         calls["n"] += 1
-        return make_response(undated=[], dated=[
-            ("gOLD", 44.05, -121.31, (2020, 1)),   # later date -> must NOT win
-            ("gNEW", 44.05, -121.31, (2018, 5))])
+        return make_response(
+            undated=[],
+            dated=[
+                ("gOLD", 44.05, -121.31, (2020, 1)),  # later date -> must NOT win
+                ("gNEW", 44.05, -121.31, (2018, 5)),
+            ],
+        )
+
     _patch_fetch(monkeypatch, responder)
 
-    result = asyncio.run(dgh.harvest_gsv_history_async(
-        city_name="Bend", center_lat=44.05, center_lon=-121.31,
-        grid_width=40, grid_height=40, step_length=20,
-        output_csv_gz_path=out, jitter_seconds=(0.0, 0.0)))
+    result = asyncio.run(
+        dgh.harvest_gsv_history_async(
+            city_name="Bend",
+            center_lat=44.05,
+            center_lon=-121.31,
+            grid_width=40,
+            grid_height=40,
+            step_length=20,
+            output_csv_gz_path=out,
+            jitter_seconds=(0.0, 0.0),
+        )
+    )
 
-    assert calls["n"] == 1                       # only the one remaining point
-    assert result["api_requests"] == 9           # 8 carried over + 1 new
+    assert calls["n"] == 1  # only the one remaining point
+    assert result["api_requests"] == 9  # 8 carried over + 1 new
     df = pd.read_csv(out).set_index("pano_id")
     assert set(df.index) == {"gOLD", "gNEW"}
     assert df.loc["gOLD", "capture_date"] == "2010-01-01"  # earliest kept
@@ -345,25 +430,41 @@ def test_harvest_blocks_and_leaves_checkpoint_then_resumes(monkeypatch, tmp_path
     # First attempt: every search throttled -> circuit breaker trips.
     async def always_throttled(session, url, timeout):
         raise aiohttp.ClientError("simulated 429")
+
     monkeypatch.setattr(dgh, "_fetch_search", always_throttled)
 
     with pytest.raises(dgh.HarvestBlockedError):
-        asyncio.run(dgh.harvest_gsv_history_async(
-            city_name="Bend", center_lat=44.05, center_lon=-121.31,
-            grid_width=40, grid_height=40, step_length=20,
-            output_csv_gz_path=out, jitter_seconds=(0.0, 0.0),
-            circuit_breaker_limit=3))
-    assert os.path.exists(out + ".harvesting")   # progress preserved
-    assert not os.path.exists(out)               # no output yet
+        asyncio.run(
+            dgh.harvest_gsv_history_async(
+                city_name="Bend",
+                center_lat=44.05,
+                center_lon=-121.31,
+                grid_width=40,
+                grid_height=40,
+                step_length=20,
+                output_csv_gz_path=out,
+                jitter_seconds=(0.0, 0.0),
+                circuit_breaker_limit=3,
+            )
+        )
+    assert os.path.exists(out + ".harvesting")  # progress preserved
+    assert not os.path.exists(out)  # no output yet
 
     # Resume: endpoint recovers -> sweep completes, checkpoint removed.
-    response = make_response(
-        undated=[], dated=[("g2020", 44.05, -121.31, (2020, 5))])
+    response = make_response(undated=[], dated=[("g2020", 44.05, -121.31, (2020, 5))])
     _patch_fetch(monkeypatch, lambda url: response)
-    result = asyncio.run(dgh.harvest_gsv_history_async(
-        city_name="Bend", center_lat=44.05, center_lon=-121.31,
-        grid_width=40, grid_height=40, step_length=20,
-        output_csv_gz_path=out, jitter_seconds=(0.0, 0.0)))
+    result = asyncio.run(
+        dgh.harvest_gsv_history_async(
+            city_name="Bend",
+            center_lat=44.05,
+            center_lon=-121.31,
+            grid_width=40,
+            grid_height=40,
+            step_length=20,
+            output_csv_gz_path=out,
+            jitter_seconds=(0.0, 0.0),
+        )
+    )
 
     assert result["unique_panos"] == 1
     assert os.path.exists(out)

--- a/tests/test_json_v2.py
+++ b/tests/test_json_v2.py
@@ -11,17 +11,20 @@ import pytest
 from gsv_metadata_tracker import db
 from gsv_metadata_tracker.fileutils import load_city_csv_file
 from gsv_metadata_tracker.json_summarizer import (
-    generate_aggregate_v2, generate_city_metadata_summary_as_json,
-    sanitize_for_json)
-from tests.conftest import (COLUMNS, make_city_df, make_mapillary_city_df,
-                            write_city_csv_gz)
+    generate_aggregate_v2,
+    generate_city_metadata_summary_as_json,
+    sanitize_for_json,
+)
+from tests.conftest import COLUMNS, make_city_df, make_mapillary_city_df, write_city_csv_gz
 
 
 def strict_load(path):
     """json.load that raises on NaN/Infinity literals."""
+
     def _reject(token):
         raise ValueError(f"invalid token {token}")
-    with gzip.open(path, 'rt', encoding='utf-8') as f:
+
+    with gzip.open(path, "rt", encoding="utf-8") as f:
         return json.load(f, parse_constant=_reject)
 
 
@@ -32,297 +35,478 @@ def _write_run(data_dir, panos, run_date, name):
 
 
 def test_sanitize_for_json():
-    dirty = {'a': float('nan'), 'b': [float('inf'), 1.5], 'c': {'d': float('-inf')}}
+    dirty = {"a": float("nan"), "b": [float("inf"), 1.5], "c": {"d": float("-inf")}}
     clean = sanitize_for_json(dirty)
-    assert clean == {'a': None, 'b': [None, 1.5], 'c': {'d': None}}
+    assert clean == {"a": None, "b": [None, 1.5], "c": {"d": None}}
     json.dumps(clean, allow_nan=False)  # must not raise
 
 
 def test_single_pano_city_emits_valid_json(data_dir):
     # Regression: 1 unique pano -> stdev NaN -> literal NaN in the JSON
-    csv_path = _write_run(data_dir, [('p1', '2020-05-01')], date(2026, 1, 15),
-                          'solo--city_width_100_height_100_step_20_2026-01-15.csv.gz')
+    csv_path = _write_run(
+        data_dir,
+        [("p1", "2020-05-01")],
+        date(2026, 1, 15),
+        "solo--city_width_100_height_100_step_20_2026-01-15.csv.gz",
+    )
     df = load_city_csv_file(csv_path)
     json_path = generate_city_metadata_summary_as_json(
-        csv_path, df, 'Solo', None, 'Testland', 100, 100, 20,
-        force_recreate_file=True, run_date=date(2026, 1, 15))
+        csv_path,
+        df,
+        "Solo",
+        None,
+        "Testland",
+        100,
+        100,
+        20,
+        force_recreate_file=True,
+        run_date=date(2026, 1, 15),
+    )
     data = strict_load(json_path)  # raises if NaN leaked
-    assert data['all_panos']['age_stats']['stdev_pano_age_years'] is None
+    assert data["all_panos"]["age_stats"]["stdev_pano_age_years"] is None
 
 
 def test_no_date_pano_counted_in_json(data_dir):
     # End-to-end: a dateless (NO_DATE) pano must appear in the published pano
     # total and coverage, but not perturb the age stats (schema v3).
-    ts = '2026-01-15T12:00:00+00:00'
-    df_raw = pd.DataFrame([
-        (44.000, -121.0, ts, 44.0001, -121.0001, 'ok1', '2020-01-15',
-         '© Google', 'OK'),
-        (44.001, -121.0, ts, 44.0011, -121.0011, 'nd1', None,
-         '© Google', 'NO_DATE'),
-        (44.002, -121.0, ts, None, None, None, None, None, 'ZERO_RESULTS'),
-    ], columns=COLUMNS)
-    csv_path = os.path.join(
-        data_dir, 'nd--city_width_100_height_100_step_20_2026-01-15.csv.gz')
+    ts = "2026-01-15T12:00:00+00:00"
+    df_raw = pd.DataFrame(
+        [
+            (44.000, -121.0, ts, 44.0001, -121.0001, "ok1", "2020-01-15", "© Google", "OK"),
+            (44.001, -121.0, ts, 44.0011, -121.0011, "nd1", None, "© Google", "NO_DATE"),
+            (44.002, -121.0, ts, None, None, None, None, None, "ZERO_RESULTS"),
+        ],
+        columns=COLUMNS,
+    )
+    csv_path = os.path.join(data_dir, "nd--city_width_100_height_100_step_20_2026-01-15.csv.gz")
     write_city_csv_gz(df_raw, csv_path)
     df = load_city_csv_file(csv_path)
     json_path = generate_city_metadata_summary_as_json(
-        csv_path, df, 'ND', None, 'Testland', 100, 100, 20,
-        force_recreate_file=True, run_date=date(2026, 1, 15))
+        csv_path,
+        df,
+        "ND",
+        None,
+        "Testland",
+        100,
+        100,
+        20,
+        force_recreate_file=True,
+        run_date=date(2026, 1, 15),
+    )
     data = strict_load(json_path)
 
     # Both panos counted; Google subset counts the dateless © Google pano too
-    assert data['all_panos']['duplicate_stats']['total_unique_panos'] == 2
-    assert data['google_panos']['duplicate_stats']['total_unique_panos'] == 2
+    assert data["all_panos"]["duplicate_stats"]["total_unique_panos"] == 2
+    assert data["google_panos"]["duplicate_stats"]["total_unique_panos"] == 2
     # Coverage: 2 of 3 grid points hold imagery
-    assert data['coverage']['coverage_rate'] == pytest.approx(100 * 2 / 3)
+    assert data["coverage"]["coverage_rate"] == pytest.approx(100 * 2 / 3)
     # Age stats derive from the single dated pano (captured exactly 6y before)
-    assert data['all_panos']['age_stats']['avg_pano_age_years'] == \
-        pytest.approx(6.0, abs=0.01)
+    assert data["all_panos"]["age_stats"]["avg_pano_age_years"] == pytest.approx(6.0, abs=0.01)
 
 
 def test_v2_fields_and_age_pinned_to_run_date(data_dir):
     run_date = date(2026, 1, 15)
-    csv_path = _write_run(data_dir, [('p1', '2020-01-15'), ('p2', '2022-01-15')],
-                          run_date,
-                          'duo--city_width_100_height_100_step_20_2026-01-15.csv.gz')
+    csv_path = _write_run(
+        data_dir,
+        [("p1", "2020-01-15"), ("p2", "2022-01-15")],
+        run_date,
+        "duo--city_width_100_height_100_step_20_2026-01-15.csv.gz",
+    )
     df = load_city_csv_file(csv_path)
-    change = {"from_run_date": "2025-10-01", "panos_added": 1, "panos_removed": 0,
-              "capture_date_changed": 0, "coverage_delta_pct": 0.0,
-              "grid_aligned": True, "diff_file": None}
+    change = {
+        "from_run_date": "2025-10-01",
+        "panos_added": 1,
+        "panos_removed": 0,
+        "capture_date_changed": 0,
+        "coverage_delta_pct": 0.0,
+        "grid_aligned": True,
+        "diff_file": None,
+    }
     json_path = generate_city_metadata_summary_as_json(
-        csv_path, df, 'Duo', None, 'Testland', 100, 100, 20,
-        force_recreate_file=True, run_date=run_date,
-        change_from_previous_run=change)
+        csv_path,
+        df,
+        "Duo",
+        None,
+        "Testland",
+        100,
+        100,
+        20,
+        force_recreate_file=True,
+        run_date=run_date,
+        change_from_previous_run=change,
+    )
     data = strict_load(json_path)
 
-    assert data['schema_version'] == 2
-    assert data['provider'] == 'gsv'
-    assert data['run'] == {'run_date': '2026-01-15', 'is_baseline': False}
-    assert data['change_from_previous_run']['panos_added'] == 1
-    assert 'google_panos' in data
-    assert data['copyright_info_available'] is True
+    assert data["schema_version"] == 2
+    assert data["provider"] == "gsv"
+    assert data["run"] == {"run_date": "2026-01-15", "is_baseline": False}
+    assert data["change_from_previous_run"]["panos_added"] == 1
+    assert "google_panos" in data
+    assert data["copyright_info_available"] is True
 
     # Ages relative to run_date: panos captured exactly 6 and 4 years earlier
-    ages = data['all_panos']['age_stats']
-    assert ages['avg_pano_age_years'] == pytest.approx(5.0, abs=0.01)
-    assert ages['median_pano_age_years'] == pytest.approx(5.0, abs=0.01)
+    ages = data["all_panos"]["age_stats"]
+    assert ages["avg_pano_age_years"] == pytest.approx(5.0, abs=0.01)
+    assert ages["median_pano_age_years"] == pytest.approx(5.0, abs=0.01)
 
 
 def test_copyright_unknown_run_json(data_dir):
     # Archival imports (issue #93) never captured copyright_info: the
     # Google subset is unknown, so google_panos is omitted and flagged
     run_date = date(2023, 11, 5)
-    csv_path = os.path.join(
-        data_dir, 'old--city_width_1000_height_1000_step_30_2023-11-05.csv.gz')
-    write_city_csv_gz(make_city_df([('p1', '2020-05-01'), ('p2', '2021-06-01')],
-                                   run_date=run_date, copyright_info=None),
-                      csv_path)
+    csv_path = os.path.join(data_dir, "old--city_width_1000_height_1000_step_30_2023-11-05.csv.gz")
+    write_city_csv_gz(
+        make_city_df(
+            [("p1", "2020-05-01"), ("p2", "2021-06-01")], run_date=run_date, copyright_info=None
+        ),
+        csv_path,
+    )
     df = load_city_csv_file(csv_path)
     json_path = generate_city_metadata_summary_as_json(
-        csv_path, df, 'Old', None, 'Testland', 1000, 1000, 30,
-        force_recreate_file=True, run_date=run_date, is_baseline=True)
+        csv_path,
+        df,
+        "Old",
+        None,
+        "Testland",
+        1000,
+        1000,
+        30,
+        force_recreate_file=True,
+        run_date=run_date,
+        is_baseline=True,
+    )
     data = strict_load(json_path)
 
-    assert data['copyright_info_available'] is False
-    assert 'google_panos' not in data
-    assert data['run'] == {'run_date': '2023-11-05', 'is_baseline': True}
-    assert data['all_panos']['duplicate_stats']['total_unique_panos'] == 2
+    assert data["copyright_info_available"] is False
+    assert "google_panos" not in data
+    assert data["run"] == {"run_date": "2023-11-05", "is_baseline": True}
+    assert data["all_panos"]["duplicate_stats"]["total_unique_panos"] == 2
 
 
 def test_run_stats_google_panos_none_when_copyright_unknown():
     from gsv_metadata_tracker.analysis import calculate_run_stats
 
     run_date = date(2023, 11, 5)
-    df_unknown = make_city_df([('p1', '2020-05-01')], run_date=run_date,
-                              copyright_info=None)
+    df_unknown = make_city_df([("p1", "2020-05-01")], run_date=run_date, copyright_info=None)
     stats = calculate_run_stats(df_unknown, run_date)
-    assert stats['unique_google_panos'] is None
-    assert stats['unique_panos'] == 1
+    assert stats["unique_google_panos"] is None
+    assert stats["unique_panos"] == 1
 
-    df_known = make_city_df([('p1', '2020-05-01')], run_date=run_date)
+    df_known = make_city_df([("p1", "2020-05-01")], run_date=run_date)
     stats = calculate_run_stats(df_known, run_date)
-    assert stats['unique_google_panos'] == 1
+    assert stats["unique_google_panos"] == 1
 
     # A run with zero OK rows has a trivially known (zero) Google subset
     df_empty = make_city_df([], run_date=run_date, n_empty=2)
     stats = calculate_run_stats(df_empty, run_date)
-    assert stats['unique_google_panos'] == 0
+    assert stats["unique_google_panos"] == 0
 
 
 def test_aggregate_propagates_copyright_flag(conn, data_dir):
     city_id = db.register_city(
-        conn, city_name='Old', state_name=None, state_code=None,
-        country_name='Testland', country_code=None,
-        center_lat=44.0, center_lon=-121.0,
-        grid_width_m=1000, grid_height_m=1000, step_m=20)
+        conn,
+        city_name="Old",
+        state_name=None,
+        state_code=None,
+        country_name="Testland",
+        country_code=None,
+        center_lat=44.0,
+        center_lon=-121.0,
+        grid_width_m=1000,
+        grid_height_m=1000,
+        step_m=20,
+    )
     run_date = date(2023, 11, 5)
-    csv_name = f'{city_id}_width_1000_height_1000_step_30_2023-11-05.csv.gz'
+    csv_name = f"{city_id}_width_1000_height_1000_step_30_2023-11-05.csv.gz"
     csv_path = os.path.join(data_dir, csv_name)
-    write_city_csv_gz(make_city_df([('p1', '2020-05-01')], run_date=run_date,
-                                   copyright_info=None), csv_path)
+    write_city_csv_gz(
+        make_city_df([("p1", "2020-05-01")], run_date=run_date, copyright_info=None), csv_path
+    )
     df = load_city_csv_file(csv_path)
     json_path = generate_city_metadata_summary_as_json(
-        csv_path, df, 'Old', None, 'Testland', 1000, 1000, 30,
-        force_recreate_file=True, run_date=run_date, is_baseline=True)
-    db.register_run(conn, city_id=city_id, run_date=run_date,
-                    csv_filename=csv_name,
-                    json_filename=os.path.basename(json_path),
-                    is_baseline=True, unique_panos=1,
-                    unique_google_panos=None)
+        csv_path,
+        df,
+        "Old",
+        None,
+        "Testland",
+        1000,
+        1000,
+        30,
+        force_recreate_file=True,
+        run_date=run_date,
+        is_baseline=True,
+    )
+    db.register_run(
+        conn,
+        city_id=city_id,
+        run_date=run_date,
+        csv_filename=csv_name,
+        json_filename=os.path.basename(json_path),
+        is_baseline=True,
+        unique_panos=1,
+        unique_google_panos=None,
+    )
 
     summary = generate_aggregate_v2(conn, data_dir)
-    gsv = summary['cities'][0]['providers']['gsv']
+    gsv = summary["cities"][0]["providers"]["gsv"]
 
-    assert gsv['latest']['copyright_info_available'] is False
-    assert 'unique_google_panos' not in gsv['latest']['panorama_counts']
-    assert 'google_panos_age_stats' not in gsv['latest']
-    assert gsv['latest']['is_baseline'] is True
-    assert gsv['runs'][0]['unique_google_panos'] is None
+    assert gsv["latest"]["copyright_info_available"] is False
+    assert "unique_google_panos" not in gsv["latest"]["panorama_counts"]
+    assert "google_panos_age_stats" not in gsv["latest"]
+    assert gsv["latest"]["is_baseline"] is True
+    assert gsv["runs"][0]["unique_google_panos"] is None
     # No google contribution to the global gsv histograms
-    assert summary['histogram_of_capture_dates']['gsv']['google_panos_yearly'] == {}
+    assert summary["histogram_of_capture_dates"]["gsv"]["google_panos_yearly"] == {}
 
-    strict_load(os.path.join(data_dir, 'cities.json.gz'))
+    strict_load(os.path.join(data_dir, "cities.json.gz"))
 
 
 def test_mapillary_run_json(data_dir):
     run_date = date(2026, 1, 15)
     csv_path = os.path.join(
-        data_dir, 'duo--city_width_100_height_100_step_20_mapillary_2026-01-15.csv.gz')
+        data_dir, "duo--city_width_100_height_100_step_20_mapillary_2026-01-15.csv.gz"
+    )
     # 4 panos on 2 grid points (2 each) + 1 empty point: exercises the
     # rows-vs-grid-points distinction that only exists for Mapillary
-    write_city_csv_gz(make_mapillary_city_df(
-        [('m1', '2021-03-01'), ('m2', '2022-03-01'),
-         ('m3', '2023-03-01'), ('m4', '2024-03-01')],
-        run_date=run_date, panos_per_point=2), csv_path)
+    write_city_csv_gz(
+        make_mapillary_city_df(
+            [
+                ("m1", "2021-03-01"),
+                ("m2", "2022-03-01"),
+                ("m3", "2023-03-01"),
+                ("m4", "2024-03-01"),
+            ],
+            run_date=run_date,
+            panos_per_point=2,
+        ),
+        csv_path,
+    )
     df = load_city_csv_file(csv_path)
     json_path = generate_city_metadata_summary_as_json(
-        csv_path, df, 'Duo', None, 'Testland', 100, 100, 20,
-        force_recreate_file=True, run_date=run_date, provider='mapillary')
+        csv_path,
+        df,
+        "Duo",
+        None,
+        "Testland",
+        100,
+        100,
+        20,
+        force_recreate_file=True,
+        run_date=run_date,
+        provider="mapillary",
+    )
     data = strict_load(json_path)
 
-    assert data['provider'] == 'mapillary'
-    assert 'google_panos' not in data  # all rows are already provider panos
-    assert data['all_panos']['duplicate_stats']['total_unique_panos'] == 4
+    assert data["provider"] == "mapillary"
+    assert "google_panos" not in data  # all rows are already provider panos
+    assert data["all_panos"]["duplicate_stats"]["total_unique_panos"] == 4
     # search points count grid points, not pano rows
-    assert data['search_grid']['total_search_points'] == 3
-    assert data['data_file']['rows'] == 5
+    assert data["search_grid"]["total_search_points"] == 3
+    assert data["data_file"]["rows"] == 5
     # contributor breakdown replaces the single '© Google' photographer
-    assert all(k.startswith('© Mapillary contributor')
-               for k in data['all_panos']['top_10_photographers'])
+    assert all(
+        k.startswith("© Mapillary contributor") for k in data["all_panos"]["top_10_photographers"]
+    )
 
 
 def test_aggregate_v2_groups_runs_and_reports_change(conn, data_dir):
     city_id = db.register_city(
-        conn, city_name='Duo', state_name=None, state_code=None,
-        country_name='Testland', country_code=None,
-        center_lat=44.0, center_lon=-121.0,
-        grid_width_m=100, grid_height_m=100, step_m=20)
+        conn,
+        city_name="Duo",
+        state_name=None,
+        state_code=None,
+        country_name="Testland",
+        country_code=None,
+        center_lat=44.0,
+        center_lon=-121.0,
+        grid_width_m=100,
+        grid_height_m=100,
+        step_m=20,
+    )
 
     for run_date, panos, csv_name in [
-        (date(2026, 1, 15), [('p1', '2020-01-15')],
-         f'{city_id}_width_100_height_100_step_20_2026-01-15.csv.gz'),
-        (date(2026, 4, 15), [('p1', '2020-01-15'), ('p2', '2024-01-15')],
-         f'{city_id}_width_100_height_100_step_20_2026-04-15.csv.gz'),
+        (
+            date(2026, 1, 15),
+            [("p1", "2020-01-15")],
+            f"{city_id}_width_100_height_100_step_20_2026-01-15.csv.gz",
+        ),
+        (
+            date(2026, 4, 15),
+            [("p1", "2020-01-15"), ("p2", "2024-01-15")],
+            f"{city_id}_width_100_height_100_step_20_2026-04-15.csv.gz",
+        ),
     ]:
         csv_path = _write_run(data_dir, panos, run_date, csv_name)
         df = load_city_csv_file(csv_path)
         json_path = generate_city_metadata_summary_as_json(
-            csv_path, df, 'Duo', None, 'Testland', 100, 100, 20,
-            force_recreate_file=True, run_date=run_date)
-        run_id = db.register_run(conn, city_id=city_id, run_date=run_date,
-                                 csv_filename=csv_name,
-                                 json_filename=os.path.basename(json_path),
-                                 unique_google_panos=len(panos))
+            csv_path,
+            df,
+            "Duo",
+            None,
+            "Testland",
+            100,
+            100,
+            20,
+            force_recreate_file=True,
+            run_date=run_date,
+        )
+        db.register_run(
+            conn,
+            city_id=city_id,
+            run_date=run_date,
+            csv_filename=csv_name,
+            json_filename=os.path.basename(json_path),
+            unique_google_panos=len(panos),
+        )
     prev, latest = db.get_runs_for_city(conn, city_id)
-    db.record_diff(conn, city_id=city_id, from_run_id=prev.run_id,
-                   to_run_id=latest.run_id, grid_aligned=True, panos_added=1,
-                   panos_removed=0, panos_persisted=1, capture_date_changed=0,
-                   points_gained_coverage=1, points_lost_coverage=0,
-                   coverage_delta_pct=33.3, detail_filename=None)
+    db.record_diff(
+        conn,
+        city_id=city_id,
+        from_run_id=prev.run_id,
+        to_run_id=latest.run_id,
+        grid_aligned=True,
+        panos_added=1,
+        panos_removed=0,
+        panos_persisted=1,
+        capture_date_changed=0,
+        points_gained_coverage=1,
+        points_lost_coverage=0,
+        coverage_delta_pct=33.3,
+        detail_filename=None,
+    )
 
     summary = generate_aggregate_v2(conn, data_dir)
 
-    assert summary['schema_version'] == 3
-    assert summary['cities_count'] == 1
-    rec = summary['cities'][0]
-    assert rec['city_id'] == city_id
-    assert rec['city']['name'] == 'Duo'
-    gsv = rec['providers']['gsv']
-    assert len(gsv['runs']) == 2
-    assert gsv['latest']['run_date'] == '2026-04-15'
-    assert 'unique_google_panos' in gsv['latest']['panorama_counts']
-    assert 'google_panos_age_stats' in gsv['latest']
-    assert gsv['change']['panos_added'] == 1
-    assert list(summary['histogram_of_capture_dates']) == ['gsv']
+    assert summary["schema_version"] == 3
+    assert summary["cities_count"] == 1
+    rec = summary["cities"][0]
+    assert rec["city_id"] == city_id
+    assert rec["city"]["name"] == "Duo"
+    gsv = rec["providers"]["gsv"]
+    assert len(gsv["runs"]) == 2
+    assert gsv["latest"]["run_date"] == "2026-04-15"
+    assert "unique_google_panos" in gsv["latest"]["panorama_counts"]
+    assert "google_panos_age_stats" in gsv["latest"]
+    assert gsv["change"]["panos_added"] == 1
+    assert list(summary["histogram_of_capture_dates"]) == ["gsv"]
 
     # The written aggregate must be strict-parseable
-    strict_load(os.path.join(data_dir, 'cities.json.gz'))
+    strict_load(os.path.join(data_dir, "cities.json.gz"))
 
 
 def test_aggregate_v3_two_providers(conn, data_dir):
     city_id = db.register_city(
-        conn, city_name='Both', state_name=None, state_code=None,
-        country_name='Testland', country_code=None,
-        center_lat=44.0, center_lon=-121.0,
-        grid_width_m=100, grid_height_m=100, step_m=20)
+        conn,
+        city_name="Both",
+        state_name=None,
+        state_code=None,
+        country_name="Testland",
+        country_code=None,
+        center_lat=44.0,
+        center_lon=-121.0,
+        grid_width_m=100,
+        grid_height_m=100,
+        step_m=20,
+    )
 
     # One gsv run and two mapillary runs (mapillary latest has a diff)
-    gsv_csv = f'{city_id}_width_100_height_100_step_20_2026-01-15.csv.gz'
-    csv_path = _write_run(data_dir, [('g1', '2020-01-15')], date(2026, 1, 15), gsv_csv)
+    gsv_csv = f"{city_id}_width_100_height_100_step_20_2026-01-15.csv.gz"
+    csv_path = _write_run(data_dir, [("g1", "2020-01-15")], date(2026, 1, 15), gsv_csv)
     df = load_city_csv_file(csv_path)
     json_path = generate_city_metadata_summary_as_json(
-        csv_path, df, 'Both', None, 'Testland', 100, 100, 20,
-        force_recreate_file=True, run_date=date(2026, 1, 15))
-    db.register_run(conn, city_id=city_id, run_date=date(2026, 1, 15),
-                    csv_filename=gsv_csv,
-                    json_filename=os.path.basename(json_path),
-                    unique_panos=1, unique_google_panos=1)
+        csv_path,
+        df,
+        "Both",
+        None,
+        "Testland",
+        100,
+        100,
+        20,
+        force_recreate_file=True,
+        run_date=date(2026, 1, 15),
+    )
+    db.register_run(
+        conn,
+        city_id=city_id,
+        run_date=date(2026, 1, 15),
+        csv_filename=gsv_csv,
+        json_filename=os.path.basename(json_path),
+        unique_panos=1,
+        unique_google_panos=1,
+    )
 
     m_runs = []
     for run_date, panos in [
-        (date(2026, 1, 15), [('m1', '2021-05-01')]),
-        (date(2026, 4, 15), [('m1', '2021-05-01'), ('m2', '2024-05-01')]),
+        (date(2026, 1, 15), [("m1", "2021-05-01")]),
+        (date(2026, 4, 15), [("m1", "2021-05-01"), ("m2", "2024-05-01")]),
     ]:
-        name = (f'{city_id}_width_100_height_100_step_20_mapillary_'
-                f'{run_date.isoformat()}.csv.gz')
+        name = f"{city_id}_width_100_height_100_step_20_mapillary_{run_date.isoformat()}.csv.gz"
         csv_path = os.path.join(data_dir, name)
         write_city_csv_gz(make_mapillary_city_df(panos, run_date=run_date), csv_path)
         df = load_city_csv_file(csv_path)
         json_path = generate_city_metadata_summary_as_json(
-            csv_path, df, 'Both', None, 'Testland', 100, 100, 20,
-            force_recreate_file=True, run_date=run_date, provider='mapillary')
-        m_runs.append(db.register_run(
-            conn, city_id=city_id, run_date=run_date, csv_filename=name,
-            provider='mapillary', json_filename=os.path.basename(json_path),
-            unique_panos=len(panos)))
-    db.record_diff(conn, city_id=city_id, from_run_id=m_runs[0],
-                   to_run_id=m_runs[1], grid_aligned=True, panos_added=1,
-                   panos_removed=0, panos_persisted=1, capture_date_changed=0,
-                   points_gained_coverage=1, points_lost_coverage=0,
-                   coverage_delta_pct=33.3, detail_filename=None)
+            csv_path,
+            df,
+            "Both",
+            None,
+            "Testland",
+            100,
+            100,
+            20,
+            force_recreate_file=True,
+            run_date=run_date,
+            provider="mapillary",
+        )
+        m_runs.append(
+            db.register_run(
+                conn,
+                city_id=city_id,
+                run_date=run_date,
+                csv_filename=name,
+                provider="mapillary",
+                json_filename=os.path.basename(json_path),
+                unique_panos=len(panos),
+            )
+        )
+    db.record_diff(
+        conn,
+        city_id=city_id,
+        from_run_id=m_runs[0],
+        to_run_id=m_runs[1],
+        grid_aligned=True,
+        panos_added=1,
+        panos_removed=0,
+        panos_persisted=1,
+        capture_date_changed=0,
+        points_gained_coverage=1,
+        points_lost_coverage=0,
+        coverage_delta_pct=33.3,
+        detail_filename=None,
+    )
 
     summary = generate_aggregate_v2(conn, data_dir)
-    rec = summary['cities'][0]
+    rec = summary["cities"][0]
 
-    assert set(rec['providers']) == {'gsv', 'mapillary'}
-    assert rec['city']['name'] == 'Both'  # taken from the gsv run
+    assert set(rec["providers"]) == {"gsv", "mapillary"}
+    assert rec["city"]["name"] == "Both"  # taken from the gsv run
 
-    mly = rec['providers']['mapillary']
-    assert len(mly['runs']) == 2
-    assert mly['latest']['run_date'] == '2026-04-15'
-    assert mly['latest']['panorama_counts'] == {'unique_panos': 2}
-    assert 'google_panos_age_stats' not in mly['latest']
-    assert mly['change']['panos_added'] == 1
-    assert mly['runs'][0]['unique_google_panos'] is None
+    mly = rec["providers"]["mapillary"]
+    assert len(mly["runs"]) == 2
+    assert mly["latest"]["run_date"] == "2026-04-15"
+    assert mly["latest"]["panorama_counts"] == {"unique_panos": 2}
+    assert "google_panos_age_stats" not in mly["latest"]
+    assert mly["change"]["panos_added"] == 1
+    assert mly["runs"][0]["unique_google_panos"] is None
     # The gsv series is untouched by the mapillary runs
-    assert rec['providers']['gsv']['change'] is None
-    assert len(rec['providers']['gsv']['runs']) == 1
+    assert rec["providers"]["gsv"]["change"] is None
+    assert len(rec["providers"]["gsv"]["runs"]) == 1
 
     # Per-provider global histograms; mapillary's google section stays empty
-    hists = summary['histogram_of_capture_dates']
-    assert set(hists) == {'gsv', 'mapillary'}
-    assert hists['mapillary']['all_panos_yearly'] == {'2021': 1, '2024': 1} or \
-        hists['mapillary']['all_panos_yearly'] == {2021: 1, 2024: 1}
-    assert hists['mapillary']['google_panos_yearly'] == {}
+    hists = summary["histogram_of_capture_dates"]
+    assert set(hists) == {"gsv", "mapillary"}
+    assert hists["mapillary"]["all_panos_yearly"] == {"2021": 1, "2024": 1} or hists["mapillary"][
+        "all_panos_yearly"
+    ] == {2021: 1, 2024: 1}
+    assert hists["mapillary"]["google_panos_yearly"] == {}
 
-    strict_load(os.path.join(data_dir, 'cities.json.gz'))
+    strict_load(os.path.join(data_dir, "cities.json.gz"))

--- a/tests/test_mapillary.py
+++ b/tests/test_mapillary.py
@@ -8,7 +8,7 @@ import asyncio
 import gzip
 import math
 import re
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 import geopy
 import mapbox_vector_tile
@@ -25,8 +25,9 @@ SEATTLE = (47.6062, -122.3321)
 
 # ── Tile math ──────────────────────────────────────────────────────────────
 
+
 def test_tile_frac_known_anchors():
-    n = 2 ** 14
+    n = 2**14
     # Greenwich/equator sits exactly at the center of the tile grid
     fx, fy = dm.lonlat_to_tile_frac(0.0, 0.0, 14)
     assert fx == pytest.approx(n / 2)
@@ -36,12 +37,15 @@ def test_tile_frac_known_anchors():
     assert fx == pytest.approx(0.0)
 
 
-@pytest.mark.parametrize("lon,lat", [
-    (0.0, 0.0),
-    (-122.3321, 47.6062),   # Seattle
-    (151.2093, -33.8688),   # Sydney (southern hemisphere)
-    (18.9553, 69.6496),     # Tromsø (high latitude)
-])
+@pytest.mark.parametrize(
+    "lon,lat",
+    [
+        (0.0, 0.0),
+        (-122.3321, 47.6062),  # Seattle
+        (151.2093, -33.8688),  # Sydney (southern hemisphere)
+        (18.9553, 69.6496),  # Tromsø (high latitude)
+    ],
+)
 def test_tile_frac_roundtrip(lon, lat):
     fx, fy = dm.lonlat_to_tile_frac(lon, lat, 14)
     lon2, lat2 = dm.tile_frac_to_lonlat(fx, fy, 14)
@@ -54,8 +58,7 @@ def test_tiles_for_bbox_single_tile():
     fx, fy = dm.lonlat_to_tile_frac(*reversed(SEATTLE), 14)
     lon_mid, lat_mid = dm.tile_frac_to_lonlat(int(fx) + 0.5, int(fy) + 0.5, 14)
     eps = 1e-5
-    tiles = dm.tiles_for_bbox(lon_mid - eps, lat_mid - eps,
-                              lon_mid + eps, lat_mid + eps)
+    tiles = dm.tiles_for_bbox(lon_mid - eps, lat_mid - eps, lon_mid + eps, lat_mid + eps)
     assert tiles == [(int(fx), int(fy))]
 
 
@@ -65,8 +68,9 @@ def test_tiles_for_bbox_straddles_boundary():
     x0, y0 = int(fx), int(fy)
     corner_lon, corner_lat = dm.tile_frac_to_lonlat(x0, y0, 14)
     eps = 1e-5
-    tiles = set(dm.tiles_for_bbox(corner_lon - eps, corner_lat - eps,
-                                  corner_lon + eps, corner_lat + eps))
+    tiles = set(
+        dm.tiles_for_bbox(corner_lon - eps, corner_lat - eps, corner_lon + eps, corner_lat + eps)
+    )
     assert tiles == {(x0 - 1, y0 - 1), (x0, y0 - 1), (x0 - 1, y0), (x0, y0)}
 
 
@@ -74,8 +78,9 @@ def test_grid_bbox_contains_every_grid_point():
     lat, lon = SEATTLE
     width, height, step = 1000, 600, 20
     min_lon, min_lat, max_lon, max_lat = dm.grid_bbox(lat, lon, width, height, step)
-    points = generate_grid_points(geopy.Point(lat, lon),
-                                  int(width / step), int(height / step), step)
+    points = generate_grid_points(
+        geopy.Point(lat, lon), int(width / step), int(height / step), step
+    )
     for p_lat, p_lon, _, _ in points:
         assert min_lat < p_lat < max_lat
         assert min_lon < p_lon < max_lon
@@ -92,6 +97,7 @@ def test_estimate_tile_count_matches_enumeration():
 
 # ── Synthetic tile encoding (shared by decode + end-to-end tests) ──────────
 
+
 def encode_tile(features, tile_x, tile_y, zoom=14, extent=4096):
     """
     Build raw MVT bytes for the 'image' layer from records with lon/lat and
@@ -99,36 +105,47 @@ def encode_tile(features, tile_x, tile_y, zoom=14, extent=4096):
     """
     encoded_features = []
     for f in features:
-        fx, fy = dm.lonlat_to_tile_frac(f['lon'], f['lat'], zoom)
+        fx, fy = dm.lonlat_to_tile_frac(f["lon"], f["lat"], zoom)
         px = (fx - tile_x) * extent
         py = (1 - (fy - tile_y)) * extent  # y-up, matching decode()'s default
-        props = {k: v for k, v in f.items() if k not in ('lon', 'lat')}
-        encoded_features.append({
-            'geometry': {'type': 'Point', 'coordinates': [px, py]},
-            'properties': props,
-        })
-    return mapbox_vector_tile.encode(
-        [{'name': dm.IMAGE_LAYER, 'features': encoded_features}])
+        props = {k: v for k, v in f.items() if k not in ("lon", "lat")}
+        encoded_features.append(
+            {
+                "geometry": {"type": "Point", "coordinates": [px, py]},
+                "properties": props,
+            }
+        )
+    return mapbox_vector_tile.encode([{"name": dm.IMAGE_LAYER, "features": encoded_features}])
 
 
-def make_image(image_id, lon, lat, *, is_pano=True,
-               captured_at=1650000000000, creator_id=42):
-    return {'id': image_id, 'lon': lon, 'lat': lat, 'is_pano': is_pano,
-            'captured_at': captured_at, 'creator_id': creator_id}
+def make_image(image_id, lon, lat, *, is_pano=True, captured_at=1650000000000, creator_id=42):
+    return {
+        "id": image_id,
+        "lon": lon,
+        "lat": lat,
+        "is_pano": is_pano,
+        "captured_at": captured_at,
+        "creator_id": creator_id,
+    }
 
 
 # ── Decoding ───────────────────────────────────────────────────────────────
+
 
 def test_decode_filters_non_pano():
     lat, lon = SEATTLE
     fx, fy = dm.lonlat_to_tile_frac(lon, lat, 14)
     x, y = int(fx), int(fy)
-    tile = encode_tile([
-        make_image(1, lon, lat, is_pano=True),
-        make_image(2, lon + 1e-4, lat, is_pano=False),   # flat phone photo
-    ], x, y)
+    tile = encode_tile(
+        [
+            make_image(1, lon, lat, is_pano=True),
+            make_image(2, lon + 1e-4, lat, is_pano=False),  # flat phone photo
+        ],
+        x,
+        y,
+    )
     records = dm.decode_image_features(tile, x, y)
-    assert [r['id'] for r in records] == ['1']
+    assert [r["id"] for r in records] == ["1"]
 
 
 def test_decode_coordinates_are_accurate():
@@ -137,19 +154,21 @@ def test_decode_coordinates_are_accurate():
     lat, lon = SEATTLE
     fx, fy = dm.lonlat_to_tile_frac(lon, lat, 14)
     x, y = int(fx), int(fy)
-    records = dm.decode_image_features(
-        encode_tile([make_image(7, lon, lat)], x, y), x, y)
+    records = dm.decode_image_features(encode_tile([make_image(7, lon, lat)], x, y), x, y)
     assert len(records) == 1
-    assert records[0]['lon'] == pytest.approx(lon, abs=5e-5)
-    assert records[0]['lat'] == pytest.approx(lat, abs=5e-5)
-    assert records[0]['captured_at_ms'] == 1650000000000
-    assert records[0]['creator_id'] == 42
+    assert records[0]["lon"] == pytest.approx(lon, abs=5e-5)
+    assert records[0]["lat"] == pytest.approx(lat, abs=5e-5)
+    assert records[0]["captured_at_ms"] == 1650000000000
+    assert records[0]["creator_id"] == 42
 
 
 def test_decode_empty_or_missing_layer():
-    assert dm.decode_image_features(
-        mapbox_vector_tile.encode([{'name': 'sequence', 'features': []}]),
-        100, 100) == []
+    assert (
+        dm.decode_image_features(
+            mapbox_vector_tile.encode([{"name": "sequence", "features": []}]), 100, 100
+        )
+        == []
+    )
 
 
 def test_decode_ids_are_strings():
@@ -157,29 +176,35 @@ def test_decode_ids_are_strings():
     fx, fy = dm.lonlat_to_tile_frac(lon, lat, 14)
     x, y = int(fx), int(fy)
     records = dm.decode_image_features(
-        encode_tile([make_image(1234567890123, lon, lat)], x, y), x, y)
-    assert records[0]['id'] == '1234567890123'
+        encode_tile([make_image(1234567890123, lon, lat)], x, y), x, y
+    )
+    assert records[0]["id"] == "1234567890123"
 
 
 # ── Capture dates ──────────────────────────────────────────────────────────
 
+
 def test_captured_at_valid_epoch_ms():
     # 2022-01-03T10:43:50Z
-    assert dm.captured_at_to_iso_date(1641206630491) == '2022-01-03'
+    assert dm.captured_at_to_iso_date(1641206630491) == "2022-01-03"
 
 
-@pytest.mark.parametrize("bogus", [
-    None,                # missing
-    0,                   # epoch zero (dead device clock)
-    -1000,               # negative
-    915148800000,        # 1999 — before street-level imagery existed
-    4102444800000,       # year 2100 — future device clock
-])
+@pytest.mark.parametrize(
+    "bogus",
+    [
+        None,  # missing
+        0,  # epoch zero (dead device clock)
+        -1000,  # negative
+        915148800000,  # 1999 — before street-level imagery existed
+        4102444800000,  # year 2100 — future device clock
+    ],
+)
 def test_captured_at_bogus_values_rejected(bogus):
-    assert dm.captured_at_to_iso_date(bogus) == ''
+    assert dm.captured_at_to_iso_date(bogus) == ""
 
 
 # ── Grid assignment ────────────────────────────────────────────────────────
+
 
 def test_assign_grid_points_map_to_themselves():
     # Consistency between the geodesic grid builder and the equirectangular
@@ -188,14 +213,12 @@ def test_assign_grid_points_map_to_themselves():
     lat, lon = SEATTLE
     step = 20
     for width_steps, height_steps in [(4, 4), (5, 5), (5, 4)]:
-        points = generate_grid_points(geopy.Point(lat, lon),
-                                      width_steps, height_steps, step)
+        points = generate_grid_points(geopy.Point(lat, lon), width_steps, height_steps, step)
         lats = np.array([p[0] for p in points])
         lons = np.array([p[1] for p in points])
-        i, j, in_grid = dm.assign_to_grid(lats, lons, lat, lon,
-                                          width_steps, height_steps, step)
+        i, j, in_grid = dm.assign_to_grid(lats, lons, lat, lon, width_steps, height_steps, step)
         assert in_grid.all()
-        assert list(zip(i, j)) == [(p[2], p[3]) for p in points]
+        assert list(zip(i, j, strict=False)) == [(p[2], p[3]) for p in points]
 
 
 def test_assign_nearest_point_wins():
@@ -204,13 +227,13 @@ def test_assign_nearest_point_wins():
     # ~6m north and ~4m east of the center: rounds to (0, 0)
     img_lat = lat + 6 / dm._M_PER_DEG_LAT
     img_lon = lon + 4 / (dm._M_PER_DEG_LAT * math.cos(math.radians(lat)))
-    i, j, in_grid = dm.assign_to_grid(np.array([img_lat]), np.array([img_lon]),
-                                      lat, lon, 4, 4, step)
+    i, j, in_grid = dm.assign_to_grid(
+        np.array([img_lat]), np.array([img_lon]), lat, lon, 4, 4, step
+    )
     assert (i[0], j[0]) == (0, 0) and in_grid[0]
     # ~14m north: rounds to (1, 0)
     img_lat = lat + 14 / dm._M_PER_DEG_LAT
-    i, j, in_grid = dm.assign_to_grid(np.array([img_lat]), np.array([lon]),
-                                      lat, lon, 4, 4, step)
+    i, j, in_grid = dm.assign_to_grid(np.array([img_lat]), np.array([lon]), lat, lon, 4, 4, step)
     assert (i[0], j[0]) == (1, 0) and in_grid[0]
 
 
@@ -222,13 +245,14 @@ def test_assign_drops_images_beyond_grid_margin():
     just_inside = lat + (2 * step + 9) / dm._M_PER_DEG_LAT
     well_outside = lat + (3 * step) / dm._M_PER_DEG_LAT
     i, _, in_grid = dm.assign_to_grid(
-        np.array([just_inside, well_outside]), np.array([lon, lon]),
-        lat, lon, 4, 4, step)
+        np.array([just_inside, well_outside]), np.array([lon, lon]), lat, lon, 4, 4, step
+    )
     assert in_grid.tolist() == [True, False]
     assert i[0] == 2
 
 
 # ── End-to-end download (tiles served from memory) ─────────────────────────
+
 
 @pytest.fixture
 def straddling_city():
@@ -242,23 +266,26 @@ def straddling_city():
     return lat, boundary_lon
 
 
-def _run_download(monkeypatch, tmp_path, tiles_by_xy, center_lat,
-                  center_lon, width=100, height=100, step=20):
+def _run_download(
+    monkeypatch, tmp_path, tiles_by_xy, center_lat, center_lon, width=100, height=100, step=20
+):
     served = []
 
     async def fake_fetch(session, url, timeout):
-        m = re.search(r'/2/14/(\d+)/(\d+)\?access_token=(.+)$', url)
+        m = re.search(r"/2/14/(\d+)/(\d+)\?access_token=(.+)$", url)
         assert m, f"unexpected tile URL: {url}"
-        assert m.group(3) == 'MLY|test|token'
+        assert m.group(3) == "MLY|test|token"
         xy = (int(m.group(1)), int(m.group(2)))
         served.append(xy)
         return tiles_by_xy.get(xy, mapbox_vector_tile.encode([]))
 
-    monkeypatch.setattr(dm, '_fetch_tile', fake_fetch)
-    out_path = str(tmp_path / 'test_mapillary_2026-07-05.csv.gz')
-    result = asyncio.run(dm.download_mapillary_metadata_async(
-        'Test City', center_lat, center_lon, width, height, step,
-        'MLY|test|token', out_path))
+    monkeypatch.setattr(dm, "_fetch_tile", fake_fetch)
+    out_path = str(tmp_path / "test_mapillary_2026-07-05.csv.gz")
+    result = asyncio.run(
+        dm.download_mapillary_metadata_async(
+            "Test City", center_lat, center_lon, width, height, step, "MLY|test|token", out_path
+        )
+    )
     return result, served
 
 
@@ -280,91 +307,97 @@ def test_download_end_to_end(monkeypatch, tmp_path, straddling_city):
     def features_for(x, y):
         min_lon, min_lat = dm.tile_frac_to_lonlat(x, y + 1, 14)
         max_lon, max_lat = dm.tile_frac_to_lonlat(x + 1, y, 14)
-        own = [f for f in (east_pano, flat_photo, no_date)
-               if min_lon <= f['lon'] < max_lon and min_lat <= f['lat'] < max_lat]
+        own = [
+            f
+            for f in (east_pano, flat_photo, no_date)
+            if min_lon <= f["lon"] < max_lon and min_lat <= f["lat"] < max_lat
+        ]
         return own + [center_pano]  # duplicated everywhere
 
-    tiles_by_xy = {(x, y): encode_tile(features_for(x, y), x, y)
-                   for (x, y) in expected_tiles}
+    tiles_by_xy = {(x, y): encode_tile(features_for(x, y), x, y) for (x, y) in expected_tiles}
     result, served = _run_download(monkeypatch, tmp_path, tiles_by_xy, lat, lon)
-    df = result['df']
+    df = result["df"]
 
     # Contract: exact 9-column schema, every tile fetched exactly once
     assert list(df.columns) == list(METADATA_DTYPES.keys())
     assert sorted(served) == sorted(expected_tiles)
-    assert result['api_requests'] == len(expected_tiles)
+    assert result["api_requests"] == len(expected_tiles)
 
     # Cross-tile dedup: pano 101 appears in every tile but only once here
-    ok = df[df['status'] == 'OK']
-    assert sorted(ok['pano_id']) == ['101', '102']
-    assert (df['status'] == 'NO_DATE').sum() == 1
+    ok = df[df["status"] == "OK"]
+    assert sorted(ok["pano_id"]) == ["101", "102"]
+    assert (df["status"] == "NO_DATE").sum() == 1
 
     # Grid semantics: 100m/20m -> 6x6 grid; every point present exactly once
     # unless covered; total rows = panos + no_date + empty points
     n_points = 6 * 6
-    covered = df[df['status'] != 'ZERO_RESULTS'][['query_lat', 'query_lon']]
+    covered = df[df["status"] != "ZERO_RESULTS"][["query_lat", "query_lon"]]
     n_covered_points = len(covered.drop_duplicates())
-    assert (df['status'] == 'ZERO_RESULTS').sum() == n_points - n_covered_points
+    assert (df["status"] == "ZERO_RESULTS").sum() == n_points - n_covered_points
     assert len(df) == 2 + 1 + (n_points - n_covered_points)
 
     # Panos landed on distinct nearest grid points
-    assert len(ok[['query_lat', 'query_lon']].drop_duplicates()) == 2
+    assert len(ok[["query_lat", "query_lon"]].drop_duplicates()) == 2
 
     # Field contents
-    center_row = ok[ok['pano_id'] == '101'].iloc[0]
+    center_row = ok[ok["pano_id"] == "101"].iloc[0]
     # the shared loader parses capture_date to Timestamp, as for GSV runs
-    assert center_row['capture_date'] == pd.Timestamp('2022-01-03')
-    assert center_row['copyright_info'] == '© Mapillary contributor 42'
-    assert center_row['pano_lat'] == pytest.approx(lat, abs=5e-5)
-    assert center_row['pano_lon'] == pytest.approx(lon, abs=5e-5)
-    east_row = ok[ok['pano_id'] == '102'].iloc[0]
-    assert east_row['copyright_info'] == '© Mapillary contributor 7'
+    assert center_row["capture_date"] == pd.Timestamp("2022-01-03")
+    assert center_row["copyright_info"] == "© Mapillary contributor 42"
+    assert center_row["pano_lat"] == pytest.approx(lat, abs=5e-5)
+    assert center_row["pano_lon"] == pytest.approx(lon, abs=5e-5)
+    east_row = ok[ok["pano_id"] == "102"].iloc[0]
+    assert east_row["copyright_info"] == "© Mapillary contributor 7"
 
     # File on disk parses through the shared loader path (result already did,
     # but verify the write is a real gzip csv)
-    with gzip.open(result['filename_with_path'], 'rt') as f:
-        assert f.readline().strip() == ','.join(METADATA_DTYPES.keys())
+    with gzip.open(result["filename_with_path"], "rt") as f:
+        assert f.readline().strip() == ",".join(METADATA_DTYPES.keys())
 
     # Timestamps are ISO UTC and ordered
-    started = datetime.fromisoformat(result['started_at'])
-    finished = datetime.fromisoformat(result['finished_at'])
-    assert started.tzinfo == timezone.utc and started <= finished
+    started = datetime.fromisoformat(result["started_at"])
+    finished = datetime.fromisoformat(result["finished_at"])
+    assert started.tzinfo == UTC and started <= finished
 
 
 def test_download_city_with_no_imagery(monkeypatch, tmp_path):
     # Every tile empty: pure ZERO_RESULTS fill, one row per grid point
     lat, lon = SEATTLE
     result, _ = _run_download(monkeypatch, tmp_path, {}, lat, lon)
-    df = result['df']
-    assert (df['status'] == 'ZERO_RESULTS').all()
+    df = result["df"]
+    assert (df["status"] == "ZERO_RESULTS").all()
     assert len(df) == 6 * 6
-    assert df['pano_id'].isna().all()
+    assert df["pano_id"].isna().all()
 
 
 def test_download_rejects_non_csv_gz_path(tmp_path):
-    with pytest.raises(ValueError, match='csv.gz'):
-        asyncio.run(dm.download_mapillary_metadata_async(
-            'X', *SEATTLE, 100, 100, 20, 'tok', str(tmp_path / 'out.csv')))
+    with pytest.raises(ValueError, match="csv.gz"):
+        asyncio.run(
+            dm.download_mapillary_metadata_async(
+                "X", *SEATTLE, 100, 100, 20, "tok", str(tmp_path / "out.csv")
+            )
+        )
 
 
 def test_run_stats_for_mapillary_have_no_google_count():
     # calculate_run_stats feeds db.register_run: for mapillary runs the
     # Google-copyright breakdown must be NULL, not zero-by-accident
-    from gsv_metadata_tracker.analysis import calculate_run_stats
-    from tests.conftest import make_city_df, make_mapillary_city_df
     from datetime import date
 
-    m_df = make_mapillary_city_df(
-        [('m1', '2021-03-01'), ('m2', '2022-03-01'), ('m3', '2023-03-01')],
-        panos_per_point=3)
-    stats = calculate_run_stats(m_df, date(2026, 1, 15), provider='mapillary')
-    assert stats['unique_panos'] == 3
-    assert stats['unique_google_panos'] is None
-    assert stats['status_ok'] == 3 and stats['status_zero_results'] == 1
+    from gsv_metadata_tracker.analysis import calculate_run_stats
+    from tests.conftest import make_city_df, make_mapillary_city_df
 
-    g_df = make_city_df([('p1', '2021-03-01')])
+    m_df = make_mapillary_city_df(
+        [("m1", "2021-03-01"), ("m2", "2022-03-01"), ("m3", "2023-03-01")], panos_per_point=3
+    )
+    stats = calculate_run_stats(m_df, date(2026, 1, 15), provider="mapillary")
+    assert stats["unique_panos"] == 3
+    assert stats["unique_google_panos"] is None
+    assert stats["status_ok"] == 3 and stats["status_zero_results"] == 1
+
+    g_df = make_city_df([("p1", "2021-03-01")])
     g_stats = calculate_run_stats(g_df, date(2026, 1, 15))
-    assert g_stats['unique_google_panos'] == 1  # gsv path unchanged
+    assert g_stats["unique_google_panos"] == 1  # gsv path unchanged
 
 
 def test_download_pano_outside_grid_is_dropped(monkeypatch, tmp_path):
@@ -376,4 +409,4 @@ def test_download_pano_outside_grid_is_dropped(monkeypatch, tmp_path):
     x, y = int(fx), int(fy)
     tiles = {(x, y): encode_tile([make_image(201, far_lon, lat)], x, y)}
     result, _ = _run_download(monkeypatch, tmp_path, tiles, lat, lon)
-    assert (result['df']['status'] == 'ZERO_RESULTS').all()
+    assert (result["df"]["status"] == "ZERO_RESULTS").all()

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -14,12 +14,22 @@ from gsv_metadata_tracker.json_summarizer import generate_city_metadata_summary_
 from tests.conftest import make_city_df, write_city_csv_gz
 
 PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-SCRIPT = os.path.join(PROJECT_ROOT, 'scripts', 'migrate_to_db.py')
+SCRIPT = os.path.join(PROJECT_ROOT, "scripts", "migrate_to_db.py")
 
 
-def _make_legacy_city(data_dir, slug, city_name, state_name, country_name,
-                      panos, run_date, corrupt_json=False,
-                      width=100, height=100, step=20):
+def _make_legacy_city(
+    data_dir,
+    slug,
+    city_name,
+    state_name,
+    country_name,
+    panos,
+    run_date,
+    corrupt_json=False,
+    width=100,
+    height=100,
+    step=20,
+):
     """Create a legacy undated csv.gz + sibling json.gz pair."""
     base = f"{slug}_width_{width}_height_{height}_step_{step}"
     csv_path = os.path.join(data_dir, f"{base}.csv.gz")
@@ -27,70 +37,101 @@ def _make_legacy_city(data_dir, slug, city_name, state_name, country_name,
 
     df = load_city_csv_file(csv_path)
     json_path = generate_city_metadata_summary_as_json(
-        csv_path, df, city_name, state_name, country_name,
-        width, height, step, force_recreate_file=True, run_date=run_date)
+        csv_path,
+        df,
+        city_name,
+        state_name,
+        country_name,
+        width,
+        height,
+        step,
+        force_recreate_file=True,
+        run_date=run_date,
+    )
 
     if corrupt_json:
-        with gzip.open(json_path, 'rt', encoding='utf-8') as f:
+        with gzip.open(json_path, "rt", encoding="utf-8") as f:
             text = f.read()
-        text = text.replace('"stdev_pano_age_years": null',
-                            '"stdev_pano_age_years": NaN')
-        assert 'NaN' in text
-        with gzip.open(json_path, 'wt', encoding='utf-8') as f:
+        text = text.replace('"stdev_pano_age_years": null', '"stdev_pano_age_years": NaN')
+        assert "NaN" in text
+        with gzip.open(json_path, "wt", encoding="utf-8") as f:
             f.write(text)
     return csv_path
 
 
 def _run_migration(data_dir, *extra):
     return subprocess.run(
-        [sys.executable, SCRIPT, '--data-dir', data_dir, '--no-nominatim', *extra],
-        capture_output=True, text=True, cwd=PROJECT_ROOT)
+        [sys.executable, SCRIPT, "--data-dir", data_dir, "--no-nominatim", *extra],
+        capture_output=True,
+        text=True,
+        cwd=PROJECT_ROOT,
+    )
 
 
 def test_migration_end_to_end(data_dir):
     # Alias pair: same city under two slugs (only content identity matters)
-    _make_legacy_city(data_dir, 'albany--ny', 'Albany', 'New York',
-                      'United States', [('p1', '2020-05-01')], date(2025, 1, 10))
-    _make_legacy_city(data_dir, 'albany--new-york--united-states', 'Albany',
-                      'New York', 'United States',
-                      [('p1', '2020-05-01'), ('p2', '2021-05-01')], date(2025, 6, 10))
+    _make_legacy_city(
+        data_dir,
+        "albany--ny",
+        "Albany",
+        "New York",
+        "United States",
+        [("p1", "2020-05-01")],
+        date(2025, 1, 10),
+    )
+    _make_legacy_city(
+        data_dir,
+        "albany--new-york--united-states",
+        "Albany",
+        "New York",
+        "United States",
+        [("p1", "2020-05-01"), ("p2", "2021-05-01")],
+        date(2025, 6, 10),
+    )
     # Independent city with a single-pano NaN-corrupted JSON
-    _make_legacy_city(data_dir, 'solo--town', 'Solo', None, 'Testland',
-                      [('p9', '2019-03-01')], date(2025, 2, 2), corrupt_json=True)
+    _make_legacy_city(
+        data_dir,
+        "solo--town",
+        "Solo",
+        None,
+        "Testland",
+        [("p9", "2019-03-01")],
+        date(2025, 2, 2),
+        corrupt_json=True,
+    )
 
     # Dry run: no DB created
     result = _run_migration(data_dir)
     assert result.returncode == 0, result.stderr
-    assert 'Dry run complete' in result.stdout
-    assert 'albany--new-york--united-states  <-  albany--ny' in result.stdout
-    assert not os.path.exists(os.path.join(data_dir, 'gsv_tracker.db'))
+    assert "Dry run complete" in result.stdout
+    assert "albany--new-york--united-states  <-  albany--ny" in result.stdout
+    assert not os.path.exists(os.path.join(data_dir, "gsv_tracker.db"))
 
     # Execute
-    result = _run_migration(data_dir, '--execute')
+    result = _run_migration(data_dir, "--execute")
     assert result.returncode == 0, result.stderr
 
-    conn = db.connect(os.path.join(data_dir, 'gsv_tracker.db'))
+    conn = db.connect(os.path.join(data_dir, "gsv_tracker.db"))
     cities = db.get_all_cities(conn)
     # 'solo--town' is a legacy slug; canonical id comes from the JSON identity
-    assert {c.city_id for c in cities} == {'albany--new-york--united-states',
-                                           'solo--testland'}
+    assert {c.city_id for c in cities} == {"albany--new-york--united-states", "solo--testland"}
 
     # Alias resolves; canonical-slug file chosen as the baseline
-    albany = db.resolve_city(conn, 'albany--ny')
-    assert albany.city_id == 'albany--new-york--united-states'
+    albany = db.resolve_city(conn, "albany--ny")
+    assert albany.city_id == "albany--new-york--united-states"
     run = db.get_latest_run(conn, albany.city_id)
     assert run.is_baseline
-    assert run.csv_filename.startswith('albany--new-york--united-states_')
-    assert run.run_date == '2025-06-10'
+    assert run.csv_filename.startswith("albany--new-york--united-states_")
+    assert run.run_date == "2025-06-10"
     assert run.unique_panos == 2
 
     # Corrupt JSON was regenerated as strict-parseable
-    solo_run = db.get_latest_run(conn, 'solo--testland')
-    with gzip.open(os.path.join(data_dir, solo_run.json_filename), 'rt') as f:
+    solo_run = db.get_latest_run(conn, "solo--testland")
+    with gzip.open(os.path.join(data_dir, solo_run.json_filename), "rt") as f:
         json.load(f, parse_constant=lambda t: (_ for _ in ()).throw(ValueError(t)))
 
     # Idempotent: re-running registers nothing new
-    result = _run_migration(data_dir, '--execute')
+    result = _run_migration(data_dir, "--execute")
     assert result.returncode == 0, result.stderr
-    assert 'Registered 0 cities, 0 baseline runs' in result.stdout
+    assert "Registered 0 cities, 0 baseline runs" in result.stdout
     conn.close()

--- a/tests/test_naming.py
+++ b/tests/test_naming.py
@@ -5,8 +5,12 @@ from datetime import date
 import pytest
 
 from gsv_metadata_tracker.naming import (
-    generate_base_filename, generate_run_filename, parse_filename,
-    same_grid_geometry, sanitize_city_query_str)
+    generate_base_filename,
+    generate_run_filename,
+    parse_filename,
+    same_grid_geometry,
+    sanitize_city_query_str,
+)
 
 
 def test_parse_legacy_int_name():
@@ -27,7 +31,8 @@ def test_parse_buggy_float_step_name():
 
 def test_parse_dated_name():
     p = parse_filename(
-        "bend--oregon--united-states_width_5000_height_5000_step_20_2026-07-02.json.gz")
+        "bend--oregon--united-states_width_5000_height_5000_step_20_2026-07-02.json.gz"
+    )
     assert p.run_date == date(2026, 7, 2)
     assert p.slug == "bend--oregon--united-states"
     assert p.provider == "gsv"
@@ -58,8 +63,7 @@ def test_generate_base_filename_int_casts_step():
 
 
 def test_generate_run_filename_roundtrip():
-    name = generate_run_filename("bend--oregon--united-states", 5000, 5000, 20,
-                                 date(2026, 7, 2))
+    name = generate_run_filename("bend--oregon--united-states", 5000, 5000, 20, date(2026, 7, 2))
     p = parse_filename(name + ".csv.gz")
     assert p.slug == "bend--oregon--united-states"
     assert p.run_date == date(2026, 7, 2)
@@ -69,14 +73,15 @@ def test_generate_run_filename_roundtrip():
 def test_generate_run_filename_gsv_has_no_provider_token():
     # Explicit provider='gsv' must produce byte-identical names to the
     # pre-provider convention (published URLs depend on this).
-    assert generate_run_filename("bend--or", 5000, 5000, 20, date(2026, 7, 2),
-                                 provider="gsv") == \
-        generate_run_filename("bend--or", 5000, 5000, 20, date(2026, 7, 2))
+    assert generate_run_filename(
+        "bend--or", 5000, 5000, 20, date(2026, 7, 2), provider="gsv"
+    ) == generate_run_filename("bend--or", 5000, 5000, 20, date(2026, 7, 2))
 
 
 def test_parse_mapillary_dated_name():
     p = parse_filename(
-        "bend--oregon--united-states_width_5000_height_5000_step_20_mapillary_2026-07-05.csv.gz")
+        "bend--oregon--united-states_width_5000_height_5000_step_20_mapillary_2026-07-05.csv.gz"
+    )
     assert p.provider == "mapillary"
     assert p.run_date == date(2026, 7, 5)
     assert p.slug == "bend--oregon--united-states"
@@ -90,8 +95,9 @@ def test_parse_mapillary_with_float_step():
 
 
 def test_generate_mapillary_run_filename_roundtrip():
-    name = generate_run_filename("st.-louis--mo--usa", 1000, 1000, 20,
-                                 date(2026, 7, 5), provider="mapillary")
+    name = generate_run_filename(
+        "st.-louis--mo--usa", 1000, 1000, 20, date(2026, 7, 5), provider="mapillary"
+    )
     assert name == "st.-louis--mo--usa_width_1000_height_1000_step_20_mapillary_2026-07-05"
     p = parse_filename(name + ".csv.gz")
     assert p.provider == "mapillary"
@@ -106,8 +112,7 @@ def test_parse_rejects_unknown_provider_token():
 
 def test_generate_run_filename_rejects_unknown_provider():
     with pytest.raises(ValueError):
-        generate_run_filename("bend--or", 5000, 5000, 20, date(2026, 7, 5),
-                              provider="kartaview")
+        generate_run_filename("bend--or", 5000, 5000, 20, date(2026, 7, 5), provider="kartaview")
 
 
 def test_parse_archival_step_30_dated_name():
@@ -122,26 +127,33 @@ def test_parse_archival_step_30_dated_name():
 def test_same_grid_geometry_ignores_date_and_provider():
     assert same_grid_geometry(
         "seattle--wa_width_5000_height_5000_step_20_2026-07-02.csv.gz",
-        "seattle--wa_width_5000_height_5000_step_20_2026-04-01.csv.gz")
+        "seattle--wa_width_5000_height_5000_step_20_2026-04-01.csv.gz",
+    )
     assert same_grid_geometry(
         "seattle--wa_width_5000_height_5000_step_20_2026-07-02.csv.gz",
-        "seattle--wa_width_5000_height_5000_step_20_mapillary_2026-07-02.csv.gz")
+        "seattle--wa_width_5000_height_5000_step_20_mapillary_2026-07-02.csv.gz",
+    )
     # Legacy undated vs dated: geometry is all that matters
     assert same_grid_geometry(
         "seattle--wa_width_5000_height_5000_step_20.csv.gz",
-        "seattle--wa_width_5000_height_5000_step_20_2026-07-02.csv.gz")
+        "seattle--wa_width_5000_height_5000_step_20_2026-07-02.csv.gz",
+    )
 
 
 def test_same_grid_geometry_rejects_mismatches():
     modern = "seattle--wa_width_5000_height_5000_step_20_2026-07-02.csv.gz"
     assert not same_grid_geometry(
-        modern, "seattle--wa_width_1000_height_1000_step_30_2023-11-05.csv.gz")
+        modern, "seattle--wa_width_1000_height_1000_step_30_2023-11-05.csv.gz"
+    )
     assert not same_grid_geometry(
-        modern, "seattle--wa_width_5000_height_5000_step_30_2026-07-02.csv.gz")
+        modern, "seattle--wa_width_5000_height_5000_step_30_2026-07-02.csv.gz"
+    )
     assert not same_grid_geometry(
-        modern, "seattle--wa_width_4000_height_5000_step_20_2026-07-02.csv.gz")
+        modern, "seattle--wa_width_4000_height_5000_step_20_2026-07-02.csv.gz"
+    )
     assert not same_grid_geometry(
-        modern, "seattle--wa_width_5000_height_4000_step_20_2026-07-02.csv.gz")
+        modern, "seattle--wa_width_5000_height_4000_step_20_2026-07-02.csv.gz"
+    )
 
 
 def test_same_grid_geometry_unparseable_is_false():
@@ -156,5 +168,7 @@ def test_sanitize_city_query_str():
     assert sanitize_city_query_str("Grand Marais") == "grand-marais"
     assert sanitize_city_query_str("Port Angeles, WA") == "port-angeles--wa"
     # Nominatim sometimes returns non-breaking spaces in place names
-    assert sanitize_city_query_str("Ann\xa0Arbor Charter Township, Michigan") == \
-        "ann-arbor-charter-township--michigan"
+    assert (
+        sanitize_city_query_str("Ann\xa0Arbor Charter Township, Michigan")
+        == "ann-arbor-charter-township--michigan"
+    )

--- a/tests/test_reregister.py
+++ b/tests/test_reregister.py
@@ -13,40 +13,46 @@ import pytest
 
 PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 _spec = importlib.util.spec_from_file_location(
-    "reregister_boundaries",
-    os.path.join(PROJECT_ROOT, "scripts", "reregister_boundaries.py"))
+    "reregister_boundaries", os.path.join(PROJECT_ROOT, "scripts", "reregister_boundaries.py")
+)
 rr = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(rr)
 
 
-def row(verdict, *, osm_w=None, osm_h=None, sug_lat=None, sug_lon=None,
-        city_id="c", name="City"):
-    return {"city_id": city_id, "display_name": name, "verdict": verdict,
-            "osm_bbox_width_m": "" if osm_w is None else str(osm_w),
-            "osm_bbox_height_m": "" if osm_h is None else str(osm_h),
-            "suggested_center_lat": "" if sug_lat is None else str(sug_lat),
-            "suggested_center_lon": "" if sug_lon is None else str(sug_lon)}
+def row(verdict, *, osm_w=None, osm_h=None, sug_lat=None, sug_lon=None, city_id="c", name="City"):
+    return {
+        "city_id": city_id,
+        "display_name": name,
+        "verdict": verdict,
+        "osm_bbox_width_m": "" if osm_w is None else str(osm_w),
+        "osm_bbox_height_m": "" if osm_h is None else str(osm_h),
+        "suggested_center_lat": "" if sug_lat is None else str(sug_lat),
+        "suggested_center_lon": "" if sug_lon is None else str(sug_lon),
+    }
 
 
 def cur(lat, lon, w, h, step=20):
-    return rr.Current(center_lat=lat, center_lon=lon, width_m=w, height_m=h,
-                      step_m=step)
+    return rr.Current(center_lat=lat, center_lon=lon, width_m=w, height_m=h, step_m=step)
 
 
 def test_offset_city_recenters_without_shrinking():
     # Right size (~= OSM bbox) but off-center: recenter, size essentially kept.
-    d = rr.decide(row("UNDER", osm_w=2000, osm_h=1700, sug_lat=46.44, sug_lon=-96.73),
-                  cur(46.45, -96.72, 2000, 1700))
+    d = rr.decide(
+        row("UNDER", osm_w=2000, osm_h=1700, sug_lat=46.44, sug_lon=-96.73),
+        cur(46.45, -96.72, 2000, 1700),
+    )
     assert d.action == "RESIZE"
     assert (d.new_center_lat, d.new_center_lon) == (46.44, -96.73)
-    assert d.new_width_m == 2000 and d.new_height_m == 1700   # grow-only, unchanged
+    assert d.new_width_m == 2000 and d.new_height_m == 1700  # grow-only, unchanged
     assert d.coverage_after > 0.99 > d.coverage_before
 
 
 def test_degenerate_grid_grows_to_osm_bbox():
     # Gary-style 1-point grid grows to the (modest) OSM bbox.
-    d = rr.decide(row("UNDER", osm_w=17600, osm_h=14226, sug_lat=41.6, sug_lon=-87.34),
-                  cur(41.6, -87.34, 8, 11))
+    d = rr.decide(
+        row("UNDER", osm_w=17600, osm_h=14226, sug_lat=41.6, sug_lon=-87.34),
+        cur(41.6, -87.34, 8, 11),
+    )
     assert d.action == "RESIZE"
     assert d.new_width_m == 17600 and d.new_height_m == 14226
     assert d.new_points > d.old_points
@@ -55,16 +61,21 @@ def test_degenerate_grid_grows_to_osm_bbox():
 
 def test_huge_osm_bbox_deferred_to_manual_review():
     # Đà Nẵng-style: OSM administrative bbox far exceeds the review threshold.
-    d = rr.decide(row("UNDER", osm_w=194000, osm_h=153000, sug_lat=16.06, sug_lon=108.2),
-                  cur(16.06, 108.21, 20000, 20000))
+    d = rr.decide(
+        row("UNDER", osm_w=194000, osm_h=153000, sug_lat=16.06, sug_lon=108.2),
+        cur(16.06, 108.21, 20000, 20000),
+    )
     assert d.action == "DEFER"
     assert "threshold" in d.reason
-    assert d.new_width_m is None                 # geometry untouched
+    assert d.new_width_m is None  # geometry untouched
 
 
 def test_threshold_boundary_exactly_at_cap_is_resized():
-    d = rr.decide(row("UNDER", osm_w=30000, osm_h=30000, sug_lat=1.0, sug_lon=2.0),
-                  cur(1.0, 2.0, 5000, 5000), threshold_m=30000)
+    d = rr.decide(
+        row("UNDER", osm_w=30000, osm_h=30000, sug_lat=1.0, sug_lon=2.0),
+        cur(1.0, 2.0, 5000, 5000),
+        threshold_m=30000,
+    )
     assert d.action == "RESIZE"
 
 
@@ -90,33 +101,51 @@ def test_idempotent_after_applying_target():
     r = row("UNDER", osm_w=17600, osm_h=14226, sug_lat=41.6, sug_lon=-87.34)
     first = rr.decide(r, cur(41.6, -87.34, 8, 11))
     # Feed back the post-execute geometry: same center, grown dimensions.
-    applied = cur(first.new_center_lat, first.new_center_lon,
-                  first.new_width_m, first.new_height_m)
+    applied = cur(first.new_center_lat, first.new_center_lon, first.new_width_m, first.new_height_m)
     assert rr.decide(r, applied).action == "NOCHANGE"
 
 
 def test_unknown_city_skipped():
-    assert rr.decide(row("UNDER", osm_w=5000, osm_h=5000, sug_lat=1, sug_lon=2),
-                     None).action == "SKIP"
+    assert (
+        rr.decide(row("UNDER", osm_w=5000, osm_h=5000, sug_lat=1, sug_lon=2), None).action == "SKIP"
+    )
 
 
 # --- recommendations attached to deferred (manual-review) cities ---------------
+
 
 def _row_full(verdict, **kw):
     """Report row including the extra columns recommend() reads."""
     base = {"over_area_ratio": "", "osm_polygon_area_km2": "", "center_dist_km": ""}
     base.update(kw)
-    return {**row(verdict, osm_w=kw.get("osm_w"), osm_h=kw.get("osm_h"),
-                  sug_lat=kw.get("sug_lat"), sug_lon=kw.get("sug_lon")),
-            **{k: str(v) for k, v in base.items() if k in
-               ("over_area_ratio", "osm_polygon_area_km2", "center_dist_km")}}
+    return {
+        **row(
+            verdict,
+            osm_w=kw.get("osm_w"),
+            osm_h=kw.get("osm_h"),
+            sug_lat=kw.get("sug_lat"),
+            sug_lon=kw.get("sug_lon"),
+        ),
+        **{
+            k: str(v)
+            for k, v in base.items()
+            if k in ("over_area_ratio", "osm_polygon_area_km2", "center_dist_km")
+        },
+    }
 
 
 def test_giant_offset_recommends_recenter_only():
     # OSM bbox huge but the grid already matches it (over_area_ratio ~1): the
     # recommendation is a recenter, keeping the current (large) size.
-    r = _row_full("UNDER", osm_w=106000, osm_h=84000, sug_lat=61.2, sug_lon=-149.9,
-                  over_area_ratio=1.0, center_dist_km=0.1)
+    r = _row_full(
+        "UNDER",
+        osm_w=106000,
+        osm_h=84000,
+        sug_lat=61.2,
+        sug_lon=-149.9,
+        over_area_ratio=1.0,
+        center_dist_km=0.1,
+    )
     d = rr.decide(r, cur(61.15, -149.8, 106000, 84000))
     assert d.action == "DEFER"
     assert d.rec_width_m == 106000 and d.rec_height_m == 84000
@@ -127,8 +156,16 @@ def test_giant_offset_recommends_recenter_only():
 def test_undersized_giant_recommends_full_bbox_capped_at_ceiling():
     # Đà Nẵng's 194x153 km municipality: grow toward full bbox but clamp at the
     # 80 km practical ceiling (bias bigger, but not absurd).
-    r = _row_full("UNDER", osm_w=194000, osm_h=153000, sug_lat=16.06, sug_lon=108.2,
-                  over_area_ratio=0.01, center_dist_km=1.6, osm_polygon_area_km2=15962)
+    r = _row_full(
+        "UNDER",
+        osm_w=194000,
+        osm_h=153000,
+        sug_lat=16.06,
+        sug_lon=108.2,
+        over_area_ratio=0.01,
+        center_dist_km=1.6,
+        osm_polygon_area_km2=15962,
+    )
     d = rr.decide(r, cur(16.06, 108.21, 20000, 20000))
     assert d.action == "DEFER"
     assert d.rec_width_m == rr.REC_CEILING_M and d.rec_height_m == rr.REC_CEILING_M
@@ -137,8 +174,15 @@ def test_undersized_giant_recommends_full_bbox_capped_at_ceiling():
 
 def test_undersized_giant_under_ceiling_recommends_full_bbox():
     # São Paulo 47x72 km is under the ceiling: recommend the full bbox, uncapped.
-    r = _row_full("UNDER", osm_w=47000, osm_h=72000, sug_lat=-23.6, sug_lon=-46.6,
-                  over_area_ratio=0.06, center_dist_km=0.0)
+    r = _row_full(
+        "UNDER",
+        osm_w=47000,
+        osm_h=72000,
+        sug_lat=-23.6,
+        sug_lon=-46.6,
+        over_area_ratio=0.06,
+        center_dist_km=0.0,
+    )
     d = rr.decide(r, cur(-23.6, -46.6, 15000, 15000))
     assert d.rec_width_m == 47000 and d.rec_height_m == 72000
     assert "capped" not in d.rec_basis
@@ -149,11 +193,13 @@ def test_over_recommends_keeping_big_not_shrinking():
     r = _row_full("OVER", osm_w=800, osm_h=500, sug_lat=33.9, sug_lon=35.5)
     d = rr.decide(r, cur(33.9, 35.5, 20000, 20000))
     assert d.action == "DEFER"
-    assert d.rec_width_m == 20000 and d.rec_height_m == 20000   # unchanged, not shrunk
+    assert d.rec_width_m == 20000 and d.rec_height_m == 20000  # unchanged, not shrunk
     assert "do not shrink" in d.rec_basis
 
 
 def test_wrong_place_recommendation_says_verify():
-    d = rr.decide(_row_full("WRONG_PLACE", osm_w=2000, osm_h=2000,
-                            sug_lat=33.1, sug_lon=-93.6), cur(40.0, -80.0, 39000, 60000))
+    d = rr.decide(
+        _row_full("WRONG_PLACE", osm_w=2000, osm_h=2000, sug_lat=33.1, sug_lon=-93.6),
+        cur(40.0, -80.0, 39000, 60000),
+    )
     assert d.action == "DEFER" and "verify geocode" in d.rec_basis

--- a/tests/test_run_guard.py
+++ b/tests/test_run_guard.py
@@ -11,7 +11,6 @@ every provider's rows to Google copyright.
 from datetime import date
 
 import pandas as pd
-import pytest
 
 from gsv_metadata_tracker.analysis import (
     GOOGLE_COPYRIGHT,
@@ -22,40 +21,39 @@ from gsv_metadata_tracker.analysis import (
 
 
 def _status_df(statuses):
-    return pd.DataFrame({'status': statuses})
+    return pd.DataFrame({"status": statuses})
 
 
 class TestDetectSystemicFailure:
-
     def test_all_request_denied_is_rejected(self):
-        reason = detect_systemic_failure(_status_df(['REQUEST_DENIED'] * 500))
+        reason = detect_systemic_failure(_status_df(["REQUEST_DENIED"] * 500))
         assert reason is not None
-        assert 'REQUEST_DENIED=500' in reason
+        assert "REQUEST_DENIED=500" in reason
 
     def test_all_over_query_limit_is_rejected(self):
-        reason = detect_systemic_failure(_status_df(['OVER_QUERY_LIMIT'] * 100))
+        reason = detect_systemic_failure(_status_df(["OVER_QUERY_LIMIT"] * 100))
         assert reason is not None
-        assert 'OVER_QUERY_LIMIT=100' in reason
+        assert "OVER_QUERY_LIMIT=100" in reason
 
     def test_mixed_denials_are_summed(self):
-        statuses = ['REQUEST_DENIED'] * 60 + ['OVER_QUERY_LIMIT'] * 39 + ['OK']
+        statuses = ["REQUEST_DENIED"] * 60 + ["OVER_QUERY_LIMIT"] * 39 + ["OK"]
         reason = detect_systemic_failure(_status_df(statuses))
         assert reason is not None
 
     def test_healthy_run_passes(self):
-        statuses = ['OK'] * 60 + ['ZERO_RESULTS'] * 39 + ['REQUEST_DENIED']
+        statuses = ["OK"] * 60 + ["ZERO_RESULTS"] * 39 + ["REQUEST_DENIED"]
         assert detect_systemic_failure(_status_df(statuses)) is None
 
     def test_all_zero_results_is_valid(self):
         # "No imagery anywhere" is a real answer (remote areas), not a failure
-        assert detect_systemic_failure(_status_df(['ZERO_RESULTS'] * 1000)) is None
+        assert detect_systemic_failure(_status_df(["ZERO_RESULTS"] * 1000)) is None
 
     def test_below_threshold_passes(self):
-        statuses = ['REQUEST_DENIED'] * 94 + ['OK'] * 6
+        statuses = ["REQUEST_DENIED"] * 94 + ["OK"] * 6
         assert detect_systemic_failure(_status_df(statuses)) is None
 
     def test_at_threshold_is_rejected(self):
-        statuses = ['REQUEST_DENIED'] * 95 + ['OK'] * 5
+        statuses = ["REQUEST_DENIED"] * 95 + ["OK"] * 5
         assert detect_systemic_failure(_status_df(statuses)) is not None
 
     def test_empty_df_passes(self):
@@ -63,7 +61,7 @@ class TestDetectSystemicFailure:
 
     def test_transient_errors_do_not_reject(self):
         # Per-point errors (timeouts etc.) are not credential failures
-        assert detect_systemic_failure(_status_df(['ERROR'] * 100)) is None
+        assert detect_systemic_failure(_status_df(["ERROR"] * 100)) is None
 
 
 class TestIsGoogleCopyright:
@@ -75,56 +73,64 @@ class TestIsGoogleCopyright:
     """
 
     def test_exact_match_only(self):
-        s = pd.Series([
-            '© Google',                               # official
-            '© MIB 360 - Google Virtual Tours Agency',  # third party (real)
-            '© Google Loser',                         # third party (real)
-            '© google',                               # not the official form
-            '© Jane Photographer',
-            None,                                     # archival: never recorded
-        ])
+        s = pd.Series(
+            [
+                "© Google",  # official
+                "© MIB 360 - Google Virtual Tours Agency",  # third party (real)
+                "© Google Loser",  # third party (real)
+                "© google",  # not the official form
+                "© Jane Photographer",
+                None,  # archival: never recorded
+            ]
+        )
         assert list(is_google_copyright(s)) == [True, False, False, False, False, False]
 
     def test_constant_matches_api_form(self):
-        assert GOOGLE_COPYRIGHT == '© Google'
+        assert GOOGLE_COPYRIGHT == "© Google"
 
     def test_run_stats_use_exact_match(self):
-        df = pd.DataFrame({
-            'status': ['OK'] * 3,
-            'pano_id': ['a', 'b', 'c'],
-            'capture_date': ['2024-01-01'] * 3,
-            'query_lat': [44.5] * 3,
-            'query_lon': [-123.2] * 3,
-            'pano_lat': [44.5] * 3,
-            'pano_lon': [-123.2] * 3,
-            'copyright_info': ['© Google',
-                               '© MIB 360 - Google Virtual Tours Agency',
-                               '© Google Loser'],
-        })
-        stats = calculate_run_stats(df, date(2026, 7, 6), provider='gsv')
-        assert stats['unique_panos'] == 3
-        assert stats['unique_google_panos'] == 1
+        df = pd.DataFrame(
+            {
+                "status": ["OK"] * 3,
+                "pano_id": ["a", "b", "c"],
+                "capture_date": ["2024-01-01"] * 3,
+                "query_lat": [44.5] * 3,
+                "query_lon": [-123.2] * 3,
+                "pano_lat": [44.5] * 3,
+                "pano_lon": [-123.2] * 3,
+                "copyright_info": [
+                    "© Google",
+                    "© MIB 360 - Google Virtual Tours Agency",
+                    "© Google Loser",
+                ],
+            }
+        )
+        stats = calculate_run_stats(df, date(2026, 7, 6), provider="gsv")
+        assert stats["unique_panos"] == 3
+        assert stats["unique_google_panos"] == 1
 
 
 def _pano_df(copyright_info):
-    return pd.DataFrame({
-        'query_lat': [44.56, 44.57, 44.58],
-        'query_lon': [-123.26, -123.27, -123.28],
-        'query_timestamp': ['2026-07-06T00:00:00+00:00'] * 3,
-        'pano_lat': [44.56, 44.57, 44.58],
-        'pano_lon': [-123.26, -123.27, -123.28],
-        'pano_id': ['a', 'b', 'c'],
-        'capture_date': ['2021-03-26', '2022-05-01', '2023-08-15'],
-        'copyright_info': [copyright_info] * 3,
-        'status': ['OK'] * 3,
-    })
+    return pd.DataFrame(
+        {
+            "query_lat": [44.56, 44.57, 44.58],
+            "query_lon": [-123.26, -123.27, -123.28],
+            "query_timestamp": ["2026-07-06T00:00:00+00:00"] * 3,
+            "pano_lat": [44.56, 44.57, 44.58],
+            "pano_lon": [-123.26, -123.27, -123.28],
+            "pano_id": ["a", "b", "c"],
+            "capture_date": ["2021-03-26", "2022-05-01", "2023-08-15"],
+            "copyright_info": [copyright_info] * 3,
+            "status": ["OK"] * 3,
+        }
+    )
 
 
 class TestVisualizationProviderFilter:
-
     def _marker_count(self, folium_map):
         """Count CircleMarkers anywhere in the map's child tree."""
         import folium
+
         count = 0
         stack = list(folium_map._children.values())
         while stack:
@@ -136,32 +142,37 @@ class TestVisualizationProviderFilter:
 
     def test_mapillary_rows_are_kept_for_mapillary_provider(self):
         from gsv_metadata_tracker.vis import create_visualization_map
-        df = _pano_df('© Mapillary contributor 12345')
-        m = create_visualization_map(df, 'Testville', provider='mapillary')
+
+        df = _pano_df("© Mapillary contributor 12345")
+        m = create_visualization_map(df, "Testville", provider="mapillary")
         assert self._marker_count(m) == 3
 
     def test_non_google_rows_are_dropped_for_gsv_provider(self):
         from gsv_metadata_tracker.vis import create_visualization_map
-        df = _pano_df('© Some Third Party')
-        m = create_visualization_map(df, 'Testville', provider='gsv')
+
+        df = _pano_df("© Some Third Party")
+        m = create_visualization_map(df, "Testville", provider="gsv")
         assert self._marker_count(m) == 0
 
     def test_google_named_photographer_dropped_for_gsv_provider(self):
         from gsv_metadata_tracker.vis import create_visualization_map
-        df = _pano_df('© MIB 360 - Google Virtual Tours Agency')
-        m = create_visualization_map(df, 'Testville', provider='gsv')
+
+        df = _pano_df("© MIB 360 - Google Virtual Tours Agency")
+        m = create_visualization_map(df, "Testville", provider="gsv")
         assert self._marker_count(m) == 0
 
     def test_google_rows_are_kept_for_gsv_provider(self):
         from gsv_metadata_tracker.vis import create_visualization_map
-        df = _pano_df('© Google')
-        m = create_visualization_map(df, 'Testville', provider='gsv')
+
+        df = _pano_df("© Google")
+        m = create_visualization_map(df, "Testville", provider="gsv")
         assert self._marker_count(m) == 3
 
     def test_mapillary_viewer_links_in_popups(self):
         from gsv_metadata_tracker.vis import create_visualization_map
-        df = _pano_df('© Mapillary contributor 12345')
-        m = create_visualization_map(df, 'Testville', provider='mapillary')
+
+        df = _pano_df("© Mapillary contributor 12345")
+        m = create_visualization_map(df, "Testville", provider="mapillary")
         html = m.get_root().render()
-        assert 'mapillary.com/app/?pKey=' in html
-        assert 'View in Mapillary' in html
+        assert "mapillary.com/app/?pKey=" in html
+        assert "View in Mapillary" in html

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,30 +1,37 @@
 """Scheduler logic tests — pure logic only, no network or subprocesses."""
 
-from datetime import date
+from datetime import UTC, date
 
 from gsv_metadata_tracker import db
-from gsv_metadata_tracker.scheduler import (
-    SchedulerConfig, estimate_requests, load_scheduler_config)
+from gsv_metadata_tracker.scheduler import SchedulerConfig, estimate_requests, load_scheduler_config
 
 
 def _register(conn, name, width=5000, height=5000, step=20):
     return db.register_city(
-        conn, city_name=name, state_name='Oregon', state_code='OR',
-        country_name='United States', country_code='US',
-        center_lat=44.0, center_lon=-121.0,
-        grid_width_m=width, grid_height_m=height, step_m=step)
+        conn,
+        city_name=name,
+        state_name="Oregon",
+        state_code="OR",
+        country_name="United States",
+        country_code="US",
+        center_lat=44.0,
+        center_lon=-121.0,
+        grid_width_m=width,
+        grid_height_m=height,
+        step_m=step,
+    )
 
 
 def test_estimate_requests_matches_grid_math(conn):
-    cid = _register(conn, 'Bend', width=1000, height=1000, step=20)
+    cid = _register(conn, "Bend", width=1000, height=1000, step=20)
     city = db.resolve_city(conn, cid)
     assert estimate_requests(city) == 51 * 51  # (1000//20 + 1)^2
 
 
 def test_estimate_requests_mapillary_counts_tiles(conn):
-    cid = _register(conn, 'Bend', width=5000, height=5000, step=20)
+    cid = _register(conn, "Bend", width=5000, height=5000, step=20)
     city = db.resolve_city(conn, cid)
-    tiles = estimate_requests(city, provider='mapillary')
+    tiles = estimate_requests(city, provider="mapillary")
     # A 5km grid is a handful of z14 tiles — three orders of magnitude
     # cheaper than GSV's per-point requests
     assert 4 <= tiles <= 25
@@ -36,8 +43,8 @@ def test_config_defaults_when_file_missing(tmp_path):
     assert cfg.cycle_days == 90 and cfg.batch_size == 100
     assert cfg.db_path.endswith("gsv_tracker.db")
     # No [providers] config → gsv-only with the legacy budget
-    assert cfg.enabled_providers() == ['gsv']
-    assert cfg.providers['gsv'].daily_request_budget == 10_000_000
+    assert cfg.enabled_providers() == ["gsv"]
+    assert cfg.providers["gsv"].daily_request_budget == 10_000_000
 
 
 def test_config_parses_toml(tmp_path):
@@ -57,8 +64,8 @@ enabled = true
     assert cfg.batch_size == 7
     assert cfg.publish_enabled
     # v1-style toml (no [providers]): gsv-only, legacy budget honored
-    assert cfg.enabled_providers() == ['gsv']
-    assert cfg.providers['gsv'].daily_request_budget == 1000
+    assert cfg.enabled_providers() == ["gsv"]
+    assert cfg.providers["gsv"].daily_request_budget == 1000
 
 
 def test_config_parses_provider_sections(tmp_path):
@@ -75,10 +82,10 @@ daily_request_budget = 5000
 daily_request_budget = 1
 """)
     cfg = load_scheduler_config(str(p))
-    assert cfg.enabled_providers() == ['gsv', 'mapillary']  # gsv always first
-    assert cfg.providers['gsv'].daily_request_budget == 99_000
-    assert cfg.providers['mapillary'].daily_request_budget == 5000
-    assert 'bogus' not in cfg.providers  # unknown providers are ignored
+    assert cfg.enabled_providers() == ["gsv", "mapillary"]  # gsv always first
+    assert cfg.providers["gsv"].daily_request_budget == 99_000
+    assert cfg.providers["mapillary"].daily_request_budget == 5000
+    assert "bogus" not in cfg.providers  # unknown providers are ignored
 
 
 def test_config_provider_can_be_disabled(tmp_path):
@@ -90,47 +97,54 @@ daily_request_budget = 99000
 enabled = false
 """)
     cfg = load_scheduler_config(str(p))
-    assert cfg.enabled_providers() == ['gsv']
+    assert cfg.enabled_providers() == ["gsv"]
 
 
 def test_due_cities_stalest_first(conn):
-    a = _register(conn, 'Alpha')
-    b = _register(conn, 'Beta')
-    c = _register(conn, 'Gamma')
+    a = _register(conn, "Alpha")
+    b = _register(conn, "Beta")
+    c = _register(conn, "Gamma")
     db.assign_schedule(conn, 90)
 
     # Beta succeeded long ago; Gamma succeeded recently; Alpha never ran
-    conn.execute("UPDATE schedule_state SET last_success_at = '2025-01-01T00:00:00+00:00' "
-                 "WHERE city_id = ?", (b,))
-    conn.execute("UPDATE schedule_state SET last_success_at = '2026-06-30T00:00:00+00:00' "
-                 "WHERE city_id = ?", (c,))
+    conn.execute(
+        "UPDATE schedule_state SET last_success_at = '2025-01-01T00:00:00+00:00' WHERE city_id = ?",
+        (b,),
+    )
+    conn.execute(
+        "UPDATE schedule_state SET last_success_at = '2026-06-30T00:00:00+00:00' WHERE city_id = ?",
+        (c,),
+    )
     conn.commit()
 
-    due = db.get_due_cities(conn, today=date(2026, 7, 2), cycle_days=90,
-                            grace_days=7, max_consecutive_failures=5)
+    due = db.get_due_cities(
+        conn, today=date(2026, 7, 2), cycle_days=90, grace_days=7, max_consecutive_failures=5
+    )
     ids = [x.city_id for x in due]
-    assert ids[0] == a          # never-run first (NULL last_success)
-    assert ids[1] == b          # then stalest
-    assert c not in ids         # fresh city not due
+    assert ids[0] == a  # never-run first (NULL last_success)
+    assert ids[1] == b  # then stalest
+    assert c not in ids  # fresh city not due
 
 
 def test_disabled_city_never_due(conn):
-    cid = _register(conn, 'Alpha')
+    cid = _register(conn, "Alpha")
     db.assign_schedule(conn, 90)
     conn.execute("UPDATE cities SET enabled = 0 WHERE city_id = ?", (cid,))
     conn.commit()
-    due = db.get_due_cities(conn, today=date(2026, 7, 2), cycle_days=90,
-                            grace_days=7, max_consecutive_failures=5)
+    due = db.get_due_cities(
+        conn, today=date(2026, 7, 2), cycle_days=90, grace_days=7, max_consecutive_failures=5
+    )
     assert due == []
 
 
 def test_failure_cap_excludes_city(conn):
-    cid = _register(conn, 'Alpha')
+    cid = _register(conn, "Alpha")
     db.assign_schedule(conn, 90)
     for _ in range(5):
-        db.record_attempt(conn, cid, success=False, error='x')
-    due = db.get_due_cities(conn, today=date(2026, 7, 2), cycle_days=90,
-                            grace_days=7, max_consecutive_failures=5)
+        db.record_attempt(conn, cid, success=False, error="x")
+    due = db.get_due_cities(
+        conn, today=date(2026, 7, 2), cycle_days=90, grace_days=7, max_consecutive_failures=5
+    )
     assert due == []
 
 
@@ -147,8 +161,8 @@ def test_oversized_city_does_not_starve_queue(conn, monkeypatch):
     stalest-first ordering would otherwise block collection forever."""
     from gsv_metadata_tracker import scheduler as sched
 
-    huge = _register(conn, 'Huge', width=200_000, height=200_000, step=20)
-    small = _register(conn, 'Small', width=1000, height=1000, step=20)
+    huge = _register(conn, "Huge", width=200_000, height=200_000, step=20)
+    small = _register(conn, "Small", width=1000, height=1000, step=20)
     db.assign_schedule(conn, 90)
     # Make Huge the stalest (never run) — both are due
     conn.execute("UPDATE schedule_state SET last_success_at = NULL")
@@ -156,17 +170,19 @@ def test_oversized_city_does_not_starve_queue(conn, monkeypatch):
 
     ran = []
     monkeypatch.setattr(
-        sched, '_run_one_city',
-        lambda cfg, city, today, provider='gsv': ran.append(city.city_id) or True)
-    monkeypatch.setattr(sched.db, 'connect', lambda path: conn)
-    monkeypatch.setattr(sched.time, 'sleep', lambda s: None)
-    monkeypatch.setattr(sched, 'generate_aggregate_v2', lambda c, d: None)
+        sched,
+        "_run_one_city",
+        lambda cfg, city, today, provider="gsv": ran.append(city.city_id) or True,
+    )
+    monkeypatch.setattr(sched.db, "connect", lambda path: conn)
+    monkeypatch.setattr(sched.time, "sleep", lambda s: None)
+    monkeypatch.setattr(sched, "generate_aggregate_v2", lambda c, d: None)
 
     cfg = SchedulerConfig(daily_request_budget=10_000, publish_enabled=False)
     rc = sched.cmd_run_due(cfg)
 
-    assert huge not in ran      # skipped: never fits any budget
-    assert small in ran         # not starved by the huge city ahead of it
+    assert huge not in ran  # skipped: never fits any budget
+    assert small in ran  # not starved by the huge city ahead of it
     assert rc == 0
 
 
@@ -176,60 +192,76 @@ def test_run_due_pairs_providers_per_city(conn, monkeypatch):
     from gsv_metadata_tracker import scheduler as sched
     from gsv_metadata_tracker.scheduler import ProviderConfig
 
-    cid = _register(conn, 'Bend', width=1000, height=1000, step=20)
+    cid = _register(conn, "Bend", width=1000, height=1000, step=20)
 
     ran = []
     monkeypatch.setattr(
-        sched, '_run_one_city',
-        lambda cfg, city, today, provider='gsv':
-            ran.append((city.city_id, provider)) or (provider == 'gsv'))
-    monkeypatch.setattr(sched.db, 'connect', lambda path: conn)
-    monkeypatch.setattr(sched.time, 'sleep', lambda s: None)
-    monkeypatch.setattr(sched, 'generate_aggregate_v2', lambda c, d: None)
+        sched,
+        "_run_one_city",
+        lambda cfg, city, today, provider="gsv": (
+            ran.append((city.city_id, provider)) or (provider == "gsv")
+        ),
+    )
+    monkeypatch.setattr(sched.db, "connect", lambda path: conn)
+    monkeypatch.setattr(sched.time, "sleep", lambda s: None)
+    monkeypatch.setattr(sched, "generate_aggregate_v2", lambda c, d: None)
 
-    cfg = SchedulerConfig(publish_enabled=False, providers={
-        'gsv': ProviderConfig(daily_request_budget=10_000),
-        'mapillary': ProviderConfig(daily_request_budget=1_000),
-    })
+    cfg = SchedulerConfig(
+        publish_enabled=False,
+        providers={
+            "gsv": ProviderConfig(daily_request_budget=10_000),
+            "mapillary": ProviderConfig(daily_request_budget=1_000),
+        },
+    )
     rc = sched.cmd_run_due(cfg)
 
-    assert ran == [(cid, 'gsv'), (cid, 'mapillary')]  # paired, gsv first
+    assert ran == [(cid, "gsv"), (cid, "mapillary")]  # paired, gsv first
     assert rc == 1  # the (simulated) mapillary failure surfaces in the exit code
 
     # Success/failure recorded independently per provider
-    rows = {r['provider']: r for r in conn.execute(
-        "SELECT provider, last_success_at, consecutive_failures "
-        "FROM schedule_state WHERE city_id = ?", (cid,))}
-    assert rows['gsv']['last_success_at'] is not None
-    assert rows['gsv']['consecutive_failures'] == 0
-    assert rows['mapillary']['last_success_at'] is None
-    assert rows['mapillary']['consecutive_failures'] == 1
+    rows = {
+        r["provider"]: r
+        for r in conn.execute(
+            "SELECT provider, last_success_at, consecutive_failures "
+            "FROM schedule_state WHERE city_id = ?",
+            (cid,),
+        )
+    }
+    assert rows["gsv"]["last_success_at"] is not None
+    assert rows["gsv"]["consecutive_failures"] == 0
+    assert rows["mapillary"]["last_success_at"] is None
+    assert rows["mapillary"]["consecutive_failures"] == 1
 
 
 def test_run_due_provider_budgets_are_independent(conn, monkeypatch):
     """Exhausting one provider's budget must not block the other."""
+    from datetime import datetime
+
     from gsv_metadata_tracker import scheduler as sched
     from gsv_metadata_tracker.scheduler import ProviderConfig
-    from datetime import datetime, timezone
 
-    cid = _register(conn, 'Bend', width=1000, height=1000, step=20)
-    today = datetime.now(timezone.utc).date()
+    cid = _register(conn, "Bend", width=1000, height=1000, step=20)
+    today = datetime.now(UTC).date()
     # gsv's ledger is already full for today; mapillary's is untouched
-    db.add_api_usage(conn, today, 10_000, provider='gsv')
+    db.add_api_usage(conn, today, 10_000, provider="gsv")
 
     ran = []
     monkeypatch.setattr(
-        sched, '_run_one_city',
-        lambda cfg, city, today, provider='gsv':
-            ran.append((city.city_id, provider)) or True)
-    monkeypatch.setattr(sched.db, 'connect', lambda path: conn)
-    monkeypatch.setattr(sched.time, 'sleep', lambda s: None)
-    monkeypatch.setattr(sched, 'generate_aggregate_v2', lambda c, d: None)
+        sched,
+        "_run_one_city",
+        lambda cfg, city, today, provider="gsv": ran.append((city.city_id, provider)) or True,
+    )
+    monkeypatch.setattr(sched.db, "connect", lambda path: conn)
+    monkeypatch.setattr(sched.time, "sleep", lambda s: None)
+    monkeypatch.setattr(sched, "generate_aggregate_v2", lambda c, d: None)
 
-    cfg = SchedulerConfig(publish_enabled=False, providers={
-        'gsv': ProviderConfig(daily_request_budget=10_000),
-        'mapillary': ProviderConfig(daily_request_budget=1_000),
-    })
+    cfg = SchedulerConfig(
+        publish_enabled=False,
+        providers={
+            "gsv": ProviderConfig(daily_request_budget=10_000),
+            "mapillary": ProviderConfig(daily_request_budget=1_000),
+        },
+    )
     sched.cmd_run_due(cfg)
 
-    assert ran == [(cid, 'mapillary')]  # gsv deferred, mapillary still ran
+    assert ran == [(cid, "mapillary")]  # gsv deferred, mapillary still ran

--- a/tests/test_vis.py
+++ b/tests/test_vis.py
@@ -16,21 +16,21 @@ from gsv_metadata_tracker.config import METADATA_DTYPES
 def _row(pano_id, lat, lon):
     """One valid, official-Google GSV metadata row (config.METADATA_DTYPES)."""
     return {
-        'query_lat': lat,
-        'query_lon': lon,
-        'query_timestamp': '2026-07-01T00:00:00+00:00',
-        'pano_lat': lat,
-        'pano_lon': lon,
-        'pano_id': pano_id,
-        'capture_date': '2024-08-01',
-        'copyright_info': '© Google',
-        'status': 'OK',
+        "query_lat": lat,
+        "query_lon": lon,
+        "query_timestamp": "2026-07-01T00:00:00+00:00",
+        "pano_lat": lat,
+        "pano_lon": lon,
+        "pano_id": pano_id,
+        "capture_date": "2024-08-01",
+        "copyright_info": "© Google",
+        "status": "OK",
     }
 
 
 def _frame(rows):
     df = pd.DataFrame(rows, columns=list(METADATA_DTYPES.keys()))
-    return df.astype({'pano_id': 'string', 'copyright_info': 'string'})
+    return df.astype({"pano_id": "string", "copyright_info": "string"})
 
 
 def test_single_pano_city_does_not_crash():
@@ -39,23 +39,20 @@ def test_single_pano_city_does_not_crash():
     coverage-density division would raise ZeroDivisionError without the guard
     (issue #69 — e.g. Eastsound, WA / Kodiak, AK). It must return a map instead.
     """
-    result = vis.create_visualization_map(_frame([_row('p1', 47.62, -122.35)]),
-                                           'Eastsound, WA')
+    result = vis.create_visualization_map(_frame([_row("p1", 47.62, -122.35)]), "Eastsound, WA")
     assert isinstance(result, folium.Map)
 
 
 def test_no_valid_panos_returns_empty_map():
     """Zero valid rows is already guarded and returns an empty map, not a crash."""
-    row = _row('p1', 47.62, -122.35)
-    row['status'] = 'ZERO_RESULTS'  # filtered out -> no valid rows
-    result = vis.create_visualization_map(_frame([row]), 'Nowhere, WA')
+    row = _row("p1", 47.62, -122.35)
+    row["status"] = "ZERO_RESULTS"  # filtered out -> no valid rows
+    result = vis.create_visualization_map(_frame([row]), "Nowhere, WA")
     assert isinstance(result, folium.Map)
 
 
 def test_multi_pano_city_still_builds():
     """A normal multi-pano city (non-zero area) is unaffected by the guard."""
-    rows = [_row('p1', 47.60, -122.33),
-            _row('p2', 47.62, -122.35),
-            _row('p3', 47.64, -122.31)]
-    result = vis.create_visualization_map(_frame(rows), 'Seattle, WA')
+    rows = [_row("p1", 47.60, -122.33), _row("p2", 47.62, -122.35), _row("p3", 47.64, -122.31)]
+    result = vis.create_visualization_map(_frame(rows), "Seattle, WA")
     assert isinstance(result, folium.Map)


### PR DESCRIPTION
The project's first **CI + linting** setup. Establishes a green baseline so future PRs stay clean.

## What's added
- **`.github/workflows/ci.yml`** — on push/PR to `main`:
  - **lint** job: `ruff check` + `ruff format --check`
  - **test** matrix: `pytest` on Python **3.11 / 3.12 / 3.13**
  - pip-cached, `concurrency` cancels superseded runs, least-privilege `permissions`.
- **`pyproject.toml`** — Ruff config (`E,F,W,I,B,C4,UP`, `line-length = 100`) + pytest config. `E501` is left to the formatter and `C408` is ignored (the codebase uses `dict(key=…)` deliberately); both documented inline. Package stays script-run — no build system.
- **`requirements-dev.txt`** — pins `ruff==0.15.21` (local == CI) on top of `requirements.txt`.

## Codebase changes
`ruff format` + safe autofixes (import sort/prune, PEP 604/585 annotation modernization) — **this is ~90% of the diff and is purely mechanical.**

The **only behavior-relevant, hand-made fixes** (what to actually review):
| Rule | Fix | Files |
|---|---|---|
| B904 | chain re-raises with `from e` | download_async, fileutils |
| B905 | explicit `strict=False` on `zip()` (preserves behavior) | boundary_audit, download_async, download_mapillary, test_mapillary |
| B007 | `_`-prefix unused loop vars | us_census_city_analyzer, download_async, migrate_to_db |
| F841 | drop unused assignments | vis, db, run_cities, test_json_v2 |
| B008 | module-level singleton default for `Thresholds` | boundary_audit |
| E402 | `# noqa` the intentional post-importlib import | test_build_boundary_review |
| — | `json_summarizer` now imports `parse_filename` from `naming` (its definition site) instead of the `fileutils` facade | json_summarizer |

## Review tip
The reformat dominates the line count. To see only semantic changes:
```
git show 763cd0d --ignore-all-space
```

## Verification
`ruff check` ✅ · `ruff format --check` ✅ · **219 tests pass** on the dev interpreter · all 16 package modules import cleanly.

## Note
Being a full reformat, this will conflict with the in-flight `scheduler-alerting`, `scheduler-budget-10m`, and `#24` branches. Cheapest resolution is to merge this first, then rebase each of those and re-run `ruff format` on the result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
