### PR TITLE
Deploy the scheduler on makelab1 (local publish, site deploy, resource caps)

### DIFF
--- a/config/scheduler.makelab1.toml
+++ b/config/scheduler.makelab1.toml
@@ -1,0 +1,56 @@
+# GSV Tracker scheduler configuration — makelab1 production deploy.
+#
+# This is the checked-in production config the systemd unit points at
+# (--config .../scheduler.makelab1.toml). See config/scheduler.toml for the
+# fully-annotated example; comments here are trimmed to what's deploy-specific.
+# Parsed with stdlib tomllib (Python 3.11+).
+
+[schedule]
+cycle_days = 90            # re-collect each city ~quarterly
+grace_days = 7
+max_cities_per_day = 20    # cities/day (a city runs all enabled providers)
+max_consecutive_failures = 5
+city_timeout_minutes = 180
+daily_request_budget = 10000000   # legacy fallback; superseded by [providers.*]
+
+# Per-provider daily request budgets (own run series, ledger, failure tracking).
+[providers.gsv]
+enabled = true
+# GSV metadata is free and quota-less; the real ceiling is the 30k/min rate cap.
+# 10M/day covers cycling ~1,144 cities on the 90-day schedule with headroom.
+daily_request_budget = 10000000
+
+[providers.mapillary]
+enabled = true
+# Counted in z14 vector-tile requests; Mapillary caps at 50,000/day per app.
+daily_request_budget = 40000
+
+[download]
+batch_size = 100
+connection_limit = 50
+request_timeout_s = 30.0
+sleep_between_cities_s = 60
+
+[paths]
+# The checkout + data live on lab storage (makelab2), NFS-mounted on makelab1.
+# ~/gsv-tracker is a convenience symlink to this path (see deploy/README.md).
+data_dir = "/projects/makeabilitylab/gsv-tracker/data"
+db_path  = "/projects/makeabilitylab/gsv-tracker/data/gsv_tracker.db"
+log_dir  = "/projects/makeabilitylab/gsv-tracker/logs"
+
+[publish]
+# After each successful nightly batch, publish *.csv.gz/*.json.gz to the public
+# docroot. GSV_PUBLISH_LOCAL=1 (set in the systemd unit) makes this a LOCAL rsync
+# into the NFS-mounted docroot — no SSH hop. The script excludes the DB/logs/bare
+# CSVs, so only sanitized artifacts ever reach the web server.
+enabled = true
+publish_script = "/projects/makeabilitylab/gsv-tracker/sync_data_to_server.sh"
+
+[alerts]
+# Email on an unhealthy night (>= failure_threshold failed collections) or crash.
+# makelab1's /usr/bin/mail delivers to cs.uw.edu with no relay setup.
+enabled = true
+recipient = "jonf@cs.uw.edu"
+transport = "mail"
+failure_threshold = 1
+subject_prefix = "[gsv-tracker]"

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -4,38 +4,51 @@ The scheduler runs as a **user-level systemd timer** on
 `makelab1.cs.washington.edu` (Rocky Linux 9): a oneshot service fires
 nightly, collects the cities due that day (staggered quarterly cycle,
 bounded by a daily API-request budget), diffs each against its previous
-run, regenerates the aggregate JSON, and rsyncs `data/` to the public web
-server. All state lives in `data/gsv_tracker.db`, so crashes and missed
-days self-heal.
+run, regenerates the aggregate JSON, and publishes `data/` to the public
+web docroot. All state lives in `data/gsv_tracker.db`, so crashes and
+missed days self-heal.
+
+## Where things live
+
+makelab1 is the **compute** host; storage is NFS from other servers, so
+this is deliberately split:
+
+| What | Path | Notes |
+|------|------|-------|
+| Code + data + DB + logs + `.env` | `/projects/makeabilitylab/gsv-tracker/` | On the lab fileserver **makelab2** (42 TB, backed up, group `makelab`). **Not web-served.** Colocated with Project Sidewalk. |
+| Convenience symlink | `~/gsv-tracker` → the path above | Lets the generic `%h/gsv-tracker` systemd units and `.env` resolve. |
+| Public web docroot | `/cse/web/research/makelab/public/gsv-tracker/` | On a *different* server (`new-rumble`); served at `makeabilitylab.cs.washington.edu/public/gsv-tracker/`. Holds only the flattened website + published `*.csv.gz`/`*.json.gz`. |
+
+Because makelab1 mounts the docroot directly, **publishing is a local
+rsync — no SSH to recycle** (`GSV_PUBLISH_LOCAL=1`, set in the systemd unit).
 
 ## 1. One-time setup
 
 ```bash
 ssh makelab1.cs.washington.edu
 
-# Clone and set up the environment (needs Python >= 3.11 for tomllib)
-git clone https://github.com/jonfroehlich/gsv-tracker.git ~/gsv-tracker
+# Clone onto lab storage, and symlink it into home for the systemd units
+git clone https://github.com/jonfroehlich/gsv-tracker.git /projects/makeabilitylab/gsv-tracker
+ln -s /projects/makeabilitylab/gsv-tracker ~/gsv-tracker
+
 cd ~/gsv-tracker
-python3.11 -m venv .venv
+python3.11 -m venv .venv          # 3.11+ for tomllib
 .venv/bin/pip install -r requirements.txt
 
-# API keys (same file the CLI uses) — the scheduler collects both
-# providers by default, so both are required
-echo 'GMAPS_API_KEY=YOUR_KEY_HERE' > .env
-echo 'MAPILLARY_ACCESS_TOKEN=YOUR_TOKEN_HERE' >> .env
-chmod 600 .env
+# API keys — copy your working .env up from the laptop (least error-prone):
+#   (from the laptop)  scp .env makelab1.cs.washington.edu:/projects/makeabilitylab/gsv-tracker/.env
+chmod 600 .env                    # seal the keys; the parent dir is group-readable
 ```
 
