### PR TITLE
Operator email alerts for the scheduler (issue #92)

### DIFF
--- a/config/scheduler.toml
+++ b/config/scheduler.toml
@@ -66,3 +66,21 @@ sleep_between_cities_s = 60
 # When true, run the publish script after each successful daily batch.
 enabled = false
 #publish_script = "/homes/gws/jonf/gsv-tracker/sync_data_to_server.sh"
+
+[alerts]
+# Email the operator when a nightly run finishes unhealthy (>= failure_threshold
+# failed collections) or crashes. OFF until enabled + a recipient are set;
+# nothing is ever sent otherwise. Independent of (and complementary to) the
+# optional systemd OnFailure= hook — see deploy/README.md.
+enabled = false
+#recipient = "jonf@cs.uw.edu"
+# Transport: "mail" (uses a local relay), "msmtp"/"sendmail" (SMTP), or
+# "command" (an arbitrary shell command; body on stdin, subject/recipient in
+# $GSV_ALERT_SUBJECT/$GSV_ALERT_TO — e.g. a Slack webhook curl). Confirm which
+# works on the box first:  echo test | mail -s test jonf@cs.uw.edu
+transport = "mail"
+#command = ""
+# Alert when at least this many (city, provider) collections failed. Raise it
+# to avoid paging on the occasional flaky single city.
+failure_threshold = 1
+#subject_prefix = "[gsv-tracker]"

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -88,6 +88,49 @@ systemctl --user start gsv-tracker.service           # trigger a run now
 Rotating file logs are also written to `logs/gsv_scheduler.log`, and a
 rolling catalog backup to `logs/gsv_tracker.db.backup`.
 
+### Failure alerts (email)
+
+Off by default. The scheduler emails you when a nightly run finishes with
+`>= failure_threshold` failed collections, or crashes. First confirm what
+mail transport the box has:
+
+```bash
+echo "gsv-tracker mail test $(date)" | mail -s "gsv test" jonf@cs.uw.edu
+command -v mail msmtp sendmail
+```
+
+If `mail` delivers, set in `config/scheduler.toml`:
+
+```toml
+[alerts]
+enabled = true
+recipient = "jonf@cs.uw.edu"
+transport = "mail"     # or "msmtp" / "sendmail" if there's no local relay
+```
+
+No local relay? Configure `msmtp` (a one-file `~/.msmtprc` pointing at UW's
+SMTP, or a Gmail app password) and set `transport = "msmtp"`. Any other
+channel (e.g. a Slack webhook) works via `transport = "command"` — the body
+arrives on stdin with `$GSV_ALERT_SUBJECT` / `$GSV_ALERT_TO` in the env.
+Test end-to-end without waiting for a failure:
+
+```bash
+.venv/bin/python -m gsv_metadata_tracker.scheduler notify-failure
+```
+
+**Optional systemd safety net.** For an email even when the process dies
+before it can send its own (OOM, kill), also install the notify unit and
+uncomment `OnFailure=` in `gsv-tracker.service`:
+
+```bash
+cp deploy/systemd/gsv-tracker-notify@.service ~/.config/systemd/user/
+# then uncomment the OnFailure= line in gsv-tracker.service and daemon-reload
+```
+
+Note this fires on *any* nonzero exit (run-due returns nonzero on any failed
+city), so it can duplicate the scheduler's own threshold email — enable it
+only if you want the belt-and-suspenders coverage.
+
 ### First week
 
 Start conservatively: set `max_cities_per_day = 2` and a low

--- a/deploy/systemd/gsv-tracker-notify@.service
+++ b/deploy/systemd/gsv-tracker-notify@.service
@@ -1,0 +1,13 @@
+# Failure notifier for gsv-tracker (user unit). Triggered by an OnFailure=
+# hook on gsv-tracker.service; %i is the name of the unit that failed.
+# Emails the recent log via the [alerts] transport in scheduler.toml.
+# Install: see deploy/README.md
+[Unit]
+Description=Email that %i failed
+
+[Service]
+Type=oneshot
+WorkingDirectory=%h/gsv-tracker
+# Same env as the main service (transport creds if the mailer needs them)
+EnvironmentFile=%h/gsv-tracker/.env
+ExecStart=%h/gsv-tracker/.venv/bin/python -m gsv_metadata_tracker.scheduler notify-failure --config %h/gsv-tracker/config/scheduler.toml

--- a/deploy/systemd/gsv-tracker.service
+++ b/deploy/systemd/gsv-tracker.service
@@ -4,6 +4,11 @@
 Description=GSV Tracker: collect today's due cities
 Wants=network-online.target
 After=network-online.target
+# Opt-in raw safety net: email whenever this unit exits nonzero. run-due
+# returns nonzero on ANY failed city, so the scheduler's own threshold email
+# ([alerts] in scheduler.toml) is usually the better signal; enable this too
+# only if you want a belt-and-suspenders notice on every failure/crash.
+#OnFailure=gsv-tracker-notify@%n.service
 
 [Service]
 Type=oneshot

--- a/gsv_metadata_tracker/alerting.py
+++ b/gsv_metadata_tracker/alerting.py
@@ -1,0 +1,128 @@
+"""
+Operator alerting for the scheduler (issue #92 deploy hardening).
+
+Sends a short email when a nightly ``run-due`` finishes unhealthy (too many
+failed collections, or a crash) so a deployment on makelab1 doesn't fail
+silently. Deliberately transport-agnostic — the box may have a working
+``mail`` relay, or need ``msmtp``/``sendmail``, or the operator may want a
+custom command (e.g. a Slack webhook) — and OFF by default: nothing is sent
+until ``[alerts] enabled = true`` and a recipient are configured.
+
+Pure message/argv construction (``build_send_plan``) is separated from the
+subprocess call (``send_alert``) so it is unit-testable without sending mail.
+Alerting must never crash a collection run, so ``send_alert`` swallows and
+logs its own errors and always returns a bool.
+"""
+
+import logging
+import socket
+import subprocess
+from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
+
+# Known transports. "command" is the escape hatch: an arbitrary shell command
+# that receives the body on stdin and the subject/recipient via the
+# GSV_ALERT_SUBJECT / GSV_ALERT_TO environment variables.
+TRANSPORTS = ("mail", "msmtp", "sendmail", "command")
+
+
+@dataclass
+class AlertConfig:
+    """[alerts] section of scheduler.toml."""
+
+    enabled: bool = False
+    recipient: str = ""
+    transport: str = "mail"
+    command: str = ""  # used only when transport == "command"
+    # Email when a run finishes with at least this many failed (city, provider)
+    # collections. 1 = alert on any failure; raise it to cut noise from the
+    # occasional flaky single city.
+    failure_threshold: int = 1
+    subject_prefix: str = "[gsv-tracker]"
+
+
+def _message_with_headers(recipient: str, subject: str, body: str) -> str:
+    """An RFC-822-ish message for SMTP-style transports (msmtp/sendmail)."""
+    return (
+        f"To: {recipient}\nSubject: {subject}\nFrom: gsv-tracker@{socket.gethostname()}\n\n{body}\n"
+    )
+
+
+def build_send_plan(
+    transport: str, recipient: str, subject: str, body: str, command: str = ""
+) -> tuple[object, str, bool]:
+    """
+    Resolve a transport to ``(cmd, stdin_text, use_shell)``:
+
+    * ``mail``     -> ``["mail", "-s", subject, recipient]``, body on stdin.
+    * ``msmtp``    -> ``["msmtp", recipient]`` fed a headered message.
+    * ``sendmail`` -> ``["sendmail", "-t"]`` (recipient from the To: header).
+    * ``command``  -> the raw shell string (use_shell=True); subject/recipient
+      are exported to the environment by ``send_alert``, body on stdin.
+
+    Kept free of side effects so tests can assert the exact argv/message.
+    """
+    if transport == "mail":
+        return ["mail", "-s", subject, recipient], body, False
+    if transport == "msmtp":
+        return ["msmtp", recipient], _message_with_headers(recipient, subject, body), False
+    if transport == "sendmail":
+        return ["sendmail", "-t"], _message_with_headers(recipient, subject, body), False
+    if transport == "command":
+        if not command:
+            raise ValueError('transport "command" requires [alerts] command')
+        return command, body, True
+    raise ValueError(f"unknown alert transport {transport!r} (known: {', '.join(TRANSPORTS)})")
+
+
+def should_alert(failures: int, threshold: int) -> bool:
+    """True when a completed run's failure count warrants an email."""
+    return failures >= max(1, threshold)
+
+
+def send_alert(cfg: AlertConfig, subject: str, body: str) -> bool:
+    """
+    Best-effort send. Returns True only if the transport command exited 0.
+    Never raises: a broken mailer must not take down a collection run.
+    """
+    if not cfg.enabled:
+        return False
+    if not cfg.recipient and cfg.transport != "command":
+        logger.warning("Alerts enabled but no [alerts] recipient set; skipping")
+        return False
+
+    full_subject = f"{cfg.subject_prefix} {subject}".strip()
+    try:
+        cmd, stdin_text, use_shell = build_send_plan(
+            cfg.transport, cfg.recipient, full_subject, body, cfg.command
+        )
+    except ValueError as e:
+        logger.error(f"Alert not sent — bad config: {e}")
+        return False
+
+    env = None
+    if use_shell:
+        import os
+
+        env = {**os.environ, "GSV_ALERT_SUBJECT": full_subject, "GSV_ALERT_TO": cfg.recipient}
+    try:
+        result = subprocess.run(
+            cmd,
+            input=stdin_text.encode("utf-8"),
+            shell=use_shell,
+            env=env,
+            timeout=30,
+            capture_output=True,
+        )
+    except (OSError, subprocess.SubprocessError) as e:
+        logger.error(f"Alert send failed ({cfg.transport}): {e}")
+        return False
+    if result.returncode != 0:
+        logger.error(
+            f"Alert transport {cfg.transport!r} exited "
+            f"{result.returncode}: {result.stderr.decode('utf-8', 'replace')[:200]}"
+        )
+        return False
+    logger.info(f"Alert emailed to {cfg.recipient or '(command)'}: {subject}")
+    return True

--- a/gsv_metadata_tracker/scheduler.py
+++ b/gsv_metadata_tracker/scheduler.py
@@ -20,17 +20,20 @@ import argparse
 import logging
 import logging.handlers
 import os
+import socket
 import subprocess
 import sys
 import time
 import tomllib
-from dataclasses import dataclass
+import traceback
+from dataclasses import dataclass, field
 from datetime import UTC, date, datetime
 from pathlib import Path
 
 from tabulate import tabulate
 
 from . import db
+from .alerting import AlertConfig, send_alert, should_alert
 from .download_mapillary import estimate_tile_count
 from .json_summarizer import generate_aggregate_v2
 from .naming import KNOWN_PROVIDERS
@@ -73,6 +76,8 @@ class SchedulerConfig:
     # [providers.*] — when None (no section in the TOML), falls back to
     # gsv-only with the legacy [schedule].daily_request_budget
     providers: dict[str, ProviderConfig] | None = None
+    # [alerts] — operator email on unhealthy runs (off by default)
+    alerts: AlertConfig = field(default_factory=AlertConfig)
 
     def __post_init__(self):
         if not self.db_path:
@@ -101,6 +106,7 @@ def load_scheduler_config(path: str | None = None) -> SchedulerConfig:
     dl = raw.get("download", {})
     paths = raw.get("paths", {})
     pub = raw.get("publish", {})
+    al = raw.get("alerts", {})
 
     providers = None
     if "providers" in raw:
@@ -134,6 +140,14 @@ def load_scheduler_config(path: str | None = None) -> SchedulerConfig:
         publish_enabled=pub.get("enabled", False),
         publish_script=pub.get("publish_script", str(_PROJECT_ROOT / "sync_data_to_server.sh")),
         providers=providers,
+        alerts=AlertConfig(
+            enabled=al.get("enabled", False),
+            recipient=al.get("recipient", ""),
+            transport=al.get("transport", "mail"),
+            command=al.get("command", ""),
+            failure_threshold=al.get("failure_threshold", 1),
+            subject_prefix=al.get("subject_prefix", "[gsv-tracker]"),
+        ),
     )
 
 
