### PR TITLE
Fix folium.plugins ImportError breaking --check-boundary map preview

### DIFF
--- a/streetscape_metadata_tracker/vis.py
+++ b/streetscape_metadata_tracker/vis.py
@@ -7,6 +7,7 @@ from math import cos, pi
 
 import branca.colormap as cm
 import folium
+import folium.plugins  # noqa: F401 — register folium.plugins.* (not auto-imported since folium 0.16)
 import matplotlib.colors
 import matplotlib.dates as mdates
 import matplotlib.pyplot as plt


### PR DESCRIPTION
## Problem
`gsv_tracker.py "City" --check-boundary` crashes when rendering the search-area map:

```
AttributeError: module 'folium' has no attribute 'plugins'
  at vis.py:173  folium.plugins.MeasureControl(...)
```

Since **folium 0.16**, `import folium` no longer auto-imports the `folium.plugins` submodule, so `folium.plugins.MeasureControl` in `display_search_area()` is undefined. (Pre-existing on `main`; installed folium is 0.20.0.)

## Fix
Import the submodule explicitly:

```python
import folium.plugins  # noqa: F401 — register folium.plugins.* (not auto-imported since folium 0.16)
```

## Verification
- `python gsv_tracker.py "Seattle, WA" --check-boundary` now completes and writes the HTML preview (no AttributeError).
- `ruff check` clean; `pytest tests/test_vis.py` passes.

Independent of the Streetscape Tracker rename (#128/#111) — kept on its own branch off `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)