-## 2. Move the data + catalog to makelab1
+## 2. Move the data + catalog up
 
-From the machine that currently holds `data/` (laptop):
+From the machine that currently holds `data/` (laptop), ~15 GB:
 
 ```bash
-rsync -azh --progress data/ makelab1.cs.washington.edu:gsv-tracker/data/
+rsync -azh --progress data/ makelab1.cs.washington.edu:/projects/makeabilitylab/gsv-tracker/data/
 ```
 
-Then, on makelab1, register the existing files as baseline runs (dry-run
-first, review the report, then execute):
+Then register the existing files as baseline runs (dry-run first, review, execute):
 
 ```bash
 cd ~/gsv-tracker
@@ -43,100 +56,110 @@ cd ~/gsv-tracker
 .venv/bin/python scripts/migrate_to_db.py --execute
 ```
 
-## 3. Configure
+## 3. Sanity-check the config
 
-Edit `config/scheduler.toml`: uncomment and set the `[paths]` entries to
-absolute paths, review `daily_request_budget` / `max_cities_per_day`, and
-set `[publish] enabled = true` once you've confirmed SSH key auth from
-makelab1 to the web host (`recycle.cs.washington.edu`) works:
-
-```bash
-ssh recycle.cs.washington.edu true   # should succeed without a password
-```
-
-Sanity-check before enabling the timer:
+The production config `config/scheduler.makelab1.toml` is checked in and
+already points at the paths above, enables local publish, and enables email
+alerts. Confirm mail delivers, then preview a run:
 
 ```bash
-.venv/bin/python -m gsv_metadata_tracker.scheduler status
-.venv/bin/python -m gsv_metadata_tracker.scheduler run-due --dry-run
+echo "gsv-tracker mail test $(date)" | mail -s "gsv test" jonf@cs.uw.edu
+# NB: --config is global and must come BEFORE the subcommand.
+.venv/bin/python -m gsv_metadata_tracker.scheduler --config config/scheduler.makelab1.toml status
+.venv/bin/python -m gsv_metadata_tracker.scheduler --config config/scheduler.makelab1.toml run-due --dry-run
 ```
 
-## 4. Install the systemd units (user-level, no root needed)
+Start conservative for the first few nights — set `max_cities_per_day = 2`
+in the TOML, watch, then raise. (See **First full backfill** below.)
+
+## 4. Clean up the public docroot + deploy the website
+
+The docroot currently holds a legacy full-repo checkout (`.git/`, `scripts/`,
+`config/`, `.venv/`, `*.py`, …) — none of which belongs on a web server.
+`deploy_makelab1.sh` publishes the site **flattened** (so it serves at
+`.../public/gsv-tracker/` with no `/www/` in the URL) and its `--delete`
+sweeps that legacy junk, while **protecting** `data/`, `poster/`, `cities/`,
+and `data-huge/`. Preview first:
+
+```bash
+cd ~/gsv-tracker
+./deploy_makelab1.sh --dry-run     # shows exactly what is added/deleted
+./deploy_makelab1.sh               # pulls latest code, then prompts before applying
+```
+
+Run this whenever you push new frontend/backend code. The nightly **data**
+publish is separate and automatic (step 5).
+
+## 5. Install the systemd units (user-level, no root)
 
 ```bash
 mkdir -p ~/.config/systemd/user
 cp deploy/systemd/gsv-tracker.{service,timer} ~/.config/systemd/user/
 systemctl --user daemon-reload
 systemctl --user enable --now gsv-tracker.timer
-
-# User services must survive logout:
-loginctl enable-linger $USER
+loginctl enable-linger $USER       # user services must survive logout
 ```
 
-If `enable-linger` is disallowed by policy, ask CSE IT to enable lingering
-for your account (or to install the units as a system service).
+The service ships with resource caps (`MemoryMax=8G`, `CPUQuota=400%`,
+`Nice=10`) so nightly collection can't starve Project Sidewalk, which shares
+the box and the makelab2 array. If `enable-linger` is disallowed by policy,
+ask CSE IT to enable lingering for your account.
 
