### PR TITLE
Add scheduler regenerate-aggregate subcommand

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,7 @@ python streetscape_tracker.py "Seattle, WA" --check-boundary   # preview search 
 python run_cities.py cities.txt --continue-on-error
 python -m streetscape_metadata_tracker.scheduler status
 python -m streetscape_metadata_tracker.scheduler run-due --dry-run
+python -m streetscape_metadata_tracker.scheduler regenerate-aggregate --publish   # rebuild cities.json.gz from the catalog (no collection) and rsync
 
 # One-time migration of legacy (undated) data files into the catalog
 python scripts/migrate_to_db.py            # dry run; --execute to apply

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ The repository includes several scripts divided into core data collection tools 
 
 * **`streetscape_tracker.py`**: The primary asynchronous data collection script. Each invocation collects one dated snapshot of a city, catalogs it, and diffs it against the previous run.
 * **`run_cities.py`**: A batch-processing wrapper that runs `streetscape_tracker.py` across multiple cities sequentially by reading configurations from a text file (e.g., `cities.txt`).
-* **`python -m streetscape_metadata_tracker.scheduler`**: The staggered quarterly scheduler (`status`, `assign`, `run-due` subcommands). See `deploy/README.md` for running it as a systemd timer.
+* **`python -m streetscape_metadata_tracker.scheduler`**: The staggered quarterly scheduler (`status`, `assign`, `run-due`, `regenerate-aggregate` subcommands). `regenerate-aggregate [--publish]` rebuilds `cities.json.gz` from the catalog without collecting — handy after a schema change or manual run. See `deploy/README.md` for running it as a systemd timer.
 
 ### Data Utilities & Analysis
 

--- a/streetscape_metadata_tracker/scheduler.py
+++ b/streetscape_metadata_tracker/scheduler.py
@@ -12,6 +12,7 @@ Usage (--config accepted on either side of the subcommand):
     python -m streetscape_metadata_tracker.scheduler [--config PATH] status
     python -m streetscape_metadata_tracker.scheduler [--config PATH] assign
     python -m streetscape_metadata_tracker.scheduler [--config PATH] run-due [--dry-run] [--limit N]
+    python -m streetscape_metadata_tracker.scheduler [--config PATH] regenerate-aggregate [--publish]
 
 Config: TOML (see config/scheduler.toml). Requires Python 3.11+ (tomllib).
 """
@@ -187,6 +188,24 @@ def _recent_log_tail(cfg: SchedulerConfig, n: int = 40) -> str:
         return f"(could not read {log_path}: {e})"
 
 
+def _publish(cfg: SchedulerConfig, context: str) -> int:
+    """
+    Run the publish script (rsync data/ to the web server), returning its exit
+    code and emailing the operator on failure. ``context`` (e.g. the run-due
+    summary) is prepended to the alert body so the email is self-explanatory.
+    """
+    logger.info(f"Publishing via {cfg.publish_script}")
+    result = subprocess.run(["bash", cfg.publish_script], cwd=str(_PROJECT_ROOT))
+    if result.returncode != 0:
+        logger.error("Publish script failed")
+        send_alert(
+            cfg.alerts,
+            f"publish script FAILED on {socket.gethostname()}",
+            f"{context}\n\nPublish step exited nonzero.\n\nRecent log:\n{_recent_log_tail(cfg)}",
+        )
+    return result.returncode
+
+
 def cmd_notify_failure(cfg: SchedulerConfig) -> int:
     """
     Email that the scheduled run failed. Intended for a systemd
@@ -287,6 +306,27 @@ def cmd_assign(cfg: SchedulerConfig) -> int:
         f"{len(providers)} provider(s) over a {cfg.cycle_days}-day cycle "
         f"(~{n / max(cfg.cycle_days, 1):.1f} cities/day)."
     )
+    return 0
+
+
+def cmd_regenerate(cfg: SchedulerConfig, publish: bool = False) -> int:
+    """
+    Rebuild the aggregate ``cities.json.gz`` from the catalog without collecting
+    anything, then optionally publish. Useful after a code change to the
+    aggregate schema, a manual/back-filled run, or to refresh stale published
+    data — a clean one-liner instead of an inline Python snippet.
+    """
+    conn = db.connect(cfg.db_path)
+    logger.info("Regenerating aggregate cities.json.gz")
+    agg = generate_aggregate_v2(conn, cfg.data_dir)
+    print(f"Regenerated {cfg.data_dir}/cities.json.gz ({agg['cities_count']} cities).")
+
+    if publish:
+        # An explicit --publish overrides [publish].enabled: the operator is
+        # asking for it directly on the command line.
+        if _publish(cfg, "regenerate-aggregate (manual)") != 0:
+            return 1
+        print("Published to the web server.")
     return 0
 
 