@@ -161,6 +175,34 @@ def setup_logging(cfg: SchedulerConfig, verbose: bool = False) -> None:
         format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
         handlers=handlers,
     )
+
+
+def _recent_log_tail(cfg: SchedulerConfig, n: int = 40) -> str:
+    """Last n lines of the scheduler log, for pasting into an alert email."""
+    log_path = os.path.join(cfg.log_dir, "gsv_scheduler.log")
+    try:
+        with open(log_path, encoding="utf-8", errors="replace") as f:
+            return "".join(f.readlines()[-n:]) or "(log empty)"
+    except OSError as e:
+        return f"(could not read {log_path}: {e})"
+
+
+def cmd_notify_failure(cfg: SchedulerConfig) -> int:
+    """
+    Email that the scheduled run failed. Intended for a systemd
+    ``OnFailure=`` hook, which fires when the unit exits nonzero (a crash, or
+    — since run-due returns nonzero on any failed city — a failed collection
+    the in-run threshold alert may have already covered). Best-effort.
+    """
+    host = socket.gethostname()
+    body = (
+        "gsv-tracker's scheduled run exited nonzero (systemd OnFailure).\n\n"
+        "Recent log:\n" + _recent_log_tail(cfg, 60)
+    )
+    sent = send_alert(cfg.alerts, f"scheduled run FAILED on {host}", body)
+    # 0 when we alerted or alerting is intentionally off; 1 only if a send was
+    # attempted and failed, so the notify unit's own status is meaningful.
+    return 0 if sent or not cfg.alerts.enabled else 1
 
 
 def cmd_status(cfg: SchedulerConfig) -> int:
@@ -413,11 +455,12 @@ def cmd_run_due(cfg: SchedulerConfig, dry_run: bool = False, limit: int | None =
             if processed < len(due):
                 time.sleep(cfg.sleep_between_cities_s)
 
-    logger.info(
-        f"Done: {succeeded}/{attempted} runs succeeded across "
+    summary = (
+        f"run-due {today}: {succeeded}/{attempted} runs succeeded across "
         f"{processed} cities"
         + (f"; {skipped_budget} deferred for budget" if skipped_budget else "")
     )
+    logger.info("Done: " + summary)
 
     # Regenerate the aggregate once for the whole batch
     if succeeded > 0:
@@ -440,7 +483,24 @@ def cmd_run_due(cfg: SchedulerConfig, dry_run: bool = False, limit: int | None =
         result = subprocess.run(["bash", cfg.publish_script], cwd=str(_PROJECT_ROOT))
         if result.returncode != 0:
             logger.error("Publish script failed")
+            send_alert(
+                cfg.alerts,
+                f"publish script FAILED on {socket.gethostname()}",
+                f"{summary}\n\nPublish step exited nonzero.\n\n"
+                f"Recent log:\n{_recent_log_tail(cfg)}",
+            )
             return 1
+
+    # Operator email when the batch finished unhealthy (threshold-controlled so
+    # an occasional single flaky city doesn't page every night). No-op unless
+    # [alerts] enabled.
+    failures = attempted - succeeded
+    if should_alert(failures, cfg.alerts.failure_threshold):
+        send_alert(
+            cfg.alerts,
+            f"{failures} failed collection(s) on {socket.gethostname()}",
+            f"{summary}\n\nRecent log:\n{_recent_log_tail(cfg)}",
+        )
 
     return 0 if succeeded == attempted else 1
 
@@ -461,6 +521,7 @@ def main() -> int:
     p_run = sub.add_parser("run-due", help="Collect today's due cities")
     p_run.add_argument("--dry-run", action="store_true", help="Print what would run; no downloads")
     p_run.add_argument("--limit", type=int, default=None, help="Process at most N cities (testing)")
+    sub.add_parser("notify-failure", help="Email the recent log (for a systemd OnFailure= hook)")
 
     args = parser.parse_args()
     cfg = load_scheduler_config(args.config)
@@ -470,8 +531,20 @@ def main() -> int:
         return cmd_status(cfg)
     if args.command == "assign":
         return cmd_assign(cfg)
+    if args.command == "notify-failure":
+        return cmd_notify_failure(cfg)
     if args.command == "run-due":
-        return cmd_run_due(cfg, dry_run=args.dry_run, limit=args.limit)
+        try:
+            return cmd_run_due(cfg, dry_run=args.dry_run, limit=args.limit)
+        except Exception:
+            # A crash (not just a failed city) — email the traceback before the
+            # process dies, so a silent nightly failure can't go unnoticed.
+            send_alert(
+                cfg.alerts,
+                f"run-due CRASHED on {socket.gethostname()}",
+                f"Uncaught exception in run-due:\n\n{traceback.format_exc()}",
+            )
+            raise
     return 2
 
 

--- a/tests/test_alerting.py
+++ b/tests/test_alerting.py
@@ -1,0 +1,116 @@
+"""
+Alerting tests (issue #92): transport plan construction, threshold logic, and
+the send path — exercised with harmless shell commands (`true`/`false`) so no
+mail is ever sent. Also round-trips an [alerts] TOML section through the
+scheduler config loader to confirm the wiring.
+"""
+
+import pytest
+
+from gsv_metadata_tracker.alerting import (
+    AlertConfig,
+    build_send_plan,
+    send_alert,
+    should_alert,
+)
+
+
+class TestBuildSendPlan:
+    def test_mail(self):
+        cmd, stdin, shell = build_send_plan("mail", "a@b.c", "subj", "hello")
+        assert cmd == ["mail", "-s", "subj", "a@b.c"]
+        assert stdin == "hello" and shell is False
+
+    def test_msmtp_has_headers_and_recipient(self):
+        cmd, stdin, shell = build_send_plan("msmtp", "a@b.c", "subj", "hi")
+        assert cmd == ["msmtp", "a@b.c"] and shell is False
+        assert "To: a@b.c" in stdin and "Subject: subj" in stdin
+        assert stdin.endswith("hi\n")
+
+    def test_sendmail_reads_recipient_from_headers(self):
+        cmd, stdin, shell = build_send_plan("sendmail", "a@b.c", "s", "b")
+        assert cmd == ["sendmail", "-t"] and "To: a@b.c" in stdin
+
+    def test_command_is_shell(self):
+        cmd, stdin, shell = build_send_plan("command", "", "s", "body", command="cat >/dev/null")
+        assert cmd == "cat >/dev/null" and stdin == "body" and shell is True
+
+    def test_command_without_command_raises(self):
+        with pytest.raises(ValueError):
+            build_send_plan("command", "a@b.c", "s", "b")
+
+    def test_unknown_transport_raises(self):
+        with pytest.raises(ValueError):
+            build_send_plan("carrier-pigeon", "a@b.c", "s", "b")
+
+
+class TestShouldAlert:
+    @pytest.mark.parametrize(
+        "failures,threshold,expected",
+        [
+            (0, 1, False),
+            (1, 1, True),
+            (2, 3, False),
+            (3, 3, True),
+            (5, 0, True),  # threshold floored at 1
+        ],
+    )
+    def test_threshold(self, failures, threshold, expected):
+        assert should_alert(failures, threshold) is expected
+
+
+class TestSendAlert:
+    def test_disabled_is_noop(self):
+        assert send_alert(AlertConfig(enabled=False), "s", "b") is False
+
+    def test_enabled_without_recipient_skips(self):
+        # mail/msmtp need a recipient; missing one must not attempt a send
+        cfg = AlertConfig(enabled=True, recipient="", transport="mail")
+        assert send_alert(cfg, "s", "b") is False
+
+    def test_command_success(self):
+        cfg = AlertConfig(enabled=True, transport="command", command="true")
+        assert send_alert(cfg, "s", "b") is True
+
+    def test_command_failure_returns_false(self):
+        cfg = AlertConfig(enabled=True, transport="command", command="false")
+        assert send_alert(cfg, "s", "b") is False
+
+    def test_command_receives_subject_and_recipient_in_env(self, tmp_path):
+        out = tmp_path / "env.txt"
+        cfg = AlertConfig(
+            enabled=True,
+            transport="command",
+            recipient="x@y.z",
+            subject_prefix="[p]",
+            command=f'echo "$GSV_ALERT_SUBJECT -> $GSV_ALERT_TO" > {out}',
+        )
+        assert send_alert(cfg, "boom", "body") is True
+        assert out.read_text().strip() == "[p] boom -> x@y.z"
+
+
+def test_config_loader_reads_alerts_section(tmp_path):
+    from gsv_metadata_tracker.scheduler import load_scheduler_config
+
+    p = tmp_path / "s.toml"
+    p.write_text(
+        "[alerts]\n"
+        "enabled = true\n"
+        'recipient = "ops@example.edu"\n'
+        'transport = "msmtp"\n'
+        "failure_threshold = 3\n"
+    )
+    cfg = load_scheduler_config(str(p))
+    assert cfg.alerts.enabled is True
+    assert cfg.alerts.recipient == "ops@example.edu"
+    assert cfg.alerts.transport == "msmtp"
+    assert cfg.alerts.failure_threshold == 3
+
+
+def test_config_loader_alerts_default_off(tmp_path):
+    from gsv_metadata_tracker.scheduler import load_scheduler_config
+
+    p = tmp_path / "s.toml"
+    p.write_text("[schedule]\ncycle_days = 90\n")
+    cfg = load_scheduler_config(str(p))
+    assert cfg.alerts.enabled is False


### PR DESCRIPTION
Closes #92. Operator email alerts for the scheduler so a silent nightly failure on makelab1 can't go unnoticed.

## What it adds
- **`gsv_metadata_tracker/alerting.py`** — a small `AlertConfig` + `send_alert`/`should_alert`. Transport defaults to `mail`; `command` allows a custom sink. Off by default.
- **Scheduler hooks** (`scheduler.py`):
  - threshold-controlled email when a `run-due` batch finishes unhealthy (so one flaky city doesn't page every night),
  - an alert if the publish step fails,
  - a `notify-failure` subcommand for a systemd `OnFailure=` hook,
  - a top-level try/except around `run-due` that emails the traceback before the process dies.
- **`config/scheduler.toml`** `[alerts]` section (disabled by default).
- **`deploy/`** — systemd `OnFailure=` unit + README notes.
- **`tests/test_alerting.py`** — pure-logic tests (threshold, config, transport selection); no network/mail sent.

## Notes
- Rebased onto current `main` and absorbed the repo-wide `ruff format` (issue #121), so it's lint-clean under the new CI. `247 tests pass` (main's 229 + 18 new).
- Enabling is a deploy-time flip of `enabled = true`; transport `mail` was confirmed against the real box previously.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