-## 5. Operate
+## 6. Operate
 
 ```bash
 systemctl --user list-timers gsv-tracker.timer      # next scheduled run
 journalctl --user -u gsv-tracker.service -f          # live logs
-.venv/bin/python -m gsv_metadata_tracker.scheduler status
 systemctl --user start gsv-tracker.service           # trigger a run now
+.venv/bin/python -m gsv_metadata_tracker.scheduler --config config/scheduler.makelab1.toml status
 ```
 
-Rotating file logs are also written to `logs/gsv_scheduler.log`, and a
-rolling catalog backup to `logs/gsv_tracker.db.backup`.
+Rotating file logs also go to `logs/gsv_scheduler.log`, and a rolling
+catalog backup to `logs/gsv_tracker.db.backup`.
+
+### Watching resource use (alongside Project Sidewalk)
+
+```bash
+systemd-cgtop                                        # live CPU/mem per cgroup — gsv vs sidewalk
+systemctl --user show gsv-tracker.service -p MemoryPeak -p CPUUsageNSec
+```
+
+Validate the caps after the first live night: if `MemoryPeak` approaches
+`MemoryMax`, raise it (or lower `batch_size`/`connection_limit` in the TOML).
+Data lives on NFS, so IO is network (not block-device) — CPU/memory caps and
+`Nice` are the real levers; `IOWeight` would not govern it.
 
 ### Failure alerts (email)
 
-Off by default. The scheduler emails you when a nightly run finishes with
-`>= failure_threshold` failed collections, or crashes. First confirm what
-mail transport the box has:
+Enabled in `config/scheduler.makelab1.toml` (`transport = "mail"`, which
+delivers on makelab1 with no relay setup). Test end-to-end without waiting for
+a failure:
 
 ```bash
-echo "gsv-tracker mail test $(date)" | mail -s "gsv test" jonf@cs.uw.edu
-command -v mail msmtp sendmail
+.venv/bin/python -m gsv_metadata_tracker.scheduler --config config/scheduler.makelab1.toml notify-failure
 ```
 
-If `mail` delivers, set in `config/scheduler.toml`:
-
-```toml
-[alerts]
-enabled = true
-recipient = "jonf@cs.uw.edu"
-transport = "mail"     # or "msmtp" / "sendmail" if there's no local relay
-```
-
-No local relay? Configure `msmtp` (a one-file `~/.msmtprc` pointing at UW's
-SMTP, or a Gmail app password) and set `transport = "msmtp"`. Any other
-channel (e.g. a Slack webhook) works via `transport = "command"` — the body
-arrives on stdin with `$GSV_ALERT_SUBJECT` / `$GSV_ALERT_TO` in the env.
-Test end-to-end without waiting for a failure:
-
-```bash
-.venv/bin/python -m gsv_metadata_tracker.scheduler notify-failure
-```
-
-**Optional systemd safety net.** For an email even when the process dies
-before it can send its own (OOM, kill), also install the notify unit and
-uncomment `OnFailure=` in `gsv-tracker.service`:
+**Optional systemd safety net** — for an email even when the process dies
+before it can send its own (OOM, kill): install the notify unit and uncomment
+`OnFailure=` in `gsv-tracker.service`:
 
 ```bash
 cp deploy/systemd/gsv-tracker-notify@.service ~/.config/systemd/user/
-# then uncomment the OnFailure= line in gsv-tracker.service and daemon-reload
+# then uncomment OnFailure= in gsv-tracker.service and daemon-reload
 ```
 
-Note this fires on *any* nonzero exit (run-due returns nonzero on any failed
-city), so it can duplicate the scheduler's own threshold email — enable it
-only if you want the belt-and-suspenders coverage.
+It fires on *any* nonzero exit (run-due returns nonzero on any failed city),
+so it can duplicate the scheduler's own threshold email — enable only if you
+want belt-and-suspenders coverage.
 
-### First week
+### First full backfill
 
-Start conservatively: set `max_cities_per_day = 2` and a low
-`daily_request_budget` (e.g. `30000`) in the TOML, watch a few nights of
-journal output and the public site, then raise to production values
-(defaults in the example TOML).
+Post-#91, every city needs a fresh run on the new frozen geometry, so the
+first cycle is a big one-time burst (not steady state). Once a few nights look
+healthy, raise `max_cities_per_day` (and optionally trigger extra daytime
+batches with `systemctl --user start gsv-tracker.service`) to catch up, then
+drop back to the steady ~quarterly cadence (`max_cities_per_day = 20` keeps
+~1,144 cities on the 90-day cycle with headroom).
 
 ### Disabling a city
 

--- a/deploy/systemd/gsv-tracker.service
+++ b/deploy/systemd/gsv-tracker.service
@@ -12,10 +12,29 @@ After=network-online.target
 
 [Service]
 Type=oneshot
+# %h/gsv-tracker is a symlink to the real checkout on lab storage
+# (/projects/makeabilitylab/gsv-tracker); see deploy/README.md.
 WorkingDirectory=%h/gsv-tracker
-# GMAPS_API_KEY lives here (same format as the repo .env: KEY=value)
+# GMAPS_API_KEY / MAPILLARY_ACCESS_TOKEN live here (repo .env format: KEY=value)
 EnvironmentFile=%h/gsv-tracker/.env
-ExecStart=%h/gsv-tracker/.venv/bin/python -m gsv_metadata_tracker.scheduler run-due --config %h/gsv-tracker/config/scheduler.toml
+# Publish straight to the NFS-mounted docroot (no SSH) — see sync_data_to_server.sh
+Environment=GSV_PUBLISH_LOCAL=1
+# NB: --config is a global arg and MUST precede the subcommand (argparse).
+ExecStart=%h/gsv-tracker/.venv/bin/python -m gsv_metadata_tracker.scheduler --config %h/gsv-tracker/config/scheduler.makelab1.toml run-due
 # A full day of cities can legitimately take hours
 TimeoutStartSec=12h
+
+# ── Resource guardrails ────────────────────────────────────────────────
+# makelab1 is shared with Project Sidewalk (and its data lives on the same
+# makelab2 array). These caps keep nightly collection from starving co-tenants.
+# The workload is I/O-bound async HTTP + pandas, so real peaks are modest;
+# validate after the first live night and tune:
+#   systemctl --user show gsv-tracker.service -p MemoryPeak -p CPUUsageNSec
 Nice=10
+MemoryAccounting=true
+MemoryHigh=4G
+MemoryMax=8G
+CPUAccounting=true
+CPUQuota=400%
+# Note: data lives on NFS (makelab2), so IO is network, not block-device —
+# IOWeight would not govern it; CPU/Memory caps + Nice are the real levers.

--- a/deploy_makelab1.sh
+++ b/deploy_makelab1.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+#
+# deploy_makelab1.sh
+#
+# On-demand CODE + WEBSITE deploy for the makelab1 install. Run this after you
+# push new frontend or backend code; the nightly *data* publish is separate and
+# automatic (the scheduler runs sync_data_to_server.sh --local after each batch).
+#
+# What it does, from the private checkout it lives in:
+#   1. git pull --ff-only              (fetch the latest code)
+#   2. pip install (only if requirements.txt changed in the pull)
+#   3. rsync www/ -> the public docroot, FLATTENED (so the site serves at
+#      .../public/gsv-tracker/ with no /www/ in the URL), excluding dev tooling
+#      (node_modules, eslint, tests, package files) and PROTECTING the docroot's
+#      data/, poster/, cities/, data-huge/ from deletion.
+#
+# The first run also cleans a legacy full-repo checkout out of the docroot:
+# --delete removes everything in the docroot that isn't a published site file or
+# a protected data dir (old .git/, scripts/, config/, *.py, etc.).
+#
+# Safe by default: previews with --dry-run semantics and prompts before applying
+# unless --yes is given. Makes ZERO provider API calls.
+#
+# Usage:
+#   ./deploy_makelab1.sh                 # pull + preview + confirm + deploy site
+#   ./deploy_makelab1.sh --dry-run       # show what would change, touch nothing
+#   ./deploy_makelab1.sh --yes           # skip the confirmation prompt
+#   ./deploy_makelab1.sh --skip-pull     # just re-publish the site (no git pull)
+#
+# Environment overrides:
+#   GSV_DOCROOT   public docroot (default: /cse/web/research/makelab/public/gsv-tracker)
+
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "$0")" && pwd)"
+WWW_DIR="${REPO_DIR}/www"
+DOCROOT="${GSV_DOCROOT:-/cse/web/research/makelab/public/gsv-tracker}"
+
+DRY_RUN=""
+ASSUME_YES=""
+SKIP_PULL=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run|-n) DRY_RUN="--dry-run"; shift ;;
+    --yes|-y)     ASSUME_YES="1"; shift ;;
+    --skip-pull)  SKIP_PULL="1"; shift ;;
+    --help|-h)
+      sed -n '2,30p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *) echo "Error: unknown option: $1 (try --help)"; exit 1 ;;
+  esac
+done
+
+# ──────────────────────────────────────────────
+# Validation
+# ──────────────────────────────────────────────
+if [[ ! -d "$WWW_DIR" ]]; then
+  echo "Error: www/ not found at $WWW_DIR (run from the gsv-tracker checkout)."
+  exit 1
+fi
+if [[ ! -d "$DOCROOT" ]]; then
+  echo "Error: docroot not found: $DOCROOT"
+  echo "Set GSV_DOCROOT or create it first."
+  exit 1
+fi
+command -v rsync >/dev/null || { echo "Error: rsync not installed."; exit 1; }
+
+echo "═══════════════════════════════════════════"
+echo " GSV Tracker: code + website deploy"
+echo "═══════════════════════════════════════════"
+echo "  Repo:    $REPO_DIR"
+echo "  Site:    $WWW_DIR/  ->  $DOCROOT/  (flattened)"
+[[ -n "$DRY_RUN" ]] && echo "  Mode:    DRY RUN"
+echo ""
+
+# ──────────────────────────────────────────────
+# 1. Pull latest code (+ deps if requirements changed)
+# ──────────────────────────────────────────────
+if [[ -z "$SKIP_PULL" && -z "$DRY_RUN" ]]; then
+  echo "→ git pull --ff-only"
+  before="$(git -C "$REPO_DIR" rev-parse HEAD)"
+  git -C "$REPO_DIR" pull --ff-only
+  after="$(git -C "$REPO_DIR" rev-parse HEAD)"
+  if [[ "$before" != "$after" ]] && \
+     git -C "$REPO_DIR" diff --name-only "$before" "$after" | grep -qx 'requirements.txt'; then
+    echo "→ requirements.txt changed — updating venv"
+    "${REPO_DIR}/.venv/bin/pip" install -q -r "${REPO_DIR}/requirements.txt"
+  fi
+  echo ""
+elif [[ -n "$SKIP_PULL" ]]; then
+  echo "→ skipping git pull (--skip-pull)"
+  echo ""
+fi
+
+# ──────────────────────────────────────────────
+# 2. Publish the website (flattened into the docroot)
+# ──────────────────────────────────────────────
+# --delete keeps the docroot clean (and sweeps out any legacy full-repo files),
+# but the anchored --exclude entries below are PROTECTED from deletion: rsync
+# never removes an excluded path on the receiving side. That is what shields the
+# 15 GB data/ (and the other static asset dirs) from --delete.
+#
+# The dev-tooling excludes keep node_modules/, tests, and package/lint files off
+# the public web server.
+RSYNC_ARGS=(
+  -rlptvh --delete
+  --chmod=D2755,F644
+  # protect docroot content this script does not manage:
+  --exclude='/data/'
+  --exclude='/poster/'
+  --exclude='/cities/'
+  --exclude='/data-huge/'
+  # NOTE: a legacy docroot/www/ subdir (from the old symlink layout) is
+  # intentionally NOT excluded, so --delete sweeps it during the flatten.
+  # keep dev tooling out of the published site:
+  --exclude='node_modules/'
+  --exclude='__tests__/'
+  --exclude='eslint.config.js'
+  --exclude='package.json'
+  --exclude='package-lock.json'
+  --exclude='.gitignore'
+  --exclude='.git/'
+)
+
+if [[ -n "$DRY_RUN" ]]; then
+  echo "→ Preview of website changes (no files touched):"
+  rsync "${RSYNC_ARGS[@]}" --dry-run "$WWW_DIR/" "$DOCROOT/"
+  echo ""
+  echo "DRY RUN complete. Re-run without --dry-run to apply."
+  exit 0
+fi
+
+# Real run: preview deletions first, then confirm (unless --yes).
+echo "→ Preview (what the deploy will change):"
+rsync "${RSYNC_ARGS[@]}" --dry-run "$WWW_DIR/" "$DOCROOT/" | sed 's/^/    /'
+echo ""
+if [[ -z "$ASSUME_YES" ]]; then
+  read -r -p "Apply these changes to $DOCROOT ? [y/N] " reply
+  [[ "$reply" =~ ^[Yy]$ ]] || { echo "Aborted."; exit 0; }
+fi
+
+rsync "${RSYNC_ARGS[@]}" "$WWW_DIR/" "$DOCROOT/"
+
+echo ""
+echo "Site deployed to: https://makeabilitylab.cs.washington.edu/public/gsv-tracker/"

