### PR TITLE
Fix five pre-v2 audit blockers (publish filter, Mapillary diffs, XSS, v1 adapter, credential logging)

### DIFF
--- a/streetscape_metadata_tracker/diff.py
+++ b/streetscape_metadata_tracker/diff.py
@@ -154,10 +154,12 @@ def compute_run_diff(df_old: pd.DataFrame, df_new: pd.DataFrame) -> RunDiff:
     )
 
     # Grid-point coverage transitions, only when both runs sampled the
-    # exact same grid points
+    # exact same grid points. Compare unique point sets, never row counts:
+    # Mapillary runs hold one row per pano, so row counts differ between
+    # runs of the identical frozen grid.
     old_keys = _grid_keys(df_old)
     new_keys = _grid_keys(df_new)
-    grid_aligned = len(old_keys) == len(new_keys) and set(old_keys) == set(new_keys)
+    grid_aligned = set(old_keys) == set(new_keys)
 
     points_gained = points_lost = coverage_delta = None
     if grid_aligned:

--- a/streetscape_metadata_tracker/download_common.py
+++ b/streetscape_metadata_tracker/download_common.py
@@ -7,6 +7,7 @@ live here so provider-specific downloaders (`download_gsv.py`,
 provider importing from another's module.
 """
 
+import re
 from datetime import datetime
 
 import geopy.distance
@@ -17,6 +18,28 @@ class DownloadError(Exception):
     """Custom exception for download-related errors."""
 
     pass
+
+
+# Credential-bearing query parameters (GSV's key=, Mapillary's
+# access_token=) as they appear inside request URLs.
+_CREDENTIAL_PATTERN = re.compile(r"(?i)\b(key|access_token|token)=[^&\s'\"]+")
+
+
+def redact_credentials(text: str) -> str:
+    """
+    Strip API credentials from text destined for logs, exceptions, or
+    alert emails.
+
+    Provider APIs carry credentials in URL query parameters, and HTTP
+    client exceptions (e.g. aiohttp.ClientResponseError) stringify with the
+    full request URL — so any raw ``str(e)`` that gets logged can leak the
+    key, and the scheduler pastes log tails into operator alert emails.
+    Every log/raise of provider-HTTP error text must pass through here.
+
+    >>> redact_credentials("HTTP 403 for https://x/tile?access_token=MLY123")
+    'HTTP 403 for https://x/tile?access_token=REDACTED'
+    """
+    return _CREDENTIAL_PATTERN.sub(r"\1=REDACTED", str(text))
 
 
 def generate_grid_points(

--- a/streetscape_metadata_tracker/download_gsv.py
+++ b/streetscape_metadata_tracker/download_gsv.py
@@ -16,7 +16,12 @@ from filelock import FileLock
 from tqdm import tqdm
 
 from .config import METADATA_DTYPES
-from .download_common import DownloadError, generate_grid_points, standardize_capture_date
+from .download_common import (
+    DownloadError,
+    generate_grid_points,
+    redact_credentials,
+    standardize_capture_date,
+)
 from .fileutils import load_city_csv_file
 
 logger = logging.getLogger(__name__)
@@ -67,17 +72,26 @@ async def fetch_gsv_pano_metadata_async(
     Raises:
         DownloadError: If the request fails or returns invalid data after all retries
     """
+    # Google requires the key as a query parameter, so exception/response
+    # text touching this URL must be scrubbed with redact_credentials()
+    # before it is logged or re-raised.
     url = f"https://maps.googleapis.com/maps/api/streetview/metadata?location={lat},{lon}&key={api_key}"
     try:
         async with session.get(url, timeout=timeout) as response:
             if response.status != 200:
-                raise DownloadError(f"HTTP {response.status}: {await response.text()}")
+                raise DownloadError(
+                    f"HTTP {response.status}: {redact_credentials(await response.text())}"
+                )
             return await response.json()
     except (TimeoutError, aiohttp.ClientError) as e:
-        logger.warning(f"Attempt failed for coordinates {lat},{lon}: {str(e)}, retrying...")
+        logger.warning(
+            f"Attempt failed for coordinates {lat},{lon}: {redact_credentials(e)}, retrying..."
+        )
         raise  # Let backoff handle the retry
     except Exception as e:
-        raise DownloadError(f"Error fetching data for coordinates {lat},{lon}: {str(e)}") from e
+        raise DownloadError(
+            f"Error fetching data for coordinates {lat},{lon}: {redact_credentials(e)}"
+        ) from e
 
 
 def get_processed_points(file_path: str) -> set:
@@ -132,7 +146,9 @@ async def process_batch_async(
             batch_results = []
             for (lat, lon, i, j), response in zip(points, responses, strict=False):
                 if isinstance(response, Exception):
-                    logger.error(f"Error processing point ({lat}, {lon}): {str(response)}")
+                    logger.error(
+                        f"Error processing point ({lat}, {lon}): {redact_credentials(response)}"
+                    )
                     await failed_points_queue.put((lat, lon, i, j))
                     continue
 

--- a/streetscape_metadata_tracker/download_mapillary.py
+++ b/streetscape_metadata_tracker/download_mapillary.py
@@ -43,15 +43,17 @@ import pandas as pd
 from tqdm import tqdm
 
 from .config import METADATA_DTYPES
-from .download_common import DownloadError, generate_grid_points
+from .download_common import DownloadError, generate_grid_points, redact_credentials
 from .fileutils import load_city_csv_file
 
 logger = logging.getLogger(__name__)
 
 TILE_ZOOM = 14  # the only zoom level whose tiles carry per-image metadata
-TILE_URL_TEMPLATE = (
-    "https://tiles.mapillary.com/maps/vtp/mly1_computed_public/2/{z}/{x}/{y}?access_token={token}"
-)
+# The access token is sent as an `Authorization: OAuth <token>` header, NOT
+# a query parameter: HTTP-client exceptions stringify with the full request
+# URL, so a URL-borne token would leak into logs (and from log tails into
+# the scheduler's alert emails).
+TILE_URL_TEMPLATE = "https://tiles.mapillary.com/maps/vtp/mly1_computed_public/2/{z}/{x}/{y}"
 IMAGE_LAYER = "image"
 
 # Meters per degree of latitude (WGS84 mean). Used only for nearest-grid-
@@ -305,7 +307,7 @@ async def download_mapillary_metadata_async(
 
     async def fetch_one(x: int, y: int) -> list[dict[str, Any]]:
         nonlocal api_requests
-        url = TILE_URL_TEMPLATE.format(z=TILE_ZOOM, x=x, y=y, token=access_token)
+        url = TILE_URL_TEMPLATE.format(z=TILE_ZOOM, x=x, y=y)
         async with semaphore:
             api_requests += 1
             tile_bytes = await _fetch_tile(session, url, timeout)
@@ -313,10 +315,13 @@ async def download_mapillary_metadata_async(
         return decode_image_features(tile_bytes, x, y)
 
     try:
-        async with aiohttp.ClientSession() as session:
+        # Token in a header, not the URL — see TILE_URL_TEMPLATE comment.
+        async with aiohttp.ClientSession(
+            headers={"Authorization": f"OAuth {access_token}"}
+        ) as session:
             results = await asyncio.gather(*(fetch_one(x, y) for x, y in tiles))
     except (TimeoutError, aiohttp.ClientError) as e:
-        raise DownloadError(f"Mapillary tile download failed: {e}") from e
+        raise DownloadError(f"Mapillary tile download failed: {redact_credentials(e)}") from e
     finally:
         progress_bar.close()
 

--- a/streetscape_metadata_tracker/scheduler.py
+++ b/streetscape_metadata_tracker/scheduler.py
@@ -35,6 +35,7 @@ from tabulate import tabulate
 
 from . import db
 from .alerting import AlertConfig, send_alert, should_alert
+from .download_common import redact_credentials
 from .download_mapillary import estimate_tile_count
 from .json_summarizer import generate_aggregate_v2
 from .naming import KNOWN_PROVIDERS
@@ -179,11 +180,17 @@ def setup_logging(cfg: SchedulerConfig, verbose: bool = False) -> None:
 
 
 def _recent_log_tail(cfg: SchedulerConfig, n: int = 40) -> str:
-    """Last n lines of the scheduler log, for pasting into an alert email."""
+    """
+    Last n lines of the scheduler log, for pasting into an alert email.
+
+    Scrubbed with redact_credentials as the last line of defense: anything
+    that slipped an API key/token into a log line must not travel further
+    in a cleartext email.
+    """
     log_path = os.path.join(cfg.log_dir, "streetscape_scheduler.log")
     try:
         with open(log_path, encoding="utf-8", errors="replace") as f:
-            return "".join(f.readlines()[-n:]) or "(log empty)"
+            return redact_credentials("".join(f.readlines()[-n:])) or "(log empty)"
     except OSError as e:
         return f"(could not read {log_path}: {e})"
 

--- a/sync_data_to_server.sh
+++ b/sync_data_to_server.sh
@@ -48,29 +48,21 @@ PUBLISH_LOCAL="${STREETSCAPE_PUBLISH_LOCAL:-}"
 
 # Resolve local data/ relative to this script's location
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-LOCAL_DATA_DIR="${SCRIPT_DIR}/data"
+LOCAL_DATA_DIR="${STREETSCAPE_LOCAL_DATA_DIR:-${SCRIPT_DIR}/data}"
 
-# Publish only the compressed data artifacts. Order matters for rsync
-# filters: the *.gz includes are added first so the bare *.csv / *.json
-# excludes below don't swallow them. Logs, the SQLite catalog, and
-# temp/intermediate files never leave this machine.
-INCLUDE_PATTERNS=(
-  "*.csv.gz"
-  "*.json.gz"
-)
-EXCLUDE_PATTERNS=(
-  "*.lock"
-  "*.downloading"
-  "*.backup"
-  "*.html"
-  "*.log"
-  "*.tmp"
-  "*.batch_*"
-  "*.db"
-  "*.db-wal"
-  "*.db-shm"
-  "*.csv"
-  "*.json"
+# Publish ONLY the compressed data artifacts. This is a strict whitelist:
+# directories are included so rsync can recurse, *.csv.gz / *.json.gz are
+# published, and the final catch-all exclude drops everything else — logs,
+# the SQLite catalog (+ WAL/SHM), bare *.csv/*.json, *.rejected quarantine
+# files, *.harvesting checkpoints, locks, and temp/intermediate files.
+# rsync's default for a file matching NO rule is to transfer it, so the
+# trailing '--exclude *' is what makes this default-deny; never append
+# patterns after it.
+FILTER_FLAGS=(
+  --include "*/"
+  --include "*.csv.gz"
+  --include "*.json.gz"
+  --exclude "*"
 )
 
 # ──────────────────────────────────────────────
@@ -120,6 +112,7 @@ while [[ $# -gt 0 ]]; do
       echo "  STREETSCAPE_REMOTE_USER  SSH username (default: \$USER)"
       echo "  STREETSCAPE_REMOTE_HOST  SSH host (required for remote mode; set this)"
       echo "  STREETSCAPE_REMOTE_DATA_DIR  Remote path (default: /cse/web/research/makelab/public/streetscape-tracker/data)"
+      echo "  STREETSCAPE_LOCAL_DATA_DIR   Local source dir (default: <repo>/data; used by tests)"
       exit 0
       ;;
     *)
@@ -146,15 +139,6 @@ if ! command -v rsync &> /dev/null; then
   echo "  Windows: use WSL or Git Bash, or install via winget/scoop"
   exit 1
 fi
-
-# Build filter flags (includes first so *.csv.gz survives the *.csv exclude)
-EXCLUDE_FLAGS=()
-for pattern in "${INCLUDE_PATTERNS[@]}"; do
-  EXCLUDE_FLAGS+=(--include "$pattern")
-done
-for pattern in "${EXCLUDE_PATTERNS[@]}"; do
-  EXCLUDE_FLAGS+=(--exclude "$pattern")
-done
 
 # ──────────────────────────────────────────────
 # Sync
@@ -212,8 +196,10 @@ else
   [[ -n "$DELETE" ]] && echo "  Delete: enabled (remote files not in local will be removed)"
   echo ""
 
-  rsync -azh --chmod=D2755,F644 --progress $DRY_RUN $VERBOSE $DELETE \
-    "${EXCLUDE_FLAGS[@]}" \
+  # --prune-empty-dirs: the '*/' include would otherwise recreate every
+  # directory (even ones holding only unpublished files) on the server.
+  rsync -azh --chmod=D2755,F644 --progress --prune-empty-dirs $DRY_RUN $VERBOSE $DELETE \
+    "${FILTER_FLAGS[@]}" \
     "$LOCAL_DATA_DIR/" \
     "${REMOTE_DEST}/"
 fi

--- a/tests/test_credential_redaction.py
+++ b/tests/test_credential_redaction.py
@@ -1,0 +1,92 @@
+"""Credential-scrubbing tests (audit 2026-07-11).
+
+Provider APIs can carry credentials in request URLs, and HTTP-client
+exceptions stringify with the full URL — so raw error text reaching logs
+would leak the key, and the scheduler pastes log tails into cleartext
+alert emails. These tests pin the three layers of defense: the
+redact_credentials helper, the downloader error paths, and the scheduler's
+emailed log tail.
+"""
+
+import asyncio
+
+import aiohttp
+import pytest
+
+from streetscape_metadata_tracker import download_mapillary as dm
+from streetscape_metadata_tracker.download_common import DownloadError, redact_credentials
+
+
+def test_redact_credentials_scrubs_query_params():
+    assert (
+        redact_credentials("GET https://maps.googleapis.com/x?location=1,2&key=AIzaSECRET failed")
+        == "GET https://maps.googleapis.com/x?location=1,2&key=REDACTED failed"
+    )
+    assert (
+        redact_credentials("https://tiles.mapillary.com/t?access_token=MLY%7Csecret%7C123")
+        == "https://tiles.mapillary.com/t?access_token=REDACTED"
+    )
+
+
+def test_redact_credentials_handles_multiple_and_mixed_case():
+    text = "a?KEY=S1&other=ok&access_token=S2 b?key=S3"
+    out = redact_credentials(text)
+    assert "S1" not in out and "S2" not in out and "S3" not in out
+    assert "other=ok" in out
+
+
+def test_redact_credentials_leaves_clean_text_alone():
+    msg = "HTTP 503 fetching tile (14, 2625, 5722); retrying"
+    assert redact_credentials(msg) == msg
+
+
+def test_redact_credentials_accepts_exceptions():
+    # Callers pass exception objects directly.
+    e = aiohttp.ClientError("boom url?key=SECRET")
+    assert "SECRET" not in redact_credentials(e)
+
+
+def test_mapillary_tile_url_has_no_token():
+    # The token must never be part of the request URL (it travels as an
+    # Authorization header); a regression here re-opens the log leak.
+    assert "token" not in dm.TILE_URL_TEMPLATE
+    assert "{token}" not in dm.TILE_URL_TEMPLATE
+
+
+def test_mapillary_download_error_is_scrubbed(monkeypatch, tmp_path):
+    # A failing tile fetch whose exception text contains a credential must
+    # surface as a DownloadError WITHOUT the credential.
+    async def exploding_fetch(session, url, timeout):
+        raise aiohttp.ClientError("HTTP 429 for https://tiles/x?access_token=SECRET123")
+
+    monkeypatch.setattr(dm, "_fetch_tile", exploding_fetch)
+    with pytest.raises(DownloadError) as excinfo:
+        asyncio.run(
+            dm.download_mapillary_metadata_async(
+                "Test City",
+                47.6,
+                -122.3,
+                100,
+                100,
+                20,
+                "MLY|test|token",
+                str(tmp_path / "t_2026-07-05.csv.gz"),
+            )
+        )
+    msg = str(excinfo.value)
+    assert "SECRET123" not in msg
+    assert "REDACTED" in msg
+
+
+def test_scheduler_log_tail_is_scrubbed(tmp_path):
+    from streetscape_metadata_tracker import scheduler as sched
+
+    cfg = sched.SchedulerConfig(log_dir=str(tmp_path))
+    log_path = tmp_path / "streetscape_scheduler.log"
+    log_path.write_text(
+        "2026-07-11 INFO ok line\n"
+        "2026-07-11 ERROR fetch failed: https://maps.googleapis.com/x?key=AIzaLEAKED\n"
+    )
+    tail = sched._recent_log_tail(cfg)
+    assert "AIzaLEAKED" not in tail
+    assert "ok line" in tail

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -3,7 +3,7 @@
 import pandas as pd
 
 from streetscape_metadata_tracker.diff import compute_run_diff, generate_diff_filename
-from tests.conftest import COLUMNS, make_city_df
+from tests.conftest import COLUMNS, make_city_df, make_mapillary_city_df
 
 
 def _two_point_df(point_b_status, point_b_pano, point_b_date):
@@ -85,6 +85,42 @@ def test_no_date_point_lost_coverage():
     d = compute_run_diff(old, new)
     assert d.points_gained_coverage == 0 and d.points_lost_coverage == 1
     assert abs(d.coverage_delta_pct + 50.0) < 1e-9
+
+
+def test_mapillary_grid_aligned_despite_differing_row_counts():
+    # Mapillary is a census: one row per pano, so two runs of the identical
+    # frozen grid rarely have equal row counts. Alignment must compare unique
+    # grid points, not rows (regression: row-count check nulled all Mapillary
+    # coverage transitions).
+    # Old: 2 panos on point 0, point 1 empty (3 rows, 2 grid points).
+    old = make_mapillary_city_df(
+        [("m1", "2023-01-01"), ("m2", "2023-02-01")], panos_per_point=2, n_empty=1
+    )
+    # New: 2 panos on each of points 0 and 1 (4 rows, same 2 grid points).
+    new = make_mapillary_city_df(
+        [("m1", "2023-01-01"), ("m2", "2023-02-01"), ("m3", "2024-01-01"), ("m4", "2024-02-01")],
+        panos_per_point=2,
+        n_empty=0,
+    )
+    d = compute_run_diff(old, new)
+    assert d.grid_aligned
+    assert d.points_gained_coverage == 1 and d.points_lost_coverage == 0
+    assert abs(d.coverage_delta_pct - 50.0) < 1e-9
+    assert (d.panos_added, d.panos_removed, d.panos_persisted) == (2, 0, 2)
+
+
+def test_mapillary_census_growth_on_same_point_keeps_alignment():
+    # A point gaining extra pano rows changes row counts but not the grid or
+    # its coverage: aligned, zero coverage delta.
+    old = make_mapillary_city_df([("m1", "2023-01-01")], panos_per_point=1, n_empty=1)
+    new = make_mapillary_city_df(
+        [("m1", "2023-01-01"), ("m2", "2024-01-01")], panos_per_point=2, n_empty=1
+    )
+    d = compute_run_diff(old, new)
+    assert d.grid_aligned
+    assert d.points_gained_coverage == 0 and d.points_lost_coverage == 0
+    assert d.coverage_delta_pct == 0.0
+    assert d.panos_added == 1
 
 
 def test_misaligned_grid_skips_point_stats():

--- a/tests/test_mapillary.py
+++ b/tests/test_mapillary.py
@@ -272,9 +272,12 @@ def _run_download(
     served = []
 
     async def fake_fetch(session, url, timeout):
-        m = re.search(r"/2/14/(\d+)/(\d+)\?access_token=(.+)$", url)
+        # The token must travel as an Authorization header, never in the
+        # URL (URL-borne credentials leak via exception text into logs).
+        m = re.search(r"/2/14/(\d+)/(\d+)$", url)
         assert m, f"unexpected tile URL: {url}"
-        assert m.group(3) == "MLY|test|token"
+        assert "access_token" not in url
+        assert session.headers.get("Authorization") == "OAuth MLY|test|token"
         xy = (int(m.group(1)), int(m.group(2)))
         served.append(xy)
         return tiles_by_xy.get(xy, mapbox_vector_tile.encode([]))

--- a/tests/test_sync_data_script.py
+++ b/tests/test_sync_data_script.py
@@ -1,0 +1,125 @@
+"""Guard tests for sync_data_to_server.sh's publish filter.
+
+data/ holds private working files (the SQLite catalog, logs, *.rejected
+quarantine dumps, *.harvesting checkpoints) right next to the published
+*.csv.gz / *.json.gz artifacts, and everything transferred lands on a
+public web URL. rsync's default for a file matching NO filter rule is to
+TRANSFER it, so the filter must be default-deny (trailing ``--exclude '*'``).
+These tests shell out to the REAL script in --local --dry-run mode against a
+synthetic data dir (so they can never drift from the actual filter list).
+
+Skipped automatically where bash/rsync aren't available.
+"""
+
+import os
+import shutil
+import subprocess
+
+import pytest
+
+_PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_SCRIPT = os.path.join(_PROJECT_ROOT, "sync_data_to_server.sh")
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("bash") is None or shutil.which("rsync") is None,
+    reason="sync script test needs bash + rsync",
+)
+
+# Everything the pipeline can leave in data/, and whether it may be published.
+PUBLISHED = [
+    "seattle--wa_width_20_height_20_step_1_2026-01-05.csv.gz",
+    "seattle--wa_width_20_height_20_step_1_2026-01-05.json.gz",
+    "seattle--wa_width_20_height_20_step_1_mapillary_2026-01-05.csv.gz",
+    "seattle--wa_diff_2025-10-01_to_2026-01-05.csv.gz",
+    "seattle--wa_width_20_height_20_step_1_gsv_history_2026-01-05.csv.gz",
+    "cities.json.gz",
+]
+PRIVATE = [
+    # Rejected runs (raw REQUEST_DENIED/quota dumps; cli.py renames to *.rejected)
+    "bend--or_width_20_height_20_step_1_2026-01-05.csv.gz.rejected",
+    # History-harvester resumable checkpoint (+ its atomic-write temp)
+    "bend--or_width_20_height_20_step_1_gsv_history_2026-01-05.csv.gz.harvesting",
+    "bend--or_width_20_height_20_step_1_gsv_history_2026-01-05.csv.gz.harvesting.tmp",
+    # Catalog + sidecars (local-only by contract)
+    "streetscape_tracker.db",
+    "streetscape_tracker.db-wal",
+    "streetscape_tracker.db-shm",
+    "streetscape_tracker.db.backup",
+    # Bare (uncompressed) artifacts and working files
+    "bend--or_width_20_height_20_step_1_2026-01-05.csv",
+    "bend--or_summary.json",
+    "bend--or_width_20_height_20_step_1_2026-01-05.csv.downloading",
+    "bend--or_failed_points.csv",
+    "bend--or.lock",
+    "stray.log",
+    "stray.tmp",
+    "preview.html",
+    # A file type the filter list has never heard of: default-deny means it
+    # must NOT transfer. Regression guard for the missing trailing
+    # '--exclude *' that let *.rejected / *.harvesting reach the server.
+    "unanticipated.futureformat",
+]
+
+
+def _run_dry_sync(tmp_path, names):
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    for name in names:
+        (data_dir / name).write_text("x")
+    docroot = tmp_path / "docroot"
+
+    env = {
+        **os.environ,
+        "STREETSCAPE_LOCAL_DATA_DIR": str(data_dir),
+        "STREETSCAPE_REMOTE_DATA_DIR": str(docroot),
+        "STREETSCAPE_PUBLISH_LOCAL": "1",
+    }
+    r = subprocess.run(
+        ["bash", _SCRIPT, "--dry-run", "--verbose"],
+        cwd=_PROJECT_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert r.returncode == 0, f"stderr:\n{r.stderr}"
+    return r.stdout
+
+
+def test_publish_filter_is_default_deny(tmp_path):
+    out = _run_dry_sync(tmp_path, PUBLISHED + PRIVATE)
+    # rsync lists one path per line; compare whole lines because private
+    # names can contain published names as substrings ('x.csv.gz.rejected'
+    # contains 'x.csv.gz').
+    lines = {ln.strip() for ln in out.splitlines()}
+    for name in PUBLISHED:
+        assert name in lines, f"expected {name} to be published"
+    for name in PRIVATE:
+        assert name not in lines, f"PRIVATE file {name} would be published"
+
+
+def test_nested_published_files_survive_whitelist(tmp_path):
+    # The '*/' include must let rsync recurse into subdirectories while the
+    # catch-all exclude still drops private files inside them.
+    data_dir = tmp_path / "data"
+    (data_dir / "archive").mkdir(parents=True)
+    (data_dir / "archive" / "old_run.csv.gz").write_text("x")
+    (data_dir / "archive" / "old_run.csv").write_text("x")
+    docroot = tmp_path / "docroot"
+
+    env = {
+        **os.environ,
+        "STREETSCAPE_LOCAL_DATA_DIR": str(data_dir),
+        "STREETSCAPE_REMOTE_DATA_DIR": str(docroot),
+        "STREETSCAPE_PUBLISH_LOCAL": "1",
+    }
+    r = subprocess.run(
+        ["bash", _SCRIPT, "--dry-run", "--verbose"],
+        cwd=_PROJECT_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert r.returncode == 0, f"stderr:\n{r.stderr}"
+    lines = {ln.strip() for ln in r.stdout.splitlines()}
+    assert "archive/old_run.csv.gz" in lines
+    assert "archive/old_run.csv" not in lines

--- a/www/eslint.config.js
+++ b/www/eslint.config.js
@@ -31,6 +31,8 @@ const sharedGlobals = {
   STREETSCAPE_DATA_BASE_URL: "readonly",
   PROVIDERS: "readonly",
   getColor: "readonly",
+  escapeHtml: "readonly",
+  isValidRunFilename: "readonly",
   getProviderFromFilename: "readonly",
   fetchGzippedJson: "readonly",
   adaptCityRecord: "readonly",

--- a/www/js/__tests__/streetscape-utils.test.js
+++ b/www/js/__tests__/streetscape-utils.test.js
@@ -8,6 +8,8 @@ const assert = require("node:assert/strict");
 
 const {
   adaptCityRecord,
+  escapeHtml,
+  isValidRunFilename,
   isGoogleCopyright,
   panoDateOrNull,
   googleSharePercent,
@@ -16,10 +18,52 @@ const {
 
 // --- adaptCityRecord: v1/v2/v3 aggregate flattening ------------------------
 
-test("adaptCityRecord: v1 flat record is gsv-only, passed through", () => {
-  const v1 = { city_id: "y--tx", city: "Y", pano_count: 42 };
-  assert.equal(adaptCityRecord(v1, "gsv"), v1);
-  assert.equal(adaptCityRecord(v1, "mapillary"), null);
+// A REAL v1 record, mirroring generate_aggregate_summary_as_json's output:
+// flat fields, `city` is a bare string, data_file is an object, and NONE of
+// the normalized keys (provider/pano_count/pano_age_stats/
+// capture_year_histogram) exist. Regression: the adapter used to pass v1
+// records through raw, so index.js crashed on
+// pano_age_stats.median_pano_age_years with a live pre-v2 cities.json.gz.
+const V1_RECORD = {
+  city: "Bellingham",
+  state: { name: "Washington", code: "WA" },
+  country: { name: "United States", code: "us" },
+  center: { latitude: 48.75, longitude: -122.48 },
+  bounds: { northeast: {}, southwest: {} },
+  data_file: {
+    filename: "bellingham--wa_width_5000_height_5000_step_20.csv.gz",
+    size_bytes: 12345,
+  },
+  search_area_km2: 25,
+  coverage_rate_percent: 51.2,
+  panorama_counts: { unique_panos: 100, unique_google_panos: 60 },
+  all_panos_age_stats: { median_pano_age_years: 4.2 },
+  google_panos_age_stats: { median_pano_age_years: 3.1 },
+  collection_info: { start_time: "t0", end_time: "t1", duration_seconds: 60 },
+  histogram_of_capture_dates_by_year: {
+    all_panos: { 2019: 40, 2020: 60 },
+    google_panos: { 2019: 25, 2020: 35 },
+  },
+};
+
+test("adaptCityRecord: real v1 record gains the normalized keys", () => {
+  const gsv = adaptCityRecord(V1_RECORD, "gsv");
+  assert.equal(gsv.provider, "gsv");
+  // Normalized keys derived from the flat v1 fields, preferring the
+  // official-Google subset (same rule as v2/v3).
+  assert.equal(gsv.pano_count, 60);
+  assert.equal(gsv.pano_age_stats.median_pano_age_years, 3.1);
+  assert.deepEqual(gsv.capture_year_histogram, { 2019: 25, 2020: 35 });
+  // Fields the UI iterates/branches on must exist even though v1 lacks them.
+  assert.deepEqual(gsv.runs, []);
+  assert.equal(gsv.change, null);
+  assert.equal(gsv.copyright_info_available, true);
+  // Historical flat fields survive untouched (index.js reads
+  // data_file.filename and the bare-string city name).
+  assert.equal(gsv.city, "Bellingham");
+  assert.equal(gsv.data_file.filename, V1_RECORD.data_file.filename);
+  // v1 is gsv-only.
+  assert.equal(adaptCityRecord(V1_RECORD, "mapillary"), null);
 });
 
 test("adaptCityRecord: v2 gsv-only providers-less record", () => {
@@ -79,6 +123,78 @@ test("adaptCityRecord: v3 per-provider block, null when provider missing", () =>
   assert.deepEqual(gsv.capture_year_histogram, { counts: { 2020: 5 } });
   // No mapillary block on this city → adapted record is null (omitted upstream).
   assert.equal(adaptCityRecord(v3, "mapillary"), null);
+});
+
+// --- escapeHtml: XSS guard for data-derived strings -------------------------
+
+test("escapeHtml: neutralizes markup in third-party strings", () => {
+  // A hostile Mapillary contributor name must not survive as markup.
+  assert.equal(
+    escapeHtml('<img src=x onerror=alert(1)>'),
+    "&lt;img src=x onerror=alert(1)&gt;"
+  );
+  assert.equal(
+    escapeHtml(`"quoted" & 'single' <tag>`),
+    "&quot;quoted&quot; &amp; &#39;single&#39; &lt;tag&gt;"
+  );
+  // Benign strings pass through unchanged.
+  assert.equal(escapeHtml("© Mapillary contributor 42"), "© Mapillary contributor 42");
+});
+
+test("escapeHtml: non-string inputs are safe", () => {
+  assert.equal(escapeHtml(null), "");
+  assert.equal(escapeHtml(undefined), "");
+  assert.equal(escapeHtml(12345), "12345");
+});
+
+// --- isValidRunFilename: ?file= URL-parameter validation --------------------
+
+test("isValidRunFilename: accepts every run-filename generation", () => {
+  // Legacy undated
+  assert.ok(isValidRunFilename("bend--or_width_5000_height_5000_step_20.csv.gz"));
+  // Buggy float step
+  assert.ok(isValidRunFilename("bend--or_width_5000_height_5000_step_20.0.csv.gz"));
+  // Dated, tokenless (gsv)
+  assert.ok(isValidRunFilename("bend--or_width_5000_height_5000_step_20_2026-07-05.csv.gz"));
+  // Dated, provider-tagged
+  assert.ok(
+    isValidRunFilename("bend--or_width_5000_height_5000_step_20_mapillary_2026-07-05.csv.gz")
+  );
+  // Slug with interior period (st.-louis rule)
+  assert.ok(
+    isValidRunFilename("st.-louis--mo_width_5000_height_5000_step_20_2026-07-05.csv.gz")
+  );
+});
+
+test("isValidRunFilename: rejects traversal and non-run artifacts", () => {
+  // Path traversal / separators — the attack the validator exists for.
+  assert.equal(isValidRunFilename("../../../etc/passwd"), false);
+  assert.equal(
+    isValidRunFilename("../other/x_width_1_height_1_step_1_2026-01-01.csv.gz"),
+    false
+  );
+  assert.equal(
+    isValidRunFilename("a\\b_width_1_height_1_step_1_2026-01-01.csv.gz"),
+    false
+  );
+  // URL metacharacters that could smuggle a query/fragment.
+  assert.equal(
+    isValidRunFilename("a?b_width_1_height_1_step_1_2026-01-01.csv.gz"),
+    false
+  );
+  // Non-run artifacts: diff files, history files, working files.
+  assert.equal(isValidRunFilename("bend--or_diff_2026-04-01_to_2026-07-01.csv.gz"), false);
+  assert.equal(
+    isValidRunFilename("bend--or_width_5000_height_5000_step_20_gsv_history_2026-07-05.csv.gz"),
+    false
+  );
+  assert.equal(
+    isValidRunFilename("bend--or_width_5000_height_5000_step_20_2026-07-05.csv.gz.rejected"),
+    false
+  );
+  assert.equal(isValidRunFilename("cities.json.gz"), false);
+  assert.equal(isValidRunFilename(""), false);
+  assert.equal(isValidRunFilename(null), false);
 });
 
 // --- isGoogleCopyright: exact © Google match -------------------------------

--- a/www/js/city.js
+++ b/www/js/city.js
@@ -85,7 +85,9 @@ function updateLegend(years) {
   const sortedYears = Array.from(years).sort((a, b) => b - a);
 
   // ── Section 1: Data overview ───────────────────────────────
-  let html = `<h4>${cityNameGlobal}${stateNameGlobal ? `, ${stateNameGlobal}` : ""}</h4>`;
+  // City/state names originate in OSM/Nominatim (publicly editable) via
+  // the run's JSON metadata — escape before injecting.
+  let html = `<h4>${escapeHtml(cityNameGlobal)}${stateNameGlobal ? `, ${escapeHtml(stateNameGlobal)}` : ""}</h4>`;
 
   if (statsGlobal) {
     const s = statsGlobal;
@@ -148,7 +150,7 @@ function updateLegend(years) {
       .reverse() // newest first
       .map((r) => {
         const selected = r.data_file === currentFileGlobal ? " selected" : "";
-        return `<option value="${r.data_file}"${selected}>${r.run_date}${r.is_baseline ? " (baseline)" : ""}</option>`;
+        return `<option value="${escapeHtml(r.data_file)}"${selected}>${escapeHtml(r.run_date)}${r.is_baseline ? " (baseline)" : ""}</option>`;
       })
       .join("");
     html += `
@@ -165,7 +167,7 @@ function updateLegend(years) {
     const ch = changeGlobal;
     html += `
       <div class="legend-divider"></div>
-      <div class="legend-year-header">Since ${ch.from_run_date}</div>
+      <div class="legend-year-header">Since ${escapeHtml(ch.from_run_date)}</div>
       <p class="legend-meta" style="margin:4px 0 0">
         <span style="color:#7bd88f">+${(ch.panos_added ?? 0).toLocaleString()} new</span> /
         <span style="color:#ff8a80">−${(ch.panos_removed ?? 0).toLocaleString()} removed</span>
@@ -235,7 +237,14 @@ function toggleYear(year) {
 
 // ── URL parameters ─────────────────────────────────────────────
 const urlParams = new URLSearchParams(window.location.search);
-const csvFile = urlParams.get("file");
+// ?file= is untrusted input concatenated onto the data base URL, so it is
+// validated against the filename contract (isValidRunFilename): anything
+// else — path traversal, non-run artifacts — is treated as absent.
+const rawCsvFileParam = urlParams.get("file");
+const csvFile = isValidRunFilename(rawCsvFileParam) ? rawCsvFileParam : null;
+if (rawCsvFileParam && !csvFile) {
+  console.warn("Ignoring invalid ?file= parameter:", rawCsvFileParam);
+}
 const cityQuery = urlParams.get("city");
 const decodedCityQuery = cityQuery
   ? decodeURIComponent(cityQuery).replace(/^"(.*)"$/, "$1")
@@ -570,12 +579,15 @@ function updateChartColorsForDate(chart, date) {
  */
 function buildPopupHtml(captureDate, ageFormatted, panoId, photographer) {
   const provider = PROVIDERS[providerGlobal];
+  // photographer is third-party content (Mapillary contributor names,
+  // archival GSV credits) and pano_id comes straight from the CSV — both
+  // must be escaped before entering popup HTML.
   return `
     <div style="font-family:sans-serif">
       <strong>Capture Date:</strong> ${captureDate.toLocaleDateString()}<br>
       <strong>Age:</strong> ${ageFormatted}<br>
-      <strong>Photographer:</strong> ${photographer}<br>
-      <strong>Pano ID:</strong> ${panoId}<br><br>
+      <strong>Photographer:</strong> ${escapeHtml(photographer)}<br>
+      <strong>Pano ID:</strong> ${escapeHtml(panoId)}<br><br>
       <a href="${provider.viewerUrl(panoId)}"
          target="_blank" rel="noopener"
          style="color:#2196F3;text-decoration:none">
@@ -713,7 +725,7 @@ async function loadData() {
     const fmtYears = (v) => (v != null ? `${v.toFixed(1)} years` : "—");
     const tooltipHtml = `
       <div style="font-family:sans-serif">
-        <strong>${cityLabel}</strong><br>
+        <strong>${escapeHtml(cityLabel)}</strong><br>
         <em>${PROVIDERS[providerGlobal].label}</em><br><br>
         Total panoramas: ${stats.all_panos.duplicate_stats.total_unique_panos.toLocaleString()}<br>
         ${googleLine}${copyrightNote}<br>

--- a/www/js/index.js
+++ b/www/js/index.js
@@ -97,7 +97,7 @@ function createTooltip(city) {
   let snapshotsHtml = "";
   if (city.runs && city.runs.length > 0) {
     const n = city.runs.length;
-    snapshotsHtml = `<li>Snapshots: ${n} (since ${city.runs[0].run_date})</li>`;
+    snapshotsHtml = `<li>Snapshots: ${n} (since ${escapeHtml(city.runs[0].run_date)})</li>`;
   }
 
   // Change-since-last-run line (schema v2), colored by direction
@@ -107,7 +107,7 @@ function createTooltip(city) {
     const added = ch.panos_added ?? 0;
     const removed = ch.panos_removed ?? 0;
     changeHtml = `
-      <div style="margin-top:12px"><strong>Since ${ch.from}:</strong></div>
+      <div style="margin-top:12px"><strong>Since ${escapeHtml(ch.from)}:</strong></div>
       <ul class="popup-stats-list">
         <li><span style="color:#2e7d32">+${added.toLocaleString()} new</span> /
             <span style="color:#c62828">−${removed.toLocaleString()} removed</span> panoramas</li>
@@ -116,11 +116,13 @@ function createTooltip(city) {
       </ul>`;
   }
 
+  // City/state/country names come from OSM/Nominatim (publicly editable
+  // third-party data) — escape everything data-derived entering innerHTML.
   container.innerHTML = `
-    <h3>${cityName}, ${city.state.name}, ${city.country.name}</h3>
+    <h3>${escapeHtml(cityName)}, ${escapeHtml(city.state.name)}, ${escapeHtml(city.country.name)}</h3>
     <strong>Coverage Statistics:</strong>
     <ul class="popup-stats-list">
-      <li>Data Collected: ${city.latest_run_date || (city.collection_info?.end_time ? new Date(city.collection_info.end_time).toLocaleDateString() : "Unknown")}</li>
+      <li>Data Collected: ${escapeHtml(city.latest_run_date) || (city.collection_info?.end_time ? new Date(city.collection_info.end_time).toLocaleDateString() : "Unknown")}</li>
       ${snapshotsHtml}
       <li>Area: ${city.search_area_km2.toFixed(1)} km²</li>
       ${panoLinesHtml}

--- a/www/js/streetscape-utils.js
+++ b/www/js/streetscape-utils.js
@@ -106,6 +106,46 @@ function getProviderFromFilename(filename) {
 }
 
 /**
+ * HTML-escape a string for safe interpolation into an HTML template.
+ *
+ * Every data-derived string that enters innerHTML / bindPopup /
+ * bindTooltip markup MUST pass through this: copyright/photographer
+ * fields are arbitrary third-party content (Mapillary contributor names,
+ * archival GSV photographer credits), and city/state/country names come
+ * from publicly editable OSM/Nominatim data.
+ *
+ * @param {*} value - Any value; non-strings are stringified ("" for null/undefined).
+ * @returns {string} The escaped string.
+ */
+function escapeHtml(value) {
+  if (value == null) return "";
+  return String(value)
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}
+
+/**
+ * Validate a run-data filename from an untrusted source (the ?file= URL
+ * parameter) against the filename contract (the JS mirror of naming.py).
+ *
+ * Accepts every run-filename generation — legacy undated, buggy float
+ * step, dated, provider-tagged — and rejects anything else, in particular
+ * path separators / traversal, so a crafted ?file= can never fetch
+ * resources outside the published data directory or non-run artifacts.
+ *
+ * @param {?string} filename - Candidate filename (no directories).
+ * @returns {boolean} True iff it looks like a published run csv.gz.
+ */
+function isValidRunFilename(filename) {
+  if (typeof filename !== "string") return false;
+  return /^[^/\\?#]+_width_\d+_height_\d+_step_\d+(?:\.\d+)?(?:_[a-z]+)?(?:_\d{4}-\d{2}-\d{2})?\.csv\.gz$/
+    .test(filename);
+}
+
+/**
  * Fetch a `.json.gz` file, decompress it with pako, and return the
  * parsed object.
  *
@@ -153,8 +193,26 @@ async function fetchGzippedJson(url) {
  */
 function adaptCityRecord(rec, provider = "gsv") {
   if (!rec.latest && !rec.providers) {
-    // schema v1: already flat, gsv-only
-    return provider === "gsv" ? rec : null;
+    // schema v1: flat, gsv-only. A raw v1 record has the historical flat
+    // fields but NOT the normalized keys (provider/pano_count/
+    // pano_age_stats/capture_year_histogram), so derive them here rather
+    // than passing the record through untouched — consumers read
+    // pano_age_stats.median_pano_age_years unconditionally.
+    if (provider !== "gsv") return null;
+    const v1Counts = rec.panorama_counts || {};
+    const v1Histograms = rec.histogram_of_capture_dates_by_year || {};
+    return {
+      ...rec,
+      provider: "gsv",
+      city_id: rec.city_id ?? null,
+      runs: rec.runs || [],
+      change: rec.change || null,
+      latest_run_date: rec.latest_run_date ?? null,
+      copyright_info_available: rec.copyright_info_available ?? true,
+      pano_count: v1Counts.unique_google_panos ?? v1Counts.unique_panos,
+      pano_age_stats: rec.google_panos_age_stats ?? rec.all_panos_age_stats,
+      capture_year_histogram: v1Histograms.google_panos ?? v1Histograms.all_panos,
+    };
   }
 
   // v3 groups by provider; v2 is equivalent to a gsv-only providers map
@@ -308,6 +366,8 @@ if (typeof module !== "undefined" && module.exports) {
     STREETSCAPE_DATA_BASE_URL,
     PROVIDERS,
     getColor,
+    escapeHtml,
+    isValidRunFilename,
     getProviderFromFilename,
     fetchGzippedJson,
     adaptCityRecord,


### PR DESCRIPTION
Five release-blocking findings from the 2026-07-11 pre-v2.0.0 code/security audit, each fixed with regression tests. Full suite: 279 Python tests + 13 frontend unit tests pass; ruff + ESLint clean.

## 1. Publish filter is now default-deny (`sync_data_to_server.sh`)
rsync's default for a file matching **no** filter rule is to transfer it, so `*.csv.gz.rejected` quarantine dumps and `*.harvesting` checkpoints were being published despite the documented ".rejected … excluded from the publish glob" intent. The filter is now a strict whitelist (`--include '*/' --include '*.csv.gz' --include '*.json.gz' --exclude '*'`, plus `--prune-empty-dirs`). New `STREETSCAPE_LOCAL_DATA_DIR` override lets `tests/test_sync_data_script.py` dry-run the real script against a synthetic data dir — 6 published names must transfer, 17 private ones (including an unanticipated future extension) must not.

**Post-merge chore:** the new filter prevents future leaks but won't delete already-published `.rejected`/`.harvesting` files from the docroot (excluded files are protected from `--delete`) — needs a one-time manual sweep on the server.

## 2. Mapillary diffs actually compute coverage transitions (`diff.py`)
`grid_aligned` compared row counts, but Mapillary writes one row per pano, so nearly every Mapillary run pair was flagged "grids differ" and all coverage-transition fields stored NULL. Alignment now compares unique grid-point sets. Two new tests cover differing-row-count alignment and census growth on a single point.

## 3. XSS hardening (`www/`)
- `?file=` was concatenated onto the data base URL unvalidated; it's now checked against `isValidRunFilename()` (the JS mirror of `naming.py`'s contract — accepts all run-filename generations, rejects separators/traversal, diff/history files, and URL metacharacters).
- New `escapeHtml()` applied to every data-derived string entering `innerHTML`/popup/tooltip markup: photographer/contributor fields are arbitrary third-party content, and city/state/country names come from publicly editable OSM data.

## 4. v1 aggregate no longer crashes the overview map (`streetscape-utils.js`)
`adaptCityRecord`'s v1 branch passed records through raw, but real v1 records lack the normalized keys consumers read unconditionally (`pano_age_stats.median_pano_age_years` etc.) — a live pre-v2 `cities.json.gz` took down the whole page. The v1 branch now derives `provider`/`pano_count`/`pano_age_stats`/`capture_year_histogram` (preferring the Google subset, same rule as v2/v3). The unit test now uses a real v1-shaped fixture instead of one that already contained v2 keys.

## 5. Credentials kept out of logs and alert emails
HTTP-client exceptions stringify with the full request URL, and the scheduler pastes log tails into operator alert emails. Three layers:
- Mapillary token moves from the tile URL to an `Authorization: OAuth` header.
- New `redact_credentials()` (`download_common.py`) scrubs `key=`/`access_token=` from all GSV error text before logging/raising (Google requires the key as a URL param, so scrubbing is the defense there).
- `scheduler._recent_log_tail()` redacts as a last line of defense before log lines reach email.

`tests/test_credential_redaction.py` pins all three layers. **Note:** the Mapillary header-auth change is verified against a mocked endpoint; worth one live smoke run (`--provider mapillary --force` on a small city) before the next scheduled collection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QnMmVJkyvsK932aFwP62kd