@@ -479,16 +519,7 @@ def cmd_run_due(cfg: SchedulerConfig, dry_run: bool = False, limit: int | None =
         logger.error(f"Catalog backup failed: {e}")
 
     if cfg.publish_enabled and succeeded > 0:
-        logger.info(f"Publishing via {cfg.publish_script}")
-        result = subprocess.run(["bash", cfg.publish_script], cwd=str(_PROJECT_ROOT))
-        if result.returncode != 0:
-            logger.error("Publish script failed")
-            send_alert(
-                cfg.alerts,
-                f"publish script FAILED on {socket.gethostname()}",
-                f"{summary}\n\nPublish step exited nonzero.\n\n"
-                f"Recent log:\n{_recent_log_tail(cfg)}",
-            )
+        if _publish(cfg, summary) != 0:
             return 1
 
     # Operator email when the batch finished unhealthy (threshold-controlled so
@@ -532,6 +563,14 @@ def build_parser() -> argparse.ArgumentParser:
 
     _add_global_flags(sub.add_parser("status", help="Show per-city schedule and budget status"))
     _add_global_flags(sub.add_parser("assign", help="(Re)compute stagger assignments"))
+    p_regen = sub.add_parser(
+        "regenerate-aggregate",
+        help="Rebuild cities.json.gz from the catalog (no collection)",
+    )
+    _add_global_flags(p_regen)
+    p_regen.add_argument(
+        "--publish", action="store_true", help="Also rsync data/ to the web server afterward"
+    )
     p_run = sub.add_parser("run-due", help="Collect today's due cities")
     _add_global_flags(p_run)
     p_run.add_argument("--dry-run", action="store_true", help="Print what would run; no downloads")
@@ -554,6 +593,8 @@ def main() -> int:
         return cmd_status(cfg)
     if args.command == "assign":
         return cmd_assign(cfg)
+    if args.command == "regenerate-aggregate":
+        return cmd_regenerate(cfg, publish=args.publish)
     if args.command == "notify-failure":
         return cmd_notify_failure(cfg)
     if args.command == "run-due":

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -127,6 +127,49 @@ def test_config_flag_accepted_on_either_side_of_subcommand():
     assert getattr(parser.parse_args(["status"]), "config", None) is None
 
 
+def test_regenerate_aggregate_parses_publish_flag():
+    parser = build_parser()
+    a = parser.parse_args(["regenerate-aggregate"])
+    assert a.command == "regenerate-aggregate" and a.publish is False
+    b = parser.parse_args(["--config", "/x.toml", "regenerate-aggregate", "--publish"])
+    assert b.command == "regenerate-aggregate" and b.publish and b.config == "/x.toml"
+
+
+def test_regenerate_aggregate_rebuilds_without_publish(conn, monkeypatch):
+    """regenerate-aggregate rebuilds the aggregate and, without --publish,
+    never touches the publish script."""
+    from streetscape_metadata_tracker import scheduler as sched
+
+    calls = {"agg": 0, "publish": 0}
+    monkeypatch.setattr(sched.db, "connect", lambda path: conn)
+    monkeypatch.setattr(
+        sched,
+        "generate_aggregate_v2",
+        lambda c, d: calls.__setitem__("agg", calls["agg"] + 1) or {"cities_count": 3},
+    )
+    monkeypatch.setattr(sched, "_publish", lambda cfg, ctx: calls.__setitem__("publish", 1) or 0)
+
+    rc = sched.cmd_regenerate(SchedulerConfig(publish_enabled=False))
+    assert rc == 0 and calls == {"agg": 1, "publish": 0}
+
+
+def test_regenerate_aggregate_publishes_on_flag(conn, monkeypatch):
+    """--publish runs the publish step even when [publish].enabled is false,
+    and a publish failure surfaces as a nonzero exit."""
+    from streetscape_metadata_tracker import scheduler as sched
+
+    monkeypatch.setattr(sched.db, "connect", lambda path: conn)
+    monkeypatch.setattr(sched, "generate_aggregate_v2", lambda c, d: {"cities_count": 0})
+
+    published = []
+    monkeypatch.setattr(sched, "_publish", lambda cfg, ctx: published.append(ctx) or 0)
+    assert sched.cmd_regenerate(SchedulerConfig(publish_enabled=False), publish=True) == 0
+    assert published  # publish ran despite publish_enabled=False
+
+    monkeypatch.setattr(sched, "_publish", lambda cfg, ctx: 1)  # simulate rsync failure
+    assert sched.cmd_regenerate(SchedulerConfig(publish_enabled=False), publish=True) == 1
+
+
 def test_makelab1_production_config_is_wired():
     # Guard the checked-in production config the systemd unit points at.
     cfg = load_scheduler_config(os.path.join(_PROJECT_ROOT, "config", "scheduler.makelab1.toml"))


### PR DESCRIPTION
## What

Adds a `regenerate-aggregate` scheduler subcommand that rebuilds `cities.json.gz` from the catalog **without a collection run**, with an optional `--publish` that rsyncs `data/` to the web server:

```bash
python -m streetscape_metadata_tracker.scheduler regenerate-aggregate [--publish]
```

## Why

Refreshing the published aggregate (after an aggregate-schema change, a manual/back-filled run, or to clear stale published data) previously meant an inline Python snippet. This makes it a clean one-liner — and it's exactly the refresh step called for in #131.

## How

- New `cmd_regenerate()`; the publish-script run + failure alert are factored out of `cmd_run_due` into a shared `_publish()` helper, so `run-due` behavior is unchanged.
- `--publish` explicitly overrides `[publish].enabled` — it's a direct operator request on the command line.
- Wired into the argparse parser, `main()` dispatch, and the module docstring.
- Docs: `README.md` + `CLAUDE.md` command list.

## Tests

3 new tests (flag parsing, rebuild-without-publish, publish-on-flag incl. nonzero exit on rsync failure). Full suite: **268 passed**, ruff clean.

Follow-up to the v2 rollout; the publish step is referenced by #131.

🤖 Generated with [Claude Code](https://claude.com/claude-code)