--- a/gsv_metadata_tracker/scheduler.py
+++ b/gsv_metadata_tracker/scheduler.py
@@ -8,10 +8,10 @@ daily API-request budget, then regenerates the aggregate JSON and
 catalog, so the process is crash-safe and a missed day self-heals (due
 selection is ordered stalest-first).
 
-Usage:
-    python -m gsv_metadata_tracker.scheduler status   [--config PATH]
-    python -m gsv_metadata_tracker.scheduler assign   [--config PATH]
-    python -m gsv_metadata_tracker.scheduler run-due  [--config PATH] [--dry-run] [--limit N]
+Usage (--config accepted on either side of the subcommand):
+    python -m gsv_metadata_tracker.scheduler [--config PATH] status
+    python -m gsv_metadata_tracker.scheduler [--config PATH] assign
+    python -m gsv_metadata_tracker.scheduler [--config PATH] run-due [--dry-run] [--limit N]
 
 Config: TOML (see config/scheduler.toml). Requires Python 3.11+ (tomllib).
 """
@@ -505,27 +505,50 @@ def cmd_run_due(cfg: SchedulerConfig, dry_run: bool = False, limit: int | None =
     return 0 if succeeded == attempted else 1
 
 
-def main() -> int:
+def _add_global_flags(p: argparse.ArgumentParser) -> None:
+    """Add --config/--verbose to a parser.
+
+    Applied to BOTH the top-level parser and every subparser so the flags are
+    accepted on either side of the subcommand (``--config X run-due`` and
+    ``run-due --config X`` both work — systemd/docs historically wrote it after).
+    ``SUPPRESS`` defaults mean an unused copy never clobbers the value parsed at
+    the other position.
+    """
+    p.add_argument(
+        "--config",
+        default=argparse.SUPPRESS,
+        help=f"Path to scheduler TOML (default: {DEFAULT_CONFIG_PATH})",
+    )
+    p.add_argument("--verbose", action="store_true", default=argparse.SUPPRESS)
+
+
+def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="python -m gsv_metadata_tracker.scheduler",
         description="Staggered GSV collection scheduler",
     )
-    parser.add_argument(
-        "--config", default=None, help=f"Path to scheduler TOML (default: {DEFAULT_CONFIG_PATH})"
-    )
-    parser.add_argument("--verbose", action="store_true")
+    _add_global_flags(parser)
     sub = parser.add_subparsers(dest="command", required=True)
 
-    sub.add_parser("status", help="Show per-city schedule and budget status")
-    sub.add_parser("assign", help="(Re)compute stagger assignments")
+    _add_global_flags(sub.add_parser("status", help="Show per-city schedule and budget status"))
+    _add_global_flags(sub.add_parser("assign", help="(Re)compute stagger assignments"))
     p_run = sub.add_parser("run-due", help="Collect today's due cities")
+    _add_global_flags(p_run)
     p_run.add_argument("--dry-run", action="store_true", help="Print what would run; no downloads")
     p_run.add_argument("--limit", type=int, default=None, help="Process at most N cities (testing)")
-    sub.add_parser("notify-failure", help="Email the recent log (for a systemd OnFailure= hook)")
+    _add_global_flags(
+        sub.add_parser(
+            "notify-failure", help="Email the recent log (for a systemd OnFailure= hook)"
+        )
+    )
+    return parser
 
-    args = parser.parse_args()
-    cfg = load_scheduler_config(args.config)
-    setup_logging(cfg, verbose=args.verbose)
+
+def main() -> int:
+    args = build_parser().parse_args()
+    # getattr fallbacks: SUPPRESS means the attr is absent unless the flag was given.
+    cfg = load_scheduler_config(getattr(args, "config", None))
+    setup_logging(cfg, verbose=getattr(args, "verbose", False))
 
     if args.command == "status":
         return cmd_status(cfg)

--- a/sync_data_to_server.sh
+++ b/sync_data_to_server.sh
@@ -9,11 +9,19 @@
 # Public URL:   https://makeabilitylab.cs.washington.edu/public/gsv-tracker/data/
 #
 # Usage:
-#   ./sync_data_to_server.sh                  # sync all data
+#   ./sync_data_to_server.sh                  # sync all data (rsync over SSH)
+#   ./sync_data_to_server.sh --local          # copy to a locally-mounted docroot (no SSH)
 #   ./sync_data_to_server.sh --dry-run        # preview what would be transferred
 #   ./sync_data_to_server.sh --file <file>    # sync a single file (relative to data/)
 #   ./sync_data_to_server.sh --verbose        # show detailed transfer info
 #   ./sync_data_to_server.sh --delete         # remove remote files not in local data/
+#
+# Local vs. SSH publishing:
+#   From a laptop, the docroot is remote -> rsync over SSH (the default).
+#   On a host that NFS-mounts the docroot directly (e.g. makelab1, which sees
+#   /cse/web/research/... locally), pass --local (or set GSV_PUBLISH_LOCAL=1) to
+#   copy straight to the filesystem with no SSH hop. This is what the scheduler
+#   uses when [publish] runs on the server.
 #
 # Prerequisites:
 #   - SSH access to the remote host (key-based auth recommended)
@@ -32,6 +40,11 @@ set -euo pipefail
 REMOTE_USER="${GSV_REMOTE_USER:-jonf}"
 REMOTE_HOST="${GSV_REMOTE_HOST:-recycle.cs.washington.edu}"
 REMOTE_DATA_DIR="${GSV_REMOTE_DATA_DIR:-/cse/web/research/makelab/public/gsv-tracker/data}"
+
+# Local publish mode: copy to REMOTE_DATA_DIR on the local filesystem instead of
+# rsync-over-SSH. Enabled with --local or GSV_PUBLISH_LOCAL=1. Used on hosts that
+# NFS-mount the web docroot directly (makelab1), so publishing skips SSH entirely.
+PUBLISH_LOCAL="${GSV_PUBLISH_LOCAL:-}"
 
 # Resolve local data/ relative to this script's location
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -74,6 +87,10 @@ while [[ $# -gt 0 ]]; do
       DRY_RUN="--dry-run"
       shift
       ;;
+    --local)
+      PUBLISH_LOCAL="1"
+      shift
+      ;;
     --file|-f)
       SINGLE_FILE="$2"
       shift 2
@@ -87,11 +104,12 @@ while [[ $# -gt 0 ]]; do
       shift
       ;;
     --help|-h)
-      echo "Usage: $0 [--dry-run] [--file <path>] [--verbose] [--delete]"
+      echo "Usage: $0 [--local] [--dry-run] [--file <path>] [--verbose] [--delete]"
       echo ""
       echo "Syncs local data/ to the UW makeabilitylab server."
       echo ""
       echo "Options:"
+      echo "  --local          Copy to a locally-mounted docroot (no SSH; for makelab1)"
       echo "  --dry-run, -n    Preview changes without transferring"
       echo "  --file, -f       Sync a single file (path relative to data/)"
       echo "  --verbose, -v    Show detailed transfer info"
@@ -141,11 +159,19 @@ done
 # ──────────────────────────────────────────────
 # Sync
 # ──────────────────────────────────────────────
-REMOTE_DEST="${REMOTE_USER}@${REMOTE_HOST}:${REMOTE_DATA_DIR}"
+# Local mode targets the filesystem directly (no user@host: prefix); SSH mode
+# targets the remote host. In local mode, ensure the destination dir exists.
+if [[ -n "$PUBLISH_LOCAL" ]]; then
+  REMOTE_DEST="${REMOTE_DATA_DIR}"
+  mkdir -p "$REMOTE_DATA_DIR"
+else
+  REMOTE_DEST="${REMOTE_USER}@${REMOTE_HOST}:${REMOTE_DATA_DIR}"
+fi
 
 echo "═══════════════════════════════════════════"
 echo " GSV Tracker Data Sync"
 echo "═══════════════════════════════════════════"
+[[ -n "$PUBLISH_LOCAL" ]] && echo "  Mode:   LOCAL (no SSH)"
 
 if [[ -n "$SINGLE_FILE" ]]; then
   SRC="${LOCAL_DATA_DIR}/${SINGLE_FILE}"
@@ -154,10 +180,14 @@ if [[ -n "$SINGLE_FILE" ]]; then
     exit 1
   fi
 
-  # Ensure remote subdirectory exists for nested paths
+  # Ensure destination subdirectory exists for nested paths
   REMOTE_SUBDIR="$(dirname "$SINGLE_FILE")"
   if [[ "$REMOTE_SUBDIR" != "." ]]; then
-    ssh "${REMOTE_USER}@${REMOTE_HOST}" "mkdir -p '${REMOTE_DATA_DIR}/${REMOTE_SUBDIR}'"
+    if [[ -n "$PUBLISH_LOCAL" ]]; then
+      mkdir -p "${REMOTE_DATA_DIR}/${REMOTE_SUBDIR}"
+    else
+      ssh "${REMOTE_USER}@${REMOTE_HOST}" "mkdir -p '${REMOTE_DATA_DIR}/${REMOTE_SUBDIR}'"
+    fi
   fi
 
   echo "  File:   $SINGLE_FILE"

--- a/tests/test_deploy_scripts.py
+++ b/tests/test_deploy_scripts.py
@@ -1,0 +1,67 @@
+"""Guard tests for deploy_makelab1.sh.
+
+The website deploy runs ``rsync --delete`` against the public docroot, which
+sits right next to the ~15 GB (irreplaceable) ``data/`` directory. A wrong
+filter could wipe it. These tests shell out to the REAL script in --dry-run mode
+(so they can never drift from the actual filter list) and assert that data/ is
+protected, legacy repo junk is swept, and dev tooling stays off the web server.
+
+Skipped automatically where bash/rsync aren't available.
+"""
+
+import os
+import shutil
+import subprocess
+
+import pytest
+
+_PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_SCRIPT = os.path.join(_PROJECT_ROOT, "deploy_makelab1.sh")
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("bash") is None or shutil.which("rsync") is None,
+    reason="deploy script test needs bash + rsync",
+)
+
+
+def test_deploy_dryrun_protects_data_sweeps_junk_excludes_devtooling(tmp_path):
+    docroot = tmp_path / "docroot"
+    # Protected content (must survive --delete):
+    (docroot / "data").mkdir(parents=True)
+    (docroot / "data" / "seattle.csv.gz").write_text("PRECIOUS 15GB")
+    (docroot / "poster").mkdir()
+    (docroot / "poster" / "p.png").write_text("x")
+    # Legacy full-repo junk that a flatten should sweep:
+    (docroot / "scripts").mkdir()
+    (docroot / "scripts" / "old.py").write_text("junk")
+    (docroot / "CLAUDE.md").write_text("junk")
+    (docroot / "www").mkdir()  # legacy pre-flatten subdir
+    (docroot / "www" / "stale.html").write_text("old")
+
+    env = {**os.environ, "GSV_DOCROOT": str(docroot)}
+    # --dry-run skips git pull and applies nothing; runs against the repo's real www/.
+    r = subprocess.run(
+        ["bash", _SCRIPT, "--dry-run"],
+        cwd=_PROJECT_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert r.returncode == 0, f"stderr:\n{r.stderr}"
+    out = r.stdout
+
+    # data/ and poster/ are protected — never touched, never mentioned.
+    assert "seattle.csv.gz" not in out
+    assert "p.png" not in out
+
+    # Legacy repo junk is swept by --delete.
+    assert "scripts/old.py" in out
+    assert "CLAUDE.md" in out
+    assert "stale.html" in out  # the old docroot/www/ subdir
+
+    # Dev tooling never reaches the web server.
+    assert "node_modules" not in out
+
+    # The site is flattened to the docroot root.
+    assert "index.html" in out
+    assert "city.html" in out

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,9 +1,17 @@
 """Scheduler logic tests — pure logic only, no network or subprocesses."""
 
+import os
 from datetime import UTC, date
 
 from gsv_metadata_tracker import db
-from gsv_metadata_tracker.scheduler import SchedulerConfig, estimate_requests, load_scheduler_config
+from gsv_metadata_tracker.scheduler import (
+    SchedulerConfig,
+    build_parser,
+    estimate_requests,
+    load_scheduler_config,
+)
+
+_PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 
 def _register(conn, name, width=5000, height=5000, step=20):
@@ -98,6 +106,37 @@ enabled = false
 """)
     cfg = load_scheduler_config(str(p))
     assert cfg.enabled_providers() == ["gsv"]
+
+
+def test_config_flag_accepted_on_either_side_of_subcommand():
+    # --config is global; a prior systemd unit put it AFTER the subcommand, which
+    # argparse rejected and would have failed the nightly service. It must now
+    # parse on both sides. See build_parser / _add_global_flags.
+    parser = build_parser()
+
+    before = parser.parse_args(["--config", "/x.toml", "run-due", "--dry-run"])
+    assert before.command == "run-due" and before.config == "/x.toml" and before.dry_run
+
+    after = parser.parse_args(["run-due", "--config", "/x.toml", "--dry-run"])
+    assert after.command == "run-due" and after.config == "/x.toml" and after.dry_run
+
+    # Works for a plain subcommand after the flag too.
+    assert parser.parse_args(["--config", "/y.toml", "status"]).config == "/y.toml"
+
+    # Omitted entirely: SUPPRESS leaves the attr absent so main() falls back to None.
+    assert getattr(parser.parse_args(["status"]), "config", None) is None
+
+
+def test_makelab1_production_config_is_wired():
+    # Guard the checked-in production config the systemd unit points at.
+    cfg = load_scheduler_config(os.path.join(_PROJECT_ROOT, "config", "scheduler.makelab1.toml"))
+    assert cfg.enabled_providers() == ["gsv", "mapillary"]
+    assert cfg.publish_enabled
+    assert cfg.publish_script.endswith("sync_data_to_server.sh")
+    assert cfg.alerts.enabled and cfg.alerts.transport == "mail" and cfg.alerts.recipient
+    # Data/DB live on lab storage (makelab2), not in the web docroot.
+    assert "/projects/makeabilitylab/gsv-tracker" in cfg.db_path
+    assert "/cse/web/" not in cfg.db_path and "/cse/web/" not in cfg.data_dir
 
 
 def test_due_cities_stalest_first(conn):


### PR DESCRIPTION
Wires up the unattended **makelab1** deployment — the main remaining piece before tagging v2.0.0.

## Layout
makelab1 is compute; storage is the lab fileserver **makelab2** (42 TB, backed up), NFS-mounted at `/projects/makeabilitylab/gsv-tracker` (colocated with Project Sidewalk). The public web docroot is a *separate* server, also NFS-mounted on makelab1 — so publishing is a **local rsync, no SSH**.

## What's here
- **`sync_data_to_server.sh`** — `--local` / `GSV_PUBLISH_LOCAL=1` mode: publish via local rsync into the mounted docroot (laptop SSH path unchanged).
- **`deploy_makelab1.sh`** *(new)* — on-demand code+site deploy: `git pull` → rsync `www/` **flattened** into the docroot (serves at `/public/gsv-tracker/` with no `/www/` in the URL), sweeping the legacy full-repo checkout while **protecting** `data/`, `poster/`, `cities/`, `data-huge/`. Dry-run preview + confirm by default.
- **`config/scheduler.makelab1.toml`** *(new)* — production config: paths on lab storage, local publish, email alerts (`transport=mail`).
- **`deploy/systemd/gsv-tracker.service`** — `MemoryMax=8G` / `CPUQuota=400%` / `Nice=10` caps so nightly collection can't starve Sidewalk; `GSV_PUBLISH_LOCAL=1`; points at the makelab1 config.
- **`deploy/README.md`** — rewritten runbook (makelab2 storage, local publish, flatten, resource monitoring via `systemd-cgtop`).

## Bug fix
`scheduler.py` now accepts `--config` on **either side** of the subcommand. The prior systemd unit invoked `run-due --config PATH`, which argparse **rejected** — the service would have failed to start. Latent because the makelab1 deploy was always deferred.

## Tests (250 pass, ruff clean)
- `--config` parses on both sides of the subcommand
- the committed makelab1 prod config wires publish/providers/alerts/paths correctly
- a deploy-script **dry-run guard** that shells out to the real script and asserts `data/` is protected, legacy junk is swept, and dev tooling (`node_modules`, tests, eslint) stays off the web server

## Not included (needs makelab1 access — see deploy/README.md)
Cloning to lab storage, `.env`, rsyncing the ~15 GB `data/` up, `migrate_to_db`, docroot cleanup, and installing the timer are laid out as exact SSH commands in the runbook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)