### PR TITLE
Tier 2 audit fixes: snapshot race, budget ledger, pipeline robustness, frontend correctness + stats test suite

### DIFF
--- a/streetscape_metadata_tracker/cli.py
+++ b/streetscape_metadata_tracker/cli.py
@@ -46,6 +46,7 @@ from . import (
 )
 from .analysis import calculate_run_stats, detect_systemic_failure, print_df_summary
 from .diff import compute_run_diff, generate_diff_filename, write_diff_detail
+from .download_common import DownloadError
 from .fileutils import load_city_csv_file
 from .json_summarizer import generate_aggregate_v2, generate_city_metadata_summary_as_json
 from .naming import generate_run_filename, same_grid_geometry, sanitize_city_query_str
@@ -512,37 +513,59 @@ async def _collect_one_run(conn, args, city_row, run_date, provider, config, vis
     )
     output_csv_gz_path = os.path.join(args.download_dir, f"{run_base}.csv.gz")
 
+    # Immutable-snapshot guard: an existing file with this run's name is
+    # either a concurrent collection in flight or an orphan from a run that
+    # crashed between file-write and cataloging. Overwriting is never safe
+    # (the published file could diverge from the cataloged stats/diffs), so
+    # refuse and let the operator delete a confirmed orphan.
+    if os.path.exists(output_csv_gz_path):
+        raise RuntimeError(
+            f"{output_csv_gz_path} already exists but no {provider} run is "
+            f"cataloged for {run_date}. Refusing to overwrite an existing "
+            f"snapshot (concurrent run in progress, or orphan from a crashed "
+            f"run — if confirmed orphan, delete it and re-run)."
+        )
+
     logging.info(f"Collecting {provider} run {run_date} for {city_row.city_id}")
 
-    if provider == "mapillary":
-        dict_results = await download_mapillary_metadata_async(
-            city_name=city_row.display_name,
-            center_lat=city_row.center_lat,
-            center_lon=city_row.center_lon,
-            grid_width=city_row.grid_width_m,
-            grid_height=city_row.grid_height_m,
-            step_length=city_row.step_m,
-            access_token=config["access_token"],
-            output_csv_gz_path=output_csv_gz_path,
-            request_timeout=args.timeout,
-        )
-    else:
-        logging.info(
-            f"Using batch_size={args.batch_size}, connection_limit={args.connection_limit}"
-        )
-        dict_results = await download_gsv_metadata_async(
-            city_name=city_row.display_name,
-            center_lat=city_row.center_lat,
-            center_lon=city_row.center_lon,
-            grid_width=city_row.grid_width_m,
-            grid_height=city_row.grid_height_m,
-            step_length=city_row.step_m,
-            api_key=config["api_key"],
-            output_csv_gz_path=output_csv_gz_path,
-            batch_size=args.batch_size,
-            connection_limit=args.connection_limit,
-            request_timeout=args.timeout,
-        )
+    try:
+        if provider == "mapillary":
+            dict_results = await download_mapillary_metadata_async(
+                city_name=city_row.display_name,
+                center_lat=city_row.center_lat,
+                center_lon=city_row.center_lon,
+                grid_width=city_row.grid_width_m,
+                grid_height=city_row.grid_height_m,
+                step_length=city_row.step_m,
+                access_token=config["access_token"],
+                output_csv_gz_path=output_csv_gz_path,
+                request_timeout=args.timeout,
+            )
+        else:
+            logging.info(
+                f"Using batch_size={args.batch_size}, connection_limit={args.connection_limit}"
+            )
+            dict_results = await download_gsv_metadata_async(
+                city_name=city_row.display_name,
+                center_lat=city_row.center_lat,
+                center_lon=city_row.center_lon,
+                grid_width=city_row.grid_width_m,
+                grid_height=city_row.grid_height_m,
+                step_length=city_row.step_m,
+                api_key=config["api_key"],
+                output_csv_gz_path=output_csv_gz_path,
+                batch_size=args.batch_size,
+                connection_limit=args.connection_limit,
+                request_timeout=args.timeout,
+            )
+    except DownloadError as e:
+        # Failed downloads still spent real (budgeted, possibly billable)
+        # requests; record them so tomorrow's budget check doesn't overspend.
+        spent = getattr(e, "api_requests", 0)
+        if spent:
+            db.add_api_usage(conn, run_date, spent, provider=provider)
+            logger.warning(f"Recorded {spent} {provider} API requests spent by the failed download")
+        raise
     df = dict_results["df"]
 
     # Record API usage in the daily per-provider budget ledger (the

--- a/streetscape_metadata_tracker/diff.py
+++ b/streetscape_metadata_tracker/diff.py
@@ -49,11 +49,16 @@ class RunDiff:
         return (self.panos_added + self.panos_removed + self.capture_date_changed) > 0
 
 
-def _unique_ok_panos(df: pd.DataFrame) -> pd.DataFrame:
-    """OK rows deduplicated on pano_id, keeping the newest capture_date."""
-    ok = df[df["status"] == "OK"].copy()
-    ok = ok.sort_values("capture_date", na_position="first")
-    return ok.drop_duplicates(subset=["pano_id"], keep="last")
+def _unique_present_panos(df: pd.DataFrame) -> pd.DataFrame:
+    """
+    Present rows (OK or NO_DATE) deduplicated on pano_id, keeping the newest
+    capture_date. NO_DATE panos exist — they just lack a usable date (common
+    for Mapillary's bogus contributor timestamps) — so an OK<->NO_DATE flip
+    must read as a capture-date change, not as a pano removed + added.
+    """
+    present = df[df["status"].isin(PRESENT_STATUSES)].copy()
+    present = present.sort_values("capture_date", na_position="first")
+    return present.drop_duplicates(subset=["pano_id"], keep="last")
 
 
 def _capture_date_str(value) -> str | None:
@@ -87,8 +92,8 @@ def compute_run_diff(df_old: pd.DataFrame, df_new: pd.DataFrame) -> RunDiff:
         (None when the grids don't align), and a detail DataFrame with one
         row per changed pano.
     """
-    old_panos = _unique_ok_panos(df_old).set_index("pano_id")
-    new_panos = _unique_ok_panos(df_new).set_index("pano_id")
+    old_panos = _unique_present_panos(df_old).set_index("pano_id")
+    new_panos = _unique_present_panos(df_new).set_index("pano_id")
 
     old_ids = set(old_panos.index)
     new_ids = set(new_panos.index)

--- a/streetscape_metadata_tracker/download_gsv.py
+++ b/streetscape_metadata_tracker/download_gsv.py
@@ -12,7 +12,7 @@ import aiohttp
 import backoff
 import geopy.distance
 import pandas as pd
-from filelock import FileLock
+from filelock import FileLock, Timeout
 from tqdm import tqdm
 
 from .config import METADATA_DTYPES
@@ -194,7 +194,17 @@ async def process_batch_async(
                 batch_results.append(result)
                 await progress_queue.put(1)
 
-        # Append batch results to the in-progress CSV under a file lock
+        # Every point in this batch failed (all are queued for the retry
+        # pass); an empty DataFrame would KeyError on astype and abort the
+        # whole run for what is usually a transient network blip.
+        if not batch_results:
+            return results
+
+        # Append batch results to the in-progress CSV under a file lock.
+        # The lock FILE is never deleted: removing a path another process
+        # may be locking on lets a third acquirer create a fresh lock and
+        # interleave CSV writes — the exact corruption the lock prevents.
+        # Stale lock files are harmless (excluded from publish).
         df_batch = pd.DataFrame(batch_results)  # First create the DataFrame
         df_batch = df_batch.astype(METADATA_DTYPES)  # Then apply the dtypes
 
@@ -209,21 +219,10 @@ async def process_batch_async(
             raise PermissionError(
                 "FileLock failure: " + create_helpful_permission_error(base_file_path)
             ) from e
-        finally:
-            try:
-                if os.path.exists(lock_file):
-                    os.remove(lock_file)
-            except FileNotFoundError:
-                pass
 
         results.extend(batch_results)
 
     except Exception as e:
-        try:
-            if os.path.exists(lock_file):
-                os.remove(lock_file)
-        except Exception as cleanup_error:
-            logger.error(f"Error cleaning up {lock_file}: {cleanup_error}")
         raise DownloadError(f"Error processing batch: {str(e)}") from e
 
     return results
@@ -293,6 +292,29 @@ async def download_gsv_metadata_async(
     failed_points_file = output_csv_gz_path[: -len(".csv.gz")] + "_failed_points.csv"
 
     Path(os.path.dirname(os.path.abspath(output_csv_gz_path))).mkdir(parents=True, exist_ok=True)
+
+    # Immutable-snapshot guard: a completed run file is never overwritten.
+    # A concurrent second run (e.g. scheduler + manual invocation of the
+    # same city/date) would otherwise share the same .downloading file and
+    # eventually clobber the registered snapshot with partial data.
+    if os.path.exists(file_name_compressed_with_path):
+        raise DownloadError(
+            f"Output file already exists: {file_name_compressed_with_path}. "
+            f"Runs are immutable snapshots; refusing to overwrite. "
+            f"(Same city/provider/run-date already collected?)"
+        )
+
+    # Run-level mutual exclusion, held for the WHOLE run (the per-batch
+    # lock only serializes individual appends). timeout=0: a second
+    # process fails fast instead of queueing behind a multi-hour run.
+    run_lock = FileLock(f"{file_name_downloading_with_path}.runlock", timeout=0)
+    try:
+        run_lock.acquire()
+    except Timeout:
+        raise DownloadError(
+            f"Another process is already collecting {output_csv_gz_path} "
+            f"(run lock held); refusing to run concurrently."
+        ) from None
 
     try:
         # Calculate grid dimensions
@@ -437,4 +459,11 @@ async def download_gsv_metadata_async(
         }
 
     except Exception as e:
-        raise DownloadError(f"Download failed: {str(e)}") from e
+        # Attach the request count so the caller can still record spent
+        # budget in the api_usage ledger — a failed multi-hour run can have
+        # issued 100k+ real (billable) requests.
+        error = DownloadError(f"Download failed: {redact_credentials(e)}")
+        error.api_requests = api_requests
+        raise error from e
+    finally:
+        run_lock.release()

--- a/streetscape_metadata_tracker/download_gsv_history.py
+++ b/streetscape_metadata_tracker/download_gsv_history.py
@@ -111,6 +111,17 @@ class HarvestBlockedError(DownloadError):
     """
 
 
+class HarvestIncompleteError(HarvestBlockedError):
+    """
+    Raised when isolated point failures survive all retry passes (without
+    tripping the breaker). The sweep must NOT finalize: writing the final
+    csv.gz and deleting the checkpoint would silently publish a harvest
+    with holes — and lose the record that anything was skipped — for an
+    endpoint that may disappear before a re-sweep. Subclasses
+    HarvestBlockedError so existing resume/alert handling applies.
+    """
+
+
 def build_search_url(lat: float, lon: float) -> str:
     """URL of the unpublished single-image-search endpoint for a coordinate."""
     return _SEARCH_URL.format(lat=lat, lon=lon)
@@ -275,6 +286,7 @@ async def harvest_gsv_history_async(
     jitter_seconds: tuple[float, float] = (0.2, 0.6),
     chunk_size: int = 25,
     circuit_breaker_limit: int = 8,
+    retry_passes: int = 2,
 ) -> dict[str, Any]:
     """
     Sweep a city's frozen grid and harvest every official Google panorama's
@@ -334,32 +346,43 @@ async def harvest_gsv_history_async(
     headers = {"User-Agent": _USER_AGENT}
     blocked = False
     async with aiohttp.ClientSession(headers=headers) as session:
-        for start in range(0, len(remaining), chunk_size):
-            chunk = remaining[start : start + chunk_size]
-            results = await asyncio.gather(
-                *(query_point(session, lat, lon, i, j) for (lat, lon, i, j) in chunk)
-            )
-            for i, j, lat, lon, found, err in results:
-                progress.update(1)
-                if err is not None:
-                    continue  # failed point; leave it out of `done` to retry
-                done.add((i, j))
-                for p in found:
-                    # First grid point to surface a pano wins its query coords;
-                    # keep the earliest capture_date if the same id recurs.
-                    existing = panos.get(p.pano_id)
-                    if existing is None or p.capture_date < existing["capture_date"]:
-                        panos[p.pano_id] = {
-                            "capture_date": p.capture_date,
-                            "pano_lat": p.lat,
-                            "pano_lon": p.lon,
-                            "nearest_query_lat": lat,
-                            "nearest_query_lon": lon,
-                        }
-            _save_checkpoint(checkpoint, done, panos, api_requests)
-            if breaker.tripped:
-                blocked = True
+        # Initial sweep plus up to `retry_passes` re-sweeps of the points
+        # that failed (isolated failures never re-queried used to be
+        # silently finalized as holes in the harvest).
+        for sweep in range(1 + retry_passes):
+            pending = [(lat, lon, i, j) for (lat, lon, i, j) in remaining if (i, j) not in done]
+            if not pending or blocked:
                 break
+            if sweep > 0:
+                logger.info(
+                    f"Retry pass {sweep}/{retry_passes}: re-querying {len(pending)} failed points"
+                )
+            for start in range(0, len(pending), chunk_size):
+                chunk = pending[start : start + chunk_size]
+                results = await asyncio.gather(
+                    *(query_point(session, lat, lon, i, j) for (lat, lon, i, j) in chunk)
+                )
+                for i, j, lat, lon, found, err in results:
+                    if err is not None:
+                        continue  # failed point; stays out of `done` for the next pass
+                    progress.update(1)
+                    done.add((i, j))
+                    for p in found:
+                        # First grid point to surface a pano wins its query coords;
+                        # keep the earliest capture_date if the same id recurs.
+                        existing = panos.get(p.pano_id)
+                        if existing is None or p.capture_date < existing["capture_date"]:
+                            panos[p.pano_id] = {
+                                "capture_date": p.capture_date,
+                                "pano_lat": p.lat,
+                                "pano_lon": p.lon,
+                                "nearest_query_lat": lat,
+                                "nearest_query_lon": lon,
+                            }
+                _save_checkpoint(checkpoint, done, panos, api_requests)
+                if breaker.tripped:
+                    blocked = True
+                    break
     progress.close()
 
     if blocked:
@@ -367,6 +390,15 @@ async def harvest_gsv_history_async(
             f"Harvest aborted for {city_name}: {breaker.consecutive} consecutive "
             f"failed searches suggest the endpoint is throttling us. Progress "
             f"saved to {checkpoint}; rerun to resume."
+        )
+
+    unfinished = len(grid_points) - len(done)
+    if unfinished > 0:
+        raise HarvestIncompleteError(
+            f"Harvest incomplete for {city_name}: {unfinished} grid points "
+            f"still failed after {retry_passes} retry passes. Refusing to "
+            f"finalize a harvest with holes; progress saved to {checkpoint}; "
+            f"rerun to resume."
         )
 
     harvested_at = datetime.now(UTC).isoformat()

--- a/streetscape_metadata_tracker/download_mapillary.py
+++ b/streetscape_metadata_tracker/download_mapillary.py
@@ -56,10 +56,26 @@ TILE_ZOOM = 14  # the only zoom level whose tiles carry per-image metadata
 TILE_URL_TEMPLATE = "https://tiles.mapillary.com/maps/vtp/mly1_computed_public/2/{z}/{x}/{y}"
 IMAGE_LAYER = "image"
 
-# Meters per degree of latitude (WGS84 mean). Used only for nearest-grid-
-# point assignment, where the <0.1% equirectangular error over a city-sized
-# area is orders of magnitude below half a grid step.
+# Meters per degree of latitude (WGS84 mean). Kept for rough offset math in
+# tests/estimates; the actual grid assignment uses the latitude-local series
+# below (the mean constant mis-assigned edge panos by whole grid rows —
+# ~0.7% error at the equator is +1 row at 2.5 km from center).
 _M_PER_DEG_LAT = 111320.0
+
+
+def _meters_per_degree(lat_deg):
+    """
+    (m_per_deg_lat, m_per_deg_lon) at a latitude, via the standard WGS84
+    series expansion. Accepts scalars or numpy arrays. Matches the geodesic
+    math that builds the grid to well under a meter over a city-sized area,
+    so nearest-grid-point assignment can't drift by rows near the edges.
+    """
+    phi = np.radians(lat_deg)
+    m_lat = (
+        111132.92 - 559.82 * np.cos(2 * phi) + 1.175 * np.cos(4 * phi) - 0.0023 * np.cos(6 * phi)
+    )
+    m_lon = 111412.84 * np.cos(phi) - 93.5 * np.cos(3 * phi) + 0.118 * np.cos(5 * phi)
+    return m_lat, m_lon
 
 
 # ── Slippy-map tile math (stdlib only) ─────────────────────────────────────
@@ -220,8 +236,15 @@ def assign_to_grid(
     than half a step beyond the outermost grid points, which the caller
     drops.
     """
-    dy_m = (image_lats - center_lat) * _M_PER_DEG_LAT
-    dx_m = (image_lons - center_lon) * _M_PER_DEG_LAT * math.cos(math.radians(center_lat))
+    # Latitude-local scales: the grid is built geodesically, so a global
+    # mean m/° mis-assigns by whole rows near the grid edges. dy uses the
+    # series at the center↔image midpoint latitude; dx uses each image's
+    # own latitude (grid rows are constant-latitude, and their east-west
+    # spacing shrinks with cos φ at THAT row, not at the center).
+    m_lat_mid, _ = _meters_per_degree((image_lats + center_lat) / 2)
+    _, m_lon_local = _meters_per_degree(image_lats)
+    dy_m = (image_lats - center_lat) * m_lat_mid
+    dx_m = (image_lons - center_lon) * m_lon_local
     i = np.rint(dy_m / step_length).astype(int)
     j = np.rint(dx_m / step_length).astype(int)
 
@@ -320,8 +343,15 @@ async def download_mapillary_metadata_async(
             headers={"Authorization": f"OAuth {access_token}"}
         ) as session:
             results = await asyncio.gather(*(fetch_one(x, y) for x, y in tiles))
+    except DownloadError as e:
+        # e.g. the rejected-token error from _fetch_tile; attach the spent
+        # request count so the caller can still record it in the ledger.
+        e.api_requests = api_requests
+        raise
     except (TimeoutError, aiohttp.ClientError) as e:
-        raise DownloadError(f"Mapillary tile download failed: {redact_credentials(e)}") from e
+        error = DownloadError(f"Mapillary tile download failed: {redact_credentials(e)}")
+        error.api_requests = api_requests
+        raise error from e
     finally:
         progress_bar.close()
 

--- a/streetscape_metadata_tracker/json_summarizer.py
+++ b/streetscape_metadata_tracker/json_summarizer.py
@@ -540,12 +540,27 @@ def generate_aggregate_v2(conn, data_dir: str) -> dict[str, Any]:
             runs = runs_by_provider[provider]
             latest = runs[-1]
             latest_json = None
-            if latest.json_filename:
-                latest_json = _load_city_json(os.path.join(data_dir, latest.json_filename))
+            json_filename = latest.json_filename
+            if not json_filename:
+                # A crash between register_run and update_run_json_filename
+                # leaves json_filename NULL even though the sibling file may
+                # exist (or be regenerated later by
+                # generate_missing_city_json_files). Fall back to the
+                # derived name so one bad night doesn't drop the provider
+                # from the aggregate forever.
+                derived = latest.csv_filename.rsplit(".csv.gz", 1)[0] + ".json.gz"
+                if os.path.exists(os.path.join(data_dir, derived)):
+                    logger.warning(
+                        f"{city.city_id} [{provider}]: run has no cataloged "
+                        f"json_filename; using derived sibling {derived}"
+                    )
+                    json_filename = derived
+            if json_filename:
+                latest_json = _load_city_json(os.path.join(data_dir, json_filename))
             if latest_json is None:
                 logger.warning(
                     f"Skipping {city.city_id} [{provider}]: missing/unreadable "
-                    f"per-run JSON ({latest.json_filename})"
+                    f"per-run JSON ({json_filename or latest.json_filename})"
                 )
                 continue
             providers_out[provider] = _build_provider_summary(runs, latest_json, data_dir, conn)

--- a/streetscape_metadata_tracker/scheduler.py
+++ b/streetscape_metadata_tracker/scheduler.py
@@ -344,7 +344,6 @@ def _run_one_city(
     cmd = [
         sys.executable,
         str(_PROJECT_ROOT / "streetscape_tracker.py"),
-        city.display_name,
         "--provider",
         provider,
         "--run-date",
@@ -359,10 +358,20 @@ def _run_one_city(
         str(cfg.connection_limit),
         "--timeout",
         str(cfg.request_timeout_s),
+        # The scheduler already decided this city is due (cycle − grace),
+        # so disable the CLI's own skip window. Otherwise any config with
+        # cycle_days − grace_days ≤ the CLI default (80) makes every run
+        # "succeed" as a skip — stamping last_success_at while never
+        # collecting anything, forever, with green logs.
+        "--min-days-since-last-run",
+        "0",
         "--no-visual",
         "--no-publish-json",
         "--log-level",
         "INFO",
+        # '--' so a display name can never be parsed as a flag
+        "--",
+        city.display_name,
     ]
     logger.info(
         f"Collecting {city.city_id} [{provider}] "

--- a/tests/test_cli_policy.py
+++ b/tests/test_cli_policy.py
@@ -1,0 +1,261 @@
+"""Policy-layer tests for cli.py (audit 2026-07-11: previously untested).
+
+These drive the real async_main() with sys.argv patched, the city
+pre-registered (so no geocoding), and the provider downloaders stubbed —
+exercising the skip policy, --force, same-date dedup, the both-provider
+fail-fast, the systemic-failure rejection path (rename + nonzero exit +
+ledger), the immutable-snapshot overwrite refusal, and ledger recording
+for failed downloads. No network.
+"""
+
+import asyncio
+import os
+import sys
+from datetime import date
+
+import pandas as pd
+import pytest
+
+from streetscape_metadata_tracker import cli, db
+from streetscape_metadata_tracker.download_common import DownloadError
+from streetscape_metadata_tracker.fileutils import load_city_csv_file
+from streetscape_metadata_tracker.naming import generate_run_filename
+from tests.conftest import COLUMNS, make_city_df, make_mapillary_city_df, write_city_csv_gz
+
+RUN_DATE = date(2026, 7, 1)
+
+GRID = dict(grid_width_m=100, grid_height_m=100, step_m=20)
+
+
+@pytest.fixture
+def catalog(data_dir):
+    """(conn, city_id, data_dir) with one registered city, frozen geometry."""
+    conn = db.connect(os.path.join(data_dir, "streetscape_tracker.db"))
+    city_id = db.register_city(
+        conn,
+        city_name="Bend",
+        state_name="Oregon",
+        state_code="OR",
+        country_name="United States",
+        country_code="us",
+        center_lat=44.05,
+        center_lon=-121.31,
+        **GRID,
+    )
+    yield conn, city_id, data_dir
+    conn.close()
+
+
+def run_filename(city_id, provider="gsv", run_date=RUN_DATE):
+    base = generate_run_filename(
+        city_id,
+        GRID["grid_width_m"],
+        GRID["grid_height_m"],
+        GRID["step_m"],
+        run_date,
+        provider=provider,
+    )
+    return f"{base}.csv.gz"
+
+
+def run_cli(monkeypatch, city_id, data_dir, *extra, provider="gsv"):
+    """Invoke the real async_main with patched argv; returns its exit code."""
+    argv = [
+        "streetscape_tracker.py",
+        city_id,
+        "--provider",
+        provider,
+        "--download-dir",
+        data_dir,
+        "--run-date",
+        RUN_DATE.isoformat(),
+        "--no-visual",
+        "--no-publish-json",
+        *extra,
+    ]
+    monkeypatch.setattr(sys, "argv", argv)
+    return asyncio.run(cli.async_main())
+
+
+def stub_downloader(calls, df_factory=None, api_requests=25, error=None):
+    """
+    A downloader double honoring the real contract: writes the output
+    csv.gz, returns the result dict (or raises `error`). Records each
+    call's kwargs in `calls`.
+    """
+
+    async def stub(**kwargs):
+        calls.append(kwargs)
+        if error is not None:
+            raise error
+        frame = (df_factory or (lambda: make_city_df([("p1", "2020-05-01")])))()
+        path = kwargs["output_csv_gz_path"]
+        write_city_csv_gz(frame, path)
+        return {
+            "df": load_city_csv_file(path),
+            "filename_with_path": path,
+            "api_requests": api_requests,
+            "started_at": "2026-07-01T00:00:00+00:00",
+            "finished_at": "2026-07-01T00:05:00+00:00",
+        }
+
+    return stub
+
+
+def gsv_configs(monkeypatch):
+    monkeypatch.setattr(cli, "load_config", lambda provider: {"api_key": "k", "access_token": "t"})
+
+
+# ── Skip policy ─────────────────────────────────────────────────────────────
+
+
+def test_skip_when_recent_run(monkeypatch, catalog):
+    conn, city_id, data_dir = catalog
+    db.register_run(
+        conn,
+        city_id=city_id,
+        run_date=date(2026, 6, 21),  # 10 days before RUN_DATE
+        csv_filename=run_filename(city_id, run_date=date(2026, 6, 21)),
+    )
+    calls = []
+    gsv_configs(monkeypatch)
+    monkeypatch.setattr(cli, "download_gsv_metadata_async", stub_downloader(calls))
+
+    assert run_cli(monkeypatch, city_id, data_dir) == 0
+    assert calls == [], "skip policy must prevent any download"
+    assert db.get_latest_run(conn, city_id).run_date == "2026-06-21"
+
+
+def test_force_overrides_skip(monkeypatch, catalog):
+    conn, city_id, data_dir = catalog
+    db.register_run(
+        conn,
+        city_id=city_id,
+        run_date=date(2026, 6, 21),
+        csv_filename=run_filename(city_id, run_date=date(2026, 6, 21)),
+    )
+    calls = []
+    gsv_configs(monkeypatch)
+    monkeypatch.setattr(cli, "download_gsv_metadata_async", stub_downloader(calls))
+
+    assert run_cli(monkeypatch, city_id, data_dir, "--force") == 0
+    assert len(calls) == 1
+    latest = db.get_latest_run(conn, city_id)
+    assert latest.run_date == RUN_DATE.isoformat()
+    # The new run is fully cataloged, with its per-run JSON linked.
+    assert latest.json_filename == run_filename(city_id).replace(".csv.gz", ".json.gz")
+    assert db.get_api_usage(conn, RUN_DATE) == 25
+
+
+def test_same_run_date_is_noop(monkeypatch, catalog):
+    conn, city_id, data_dir = catalog
+    db.register_run(conn, city_id=city_id, run_date=RUN_DATE, csv_filename=run_filename(city_id))
+    calls = []
+    gsv_configs(monkeypatch)
+    monkeypatch.setattr(cli, "download_gsv_metadata_async", stub_downloader(calls))
+
+    # Even --force must not duplicate/overwrite the same-date snapshot.
+    assert run_cli(monkeypatch, city_id, data_dir, "--force") == 0
+    assert calls == []
+
+
+# ── Systemic-failure rejection ──────────────────────────────────────────────
+
+
+def _denied_df(n=20):
+    ts = "2026-07-01T00:00:00+00:00"
+    rows = [
+        (44.0 + i * 0.001, -121.0, ts, None, None, None, None, None, "REQUEST_DENIED")
+        for i in range(n)
+    ]
+    return pd.DataFrame(rows, columns=COLUMNS)
+
+
+def test_rejected_run_renames_exits_nonzero_and_still_records_usage(monkeypatch, catalog):
+    conn, city_id, data_dir = catalog
+    calls = []
+    gsv_configs(monkeypatch)
+    monkeypatch.setattr(
+        cli,
+        "download_gsv_metadata_async",
+        stub_downloader(calls, df_factory=_denied_df, api_requests=400),
+    )
+
+    assert run_cli(monkeypatch, city_id, data_dir) == 1, "scheduler counts failures via exit code"
+    out_path = os.path.join(data_dir, run_filename(city_id))
+    assert not os.path.exists(out_path), "rejected run must not keep the publishable name"
+    assert os.path.exists(f"{out_path}.rejected"), "raw responses kept under .rejected"
+    assert db.get_latest_run(conn, city_id) is None, "rejected run must not be cataloged"
+    # The requests were really spent: the ledger write precedes the guard.
+    assert db.get_api_usage(conn, RUN_DATE) == 400
+
+
+# ── Fail-fast and per-provider isolation ────────────────────────────────────
+
+
+def test_both_providers_fail_fast_before_any_download(monkeypatch, catalog):
+    conn, city_id, data_dir = catalog
+    calls = []
+
+    def configs(provider):
+        if provider == "mapillary":
+            raise ValueError("MAPILLARY_ACCESS_TOKEN not set")
+        return {"api_key": "k"}
+
+    monkeypatch.setattr(cli, "load_config", configs)
+    monkeypatch.setattr(cli, "download_gsv_metadata_async", stub_downloader(calls))
+    monkeypatch.setattr(cli, "download_mapillary_metadata_async", stub_downloader(calls))
+
+    with pytest.raises(SystemExit) as excinfo:
+        run_cli(monkeypatch, city_id, data_dir, provider="both")
+    assert excinfo.value.code == 1
+    # The whole point of fail-fast: GSV must NOT have collected, or the
+    # series would be left unpaired.
+    assert calls == []
+
+
+def test_one_provider_fails_other_continues(monkeypatch, catalog):
+    conn, city_id, data_dir = catalog
+    gsv_calls, mly_calls = [], []
+    gsv_error = DownloadError("Download failed: boom")
+    gsv_error.api_requests = 1234
+    gsv_configs(monkeypatch)
+    monkeypatch.setattr(
+        cli, "download_gsv_metadata_async", stub_downloader(gsv_calls, error=gsv_error)
+    )
+    monkeypatch.setattr(
+        cli,
+        "download_mapillary_metadata_async",
+        stub_downloader(
+            mly_calls,
+            df_factory=lambda: make_mapillary_city_df([("m1", "2023-01-01")]),
+            api_requests=4,
+        ),
+    )
+
+    assert run_cli(monkeypatch, city_id, data_dir, provider="both") == 1
+    assert len(gsv_calls) == 1 and len(mly_calls) == 1
+    # Mapillary's run is cataloged despite GSV failing…
+    assert db.get_latest_run(conn, city_id, provider="mapillary") is not None
+    assert db.get_latest_run(conn, city_id, provider="gsv") is None
+    # …and the failed GSV download's spent requests still hit the ledger.
+    assert db.get_api_usage(conn, RUN_DATE, provider="gsv") == 1234
+    assert db.get_api_usage(conn, RUN_DATE, provider="mapillary") == 4
+
+
+# ── Immutable snapshots ─────────────────────────────────────────────────────
+
+
+def test_refuses_to_overwrite_existing_uncataloged_snapshot(monkeypatch, catalog):
+    conn, city_id, data_dir = catalog
+    out_path = os.path.join(data_dir, run_filename(city_id))
+    with open(out_path, "wb") as f:
+        f.write(b"orphan or concurrent run in flight")
+    calls = []
+    gsv_configs(monkeypatch)
+    monkeypatch.setattr(cli, "download_gsv_metadata_async", stub_downloader(calls))
+
+    assert run_cli(monkeypatch, city_id, data_dir) == 1
+    assert calls == [], "must refuse before issuing any request"
+    with open(out_path, "rb") as f:
+        assert f.read() == b"orphan or concurrent run in flight", "existing file untouched"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,39 @@
+"""load_config tests — the function cli.py's both-provider fail-fast relies on."""
+
+import pytest
+
+from streetscape_metadata_tracker.config import load_config
+
+
+def test_load_config_gsv_requires_only_its_own_key(monkeypatch):
+    monkeypatch.setenv("GMAPS_API_KEY", "test-key")
+    monkeypatch.delenv("MAPILLARY_ACCESS_TOKEN", raising=False)
+    assert load_config("gsv") == {"api_key": "test-key"}
+
+
+def test_load_config_mapillary_requires_only_its_own_token(monkeypatch):
+    monkeypatch.setenv("MAPILLARY_ACCESS_TOKEN", "MLY|test|token")
+    monkeypatch.delenv("GMAPS_API_KEY", raising=False)
+    assert load_config("mapillary") == {"access_token": "MLY|test|token"}
+
+
+@pytest.mark.parametrize(
+    "provider,env_var",
+    [("gsv", "GMAPS_API_KEY"), ("mapillary", "MAPILLARY_ACCESS_TOKEN")],
+)
+def test_load_config_missing_credential_raises_with_var_name(monkeypatch, provider, env_var):
+    monkeypatch.delenv(env_var, raising=False)
+    with pytest.raises(ValueError, match=env_var):
+        load_config(provider)
+
+
+@pytest.mark.parametrize("provider,env_var", [("gsv", "GMAPS_API_KEY")])
+def test_load_config_empty_credential_raises(monkeypatch, provider, env_var):
+    monkeypatch.setenv(env_var, "")
+    with pytest.raises(ValueError, match=env_var):
+        load_config(provider)
+
+
+def test_load_config_unknown_provider_raises():
+    with pytest.raises(ValueError, match="[Uu]nknown provider"):
+        load_config("kartaview")

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -134,6 +134,28 @@ def test_misaligned_grid_skips_point_stats():
     assert d.panos_persisted == 1
 
 
+def test_ok_to_no_date_flip_is_a_date_change_not_churn():
+    # A pano whose date disappears (OK -> NO_DATE, common for Mapillary's
+    # bogus contributor timestamps) is still present in both runs: it must
+    # count as persisted + capture_date_changed, never as removed + added.
+    old = _two_point_df("OK", "b", "2021-03-01")
+    new = _two_point_df("NO_DATE", "b", None)
+    d = compute_run_diff(old, new)
+    assert (d.panos_added, d.panos_removed, d.panos_persisted) == (0, 0, 2)
+    assert d.capture_date_changed == 1
+    row = d.detail[d.detail["change_type"] == "capture_date_changed"].iloc[0]
+    assert row["old_capture_date"] == "2021-03-01"
+    assert row["new_capture_date"] is None
+
+
+def test_no_date_to_ok_flip_is_a_date_change_not_churn():
+    old = _two_point_df("NO_DATE", "b", None)
+    new = _two_point_df("OK", "b", "2026-05-01")
+    d = compute_run_diff(old, new)
+    assert (d.panos_added, d.panos_removed) == (0, 0)
+    assert d.capture_date_changed == 1
+
+
 def test_duplicate_pano_ids_deduped_keeping_newest_date():
     old = make_city_df([("p1", "2020-05-01"), ("p1", "2022-03-01")])
     new = make_city_df([("p1", "2022-03-01")])

--- a/tests/test_download_guard.py
+++ b/tests/test_download_guard.py
@@ -1,0 +1,52 @@
+"""Run-level guards in download_gsv_metadata_async (audit 2026-07-11).
+
+A scheduler run and a manual run of the same (city, provider, run_date)
+used to share the same .downloading file and could silently overwrite a
+registered, published snapshot with partial data. Both guards fire before
+any network request, so these tests need no HTTP mocking.
+"""
+
+import asyncio
+
+import pytest
+from filelock import FileLock
+
+from streetscape_metadata_tracker.download_common import DownloadError
+from streetscape_metadata_tracker.download_gsv import download_gsv_metadata_async
+
+
+def _run(out_path):
+    return asyncio.run(
+        download_gsv_metadata_async(
+            city_name="Test City",
+            center_lat=44.0,
+            center_lon=-121.0,
+            grid_width=100,
+            grid_height=100,
+            step_length=20,
+            api_key="unused-guards-fire-first",
+            output_csv_gz_path=str(out_path),
+        )
+    )
+
+
+def test_refuses_to_overwrite_existing_snapshot(tmp_path):
+    out = tmp_path / "t_width_100_height_100_step_20_2026-07-01.csv.gz"
+    out.write_bytes(b"registered snapshot")
+    with pytest.raises(DownloadError, match="refusing to overwrite"):
+        _run(out)
+    assert out.read_bytes() == b"registered snapshot", "existing snapshot untouched"
+
+
+def test_refuses_concurrent_run_on_same_output(tmp_path):
+    out = tmp_path / "t_width_100_height_100_step_20_2026-07-01.csv.gz"
+    # Simulate another process mid-run: it holds the run-level lock.
+    other = FileLock(
+        str(tmp_path / "t_width_100_height_100_step_20_2026-07-01.csv.downloading.runlock")
+    )
+    other.acquire()
+    try:
+        with pytest.raises(DownloadError, match="[Aa]nother process"):
+            _run(out)
+    finally:
+        other.release()

--- a/tests/test_gsv_history.py
+++ b/tests/test_gsv_history.py
@@ -7,6 +7,7 @@ mocked), so there is no network access.
 import asyncio
 import json
 import os
+import re
 import sys
 from datetime import date
 
@@ -469,3 +470,80 @@ def test_harvest_blocks_and_leaves_checkpoint_then_resumes(monkeypatch, tmp_path
     assert result["unique_panos"] == 1
     assert os.path.exists(out)
     assert not os.path.exists(out + ".harvesting")
+
+
+# ── Isolated-failure retry / refuse-to-finalize (audit 2026-07-11) ─────────
+
+
+def _point_from_url(url):
+    """Extract the (lat, lon) a search URL queries."""
+    m = re.search(r"!3d([-\d.]+)!4d([-\d.]+)!", url)
+    return float(m.group(1)), float(m.group(2))
+
+
+def test_isolated_failure_is_retried_within_the_run(monkeypatch, tmp_path):
+    """One transient failure (far below the breaker limit) must be re-queried
+    by the in-run retry pass, not silently finalized as a hole."""
+    response = make_response(undated=[], dated=[("g1", 44.05, -121.31, (2020, 1))])
+    state = {"calls": 0, "failed_once": False}
+
+    def responder(url):
+        state["calls"] += 1
+        if not state["failed_once"]:
+            state["failed_once"] = True
+            raise aiohttp.ClientError("transient blip")
+        return response
+
+    _patch_fetch(monkeypatch, responder)
+    out = str(tmp_path / "bend_gsv_history_2026-07-08.csv.gz")
+    result = asyncio.run(
+        dgh.harvest_gsv_history_async(
+            city_name="Bend",
+            center_lat=44.05,
+            center_lon=-121.31,
+            grid_width=40,
+            grid_height=40,
+            step_length=20,
+            output_csv_gz_path=out,
+            jitter_seconds=(0.0, 0.0),
+        )
+    )
+    assert result["unique_panos"] == 1
+    assert state["calls"] == 10  # 9 points + 1 retry of the failed one
+    assert os.path.exists(out)
+    assert not os.path.exists(out + ".harvesting")  # complete → checkpoint gone
+
+
+def test_refuses_to_finalize_harvest_with_holes(monkeypatch, tmp_path):
+    """A point that fails every retry pass (without tripping the breaker)
+    must abort finalization: no final csv.gz, checkpoint kept for resume —
+    previously the sweep 'completed', published the holey harvest, and
+    deleted the checkpoint, permanently losing the failed points."""
+    response = make_response(undated=[], dated=[("g1", 44.05, -121.31, (2020, 1))])
+
+    def responder(url):
+        lat, lon = _point_from_url(url)
+        if abs(lat - 44.05) < 1e-9 and abs(lon - (-121.31)) < 1e-9:
+            raise aiohttp.ClientError("this one point always fails")
+        return response
+
+    _patch_fetch(monkeypatch, responder)
+    out = str(tmp_path / "bend_gsv_history_2026-07-08.csv.gz")
+    with pytest.raises(dgh.HarvestIncompleteError, match="1 grid points"):
+        asyncio.run(
+            dgh.harvest_gsv_history_async(
+                city_name="Bend",
+                center_lat=44.05,
+                center_lon=-121.31,
+                grid_width=40,
+                grid_height=40,
+                step_length=20,
+                output_csv_gz_path=out,
+                jitter_seconds=(0.0, 0.0),
+            )
+        )
+    assert not os.path.exists(out), "must not publish a harvest with holes"
+    assert os.path.exists(out + ".harvesting"), "checkpoint kept for resume"
+    # HarvestIncompleteError extends HarvestBlockedError so existing
+    # operator handling (resume messaging) applies unchanged.
+    assert issubclass(dgh.HarvestIncompleteError, dgh.HarvestBlockedError)

--- a/tests/test_json_v2.py
+++ b/tests/test_json_v2.py
@@ -510,3 +510,85 @@ def test_aggregate_v3_two_providers(conn, data_dir):
     assert hists["mapillary"]["google_panos_yearly"] == {}
 
     strict_load(os.path.join(data_dir, "cities.json.gz"))
+
+
+def test_aggregate_falls_back_to_derived_json_when_not_cataloged(conn, data_dir):
+    """
+    A crash between register_run and update_run_json_filename leaves
+    runs.json_filename NULL while the sibling json.gz exists (or is later
+    regenerated). The aggregate must fall back to the derived sibling name
+    instead of silently dropping the provider from cities.json.gz forever
+    (audit 2026-07-11).
+    """
+    city_id = db.register_city(
+        conn,
+        city_name="Crashy",
+        state_name=None,
+        state_code=None,
+        country_name="Testland",
+        country_code=None,
+        center_lat=44.0,
+        center_lon=-121.0,
+        grid_width_m=100,
+        grid_height_m=100,
+        step_m=20,
+    )
+    name = f"{city_id}_width_100_height_100_step_20_2026-01-15.csv.gz"
+    csv_path = _write_run(data_dir, [("g1", "2020-01-15")], date(2026, 1, 15), name)
+    df = load_city_csv_file(csv_path)
+    # The per-run JSON exists on disk at the derived name…
+    generate_city_metadata_summary_as_json(
+        csv_path,
+        df,
+        "Crashy",
+        None,
+        "Testland",
+        100,
+        100,
+        20,
+        force_recreate_file=True,
+        run_date=date(2026, 1, 15),
+    )
+    # …but the crash meant it was never linked in the catalog.
+    db.register_run(
+        conn,
+        city_id=city_id,
+        run_date=date(2026, 1, 15),
+        csv_filename=name,
+        json_filename=None,
+        unique_panos=1,
+        unique_google_panos=1,
+    )
+
+    summary = generate_aggregate_v2(conn, data_dir)
+    rec = next(c for c in summary["cities"] if c["city_id"] == city_id)
+    assert "gsv" in rec["providers"], "provider must not be dropped from the aggregate"
+    assert rec["providers"]["gsv"]["latest"]["panorama_counts"]["unique_panos"] == 1
+
+
+def test_aggregate_still_skips_provider_when_json_truly_missing(conn, data_dir):
+    """No cataloged json_filename AND no sibling file → provider skipped (not a crash)."""
+    city_id = db.register_city(
+        conn,
+        city_name="Gone",
+        state_name=None,
+        state_code=None,
+        country_name="Testland",
+        country_code=None,
+        center_lat=44.0,
+        center_lon=-121.0,
+        grid_width_m=100,
+        grid_height_m=100,
+        step_m=20,
+    )
+    db.register_run(
+        conn,
+        city_id=city_id,
+        run_date=date(2026, 1, 15),
+        csv_filename=f"{city_id}_width_100_height_100_step_20_2026-01-15.csv.gz",
+        json_filename=None,
+        unique_panos=1,
+        unique_google_panos=1,
+    )
+    summary = generate_aggregate_v2(conn, data_dir)
+    assert all(c["city_id"] != city_id for c in summary["cities"])

--- a/tests/test_mapillary.py
+++ b/tests/test_mapillary.py
@@ -413,3 +413,45 @@ def test_download_pano_outside_grid_is_dropped(monkeypatch, tmp_path):
     tiles = {(x, y): encode_tile([make_image(201, far_lon, lat)], x, y)}
     result, _ = _run_download(monkeypatch, tmp_path, tiles, lat, lon)
     assert (result["df"]["status"] == "ZERO_RESULTS").all()
+
+
+# ── Latitude-local grid assignment accuracy (audit 2026-07-11, M2) ──────────
+
+
+def test_assign_to_grid_matches_geodesic_grid_far_from_center_at_equator():
+    """A pano EXACTLY at grid point (i=120, j=0) — placed with the same
+    geodesic math that builds the grid — must assign to i=120. The old
+    global-mean 111,320 m/° overstated equatorial dy by ~0.67% (true
+    ≈110,574 m/°), i.e. +0.8 rows at 2.4 km from center → i=121."""
+    origin = geopy.Point(0.0, 30.0)
+    north = geopy.distance.distance(meters=120 * 20).destination(origin, 0)
+    i, j, in_grid = dm.assign_to_grid(
+        np.array([north.latitude]),
+        np.array([north.longitude]),
+        0.0,
+        30.0,
+        width_steps=250,
+        height_steps=250,
+        step_length=20,
+    )
+    assert (int(i[0]), int(j[0])) == (120, 0)
+    assert bool(in_grid[0])
+
+
+def test_assign_to_grid_matches_geodesic_grid_far_corner_mid_latitude():
+    """Same check at Seattle's latitude on a far corner point (i=120, j=120),
+    exercising both the dy series and the per-row cos-latitude dx scale."""
+    lat0, lon0 = 47.6, -122.3
+    north = geopy.distance.distance(meters=120 * 20).destination(geopy.Point(lat0, lon0), 0)
+    corner = geopy.distance.distance(meters=120 * 20).destination(north, 90)
+    i, j, in_grid = dm.assign_to_grid(
+        np.array([corner.latitude]),
+        np.array([corner.longitude]),
+        lat0,
+        lon0,
+        width_steps=250,
+        height_steps=250,
+        step_length=20,
+    )
+    assert (int(i[0]), int(j[0])) == (120, 120)
+    assert bool(in_grid[0])

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -30,6 +30,40 @@ def _register(conn, name, width=5000, height=5000, step=20):
     )
 
 
+def test_run_one_city_command_defers_skip_policy_to_scheduler(conn, monkeypatch):
+    """
+    The scheduler already decided this city is due (cycle − grace), so the
+    subprocess must run with --min-days-since-last-run 0: otherwise any
+    config with cycle_days − grace_days ≤ the CLI default (80) makes every
+    run "succeed" as a skip — stamping last_success_at while never
+    collecting anything. The city name must also follow '--' so a display
+    name starting with '-' can't be parsed as a flag.
+    """
+    from streetscape_metadata_tracker import scheduler as sched
+
+    cid = _register(conn, "Bend")
+    city = db.resolve_city(conn, cid)
+
+    captured = {}
+
+    def fake_run(cmd, timeout=None, cwd=None):
+        captured["cmd"] = cmd
+
+        class R:
+            returncode = 0
+
+        return R()
+
+    monkeypatch.setattr(sched.subprocess, "run", fake_run)
+    assert sched._run_one_city(SchedulerConfig(), city, date(2026, 7, 1), "gsv")
+
+    cmd = captured["cmd"]
+    i = cmd.index("--min-days-since-last-run")
+    assert cmd[i + 1] == "0"
+    assert cmd[cmd.index("--") + 1] == city.display_name
+    assert cmd[-1] == city.display_name
+
+
 def test_estimate_requests_matches_grid_math(conn):
     cid = _register(conn, "Bend", width=1000, height=1000, step=20)
     city = db.resolve_city(conn, cid)

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -1,0 +1,429 @@
+"""
+Statistics-calculation tests (analysis.py + the stat-shaped json_summarizer
+helpers), extending tests/test_coverage.py and tests/test_run_guard.py.
+
+Every expected value is hand-computed and written as a literal, with the
+arithmetic in a comment — never derived by mirroring the implementation.
+Ages divide day-deltas by 365.25, so capture dates are chosen so the span
+crosses exactly span/4 leap days and the age comes out exact (e.g.
+2022-01-15 → 2026-01-15 is 1461 days = 4.0 * 365.25 → exactly 4.0 years).
+"""
+
+from datetime import date
+
+import pandas as pd
+import pytest
+
+from streetscape_metadata_tracker.analysis import (
+    calculate_coverage_stats,
+    calculate_pano_stats,
+    calculate_run_stats,
+)
+from streetscape_metadata_tracker.download_common import standardize_capture_date
+from streetscape_metadata_tracker.json_summarizer import merge_capture_date_histograms
+from tests.conftest import COLUMNS, make_city_df
+
+RUN_DATE = date(2026, 1, 15)
+NOW = pd.Timestamp(RUN_DATE)
+
+# Capture dates whose ages at RUN_DATE are exact (span crosses span/4 leap days):
+#   2022-01-15 → 2026-01-15 = 365+365+366+365 = 1461 d = 4.0 * 365.25 → 4.0 y
+#   2018-01-15 → 2026-01-15 = 8*365 + 2 (Feb 2020, 2024) = 2922 d      → 8.0 y
+#   2014-01-15 → 2026-01-15 = 12*365 + 3 (2016, 2020, 2024) = 4383 d   → 12.0 y
+CAPTURE_4Y = "2022-01-15"
+CAPTURE_8Y = "2018-01-15"
+CAPTURE_12Y = "2014-01-15"
+
+
+# ── AgeStats: hand-computed median/avg/stdev/percentiles ────────────────────
+
+
+def test_age_stats_three_panos_hand_computed():
+    """Ages 4.0, 8.0, 12.0 years: every AgeStats field checked by hand."""
+    df = make_city_df([("a", CAPTURE_4Y), ("b", CAPTURE_8Y), ("c", CAPTURE_12Y)])
+    ages = calculate_pano_stats(df, NOW).age_stats
+
+    assert ages.count == 3
+    # min/max of the capture dates, as Timestamp.isoformat()
+    assert ages.oldest_pano_date == "2014-01-15T00:00:00"
+    assert ages.newest_pano_date == "2022-01-15T00:00:00"
+    # mean = (4 + 8 + 12) / 3 = 8.0; median = middle of {4, 8, 12} = 8.0
+    assert ages.avg_pano_age_years == pytest.approx(8.0, abs=1e-9)
+    assert ages.median_pano_age_years == pytest.approx(8.0, abs=1e-9)
+    # SAMPLE stdev (ddof=1): sqrt(((4-8)^2 + 0 + (12-8)^2) / (3-1)) = sqrt(16) = 4.0.
+    # The population stdev would be sqrt(32/3) = 3.2659... — must NOT match.
+    assert ages.stdev_pano_age_years == pytest.approx(4.0, abs=1e-9)
+    assert ages.stdev_pano_age_years != pytest.approx(3.2659863, abs=1e-3)
+    # Linear-interpolated percentiles over sorted [4, 8, 12] (index = q * 2):
+    #   p10: idx 0.2 → 4 + 0.2*(8-4) = 4.8      p25: idx 0.5 → 4 + 0.5*4 = 6.0
+    #   p75: idx 1.5 → 8 + 0.5*(12-8) = 10.0    p90: idx 1.8 → 8 + 0.8*4 = 11.2
+    pct = ages.age_percentiles_years
+    assert pct["p10"] == pytest.approx(4.8, abs=1e-9)
+    assert pct["p25"] == pytest.approx(6.0, abs=1e-9)
+    assert pct["p75"] == pytest.approx(10.0, abs=1e-9)
+    assert pct["p90"] == pytest.approx(11.2, abs=1e-9)
+
+
+def test_single_pano_age_stats():
+    """1 pano: avg == median == its age, stdev None (sample stdev of n=1 is
+    undefined — NaN under ddof=1 — and must surface as None, not NaN/0),
+    every percentile equals the single age, oldest == newest."""
+    df = make_city_df([("solo", CAPTURE_4Y)])
+    ages = calculate_pano_stats(df, NOW).age_stats
+
+    assert ages.count == 1
+    assert ages.avg_pano_age_years == pytest.approx(4.0, abs=1e-9)
+    assert ages.median_pano_age_years == pytest.approx(4.0, abs=1e-9)
+    assert ages.stdev_pano_age_years is None
+    assert ages.oldest_pano_date == ages.newest_pano_date == "2022-01-15T00:00:00"
+    for p in ("p10", "p25", "p75", "p90"):
+        assert ages.age_percentiles_years[p] == pytest.approx(4.0, abs=1e-9)
+
+
+def test_single_pano_distance_stdev_is_zero_not_none():
+    """DistanceStats deliberately uses 0.0 (not None) for the n=1 stdev —
+    the opposite convention from AgeStats — so pin both here.
+
+    conftest offsets each pano 0.0001° in lat and lon from its query point:
+    dist = sqrt(0.0001^2 + 0.0001^2) * 111000 = 0.0001 * 1.4142136 * 111000
+         = 15.6978 m.
+    """
+    df = make_city_df([("solo", CAPTURE_4Y)])
+    dist = calculate_coverage_stats(df).pano_distance_stats
+
+    assert dist is not None
+    assert dist.stdev_meters == 0.0
+    assert dist.min_meters == pytest.approx(15.6978, abs=1e-3)
+    assert dist.max_meters == pytest.approx(15.6978, abs=1e-3)
+    assert dist.avg_meters == pytest.approx(15.6978, abs=1e-3)
+    assert dist.median_meters == pytest.approx(15.6978, abs=1e-3)
+
+
+def test_zero_pano_run_all_stats_none_not_nan():
+    """A run that found no imagery at all: age fields are None (never NaN,
+    never 0), distributions empty, counts zero, coverage exactly 0.0."""
+    df = make_city_df([], n_empty=3)  # 3 grid points, all ZERO_RESULTS
+
+    results = calculate_pano_stats(df, NOW)
+    ages = results.age_stats
+    assert ages.count == 0
+    assert ages.oldest_pano_date is None
+    assert ages.newest_pano_date is None
+    assert ages.avg_pano_age_years is None
+    assert ages.median_pano_age_years is None
+    assert ages.stdev_pano_age_years is None
+    assert ages.age_percentiles_years is None  # None, not a dict of Nones
+    assert results.yearly_distribution.counts == {}
+    assert results.daily_distribution.counts == {}
+    dup = results.duplicate_stats
+    assert dup.total_unique_panos == 0
+    assert dup.total_pano_references == 0
+    assert dup.most_referenced_count == 0
+    assert dup.average_references_per_pano == 0
+
+    stats = calculate_run_stats(df, RUN_DATE)
+    assert stats["total_points"] == 3
+    assert stats["status_zero_results"] == 3
+    assert stats["unique_panos"] == 0
+    assert stats["unique_google_panos"] == 0  # known-empty, not unknown
+    assert stats["coverage_rate_pct"] == 0.0
+    assert stats["oldest_capture_date"] is None
+    assert stats["newest_capture_date"] is None
+    assert stats["median_pano_age_years"] is None
+
+
+# ── Date math: run_date pinning, leap years, fractional ages ────────────────
+
+
+def test_ages_pinned_to_run_date_not_wall_clock():
+    """The same frame under two run_dates one calendar year apart must shift
+    every age by exactly 365/365.25 (2026 has no leap day) — and repeated
+    calls with the same run_date must be byte-identical. If any stat leaked
+    datetime.now(), the exact 4.0/8.0 medians asserted elsewhere in this
+    file (valid only relative to run_date) would already fail."""
+    df = make_city_df([("a", CAPTURE_4Y), ("b", CAPTURE_8Y)])
+
+    stats_2026 = calculate_run_stats(df, date(2026, 1, 15))
+    stats_2027 = calculate_run_stats(df, date(2027, 1, 15))
+    # median at 2026-01-15: (4.0 + 8.0) / 2 = 6.0 exactly
+    assert stats_2026["median_pano_age_years"] == pytest.approx(6.0, abs=1e-9)
+    # 2026-01-15 → 2027-01-15 = 365 days = 365/365.25 = 0.9993155 years
+    delta = stats_2027["median_pano_age_years"] - stats_2026["median_pano_age_years"]
+    assert delta == pytest.approx(0.9993155, abs=1e-6)
+
+    # Determinism: same inputs → identical output dict, run after run
+    assert calculate_run_stats(df, date(2026, 1, 15)) == stats_2026
+
+
+def test_leap_year_alters_one_calendar_year_age():
+    """One calendar year is NOT always 1.0 'years' (365.25-day years):
+    2023-07-01 → 2024-07-01 spans Feb 29 2024 = 366 d = 366/365.25 = 1.0020534,
+    2024-07-01 → 2025-07-01 spans no leap day = 365 d = 365/365.25 = 0.9993155.
+    """
+    df = make_city_df([("a", "2023-07-01")])
+    stats = calculate_run_stats(df, date(2024, 7, 1))
+    assert stats["median_pano_age_years"] == pytest.approx(1.0020534, abs=1e-6)
+
+    df = make_city_df([("a", "2024-07-01")])
+    stats = calculate_run_stats(df, date(2025, 7, 1))
+    assert stats["median_pano_age_years"] == pytest.approx(0.9993155, abs=1e-6)
+
+
+def test_pano_captured_on_run_date_has_age_zero():
+    """A pano captured on the run date is exactly 0.0 years old (dates and
+    run_date both resolve to midnight — no intra-day wall-clock component)."""
+    df = make_city_df([("fresh", "2026-01-15")])
+    stats = calculate_run_stats(df, RUN_DATE)
+    assert stats["median_pano_age_years"] == 0.0
+
+
+def test_fractional_age_92_days():
+    """2025-10-15 → 2026-01-15 = 16 (Oct) + 30 (Nov) + 31 (Dec) + 15 (Jan)
+    = 92 days = 92/365.25 = 0.2518823 years."""
+    df = make_city_df([("a", "2025-10-15")])
+    stats = calculate_run_stats(df, RUN_DATE)
+    assert stats["median_pano_age_years"] == pytest.approx(0.2518823, abs=1e-6)
+
+
+# ── Reduced-precision capture dates (standardize_capture_date) ──────────────
+
+
+def test_standardize_capture_date_leap_and_invalid_calendar_boundaries():
+    """Calendar-validity boundaries beyond the basic format cases already in
+    test_download_common: real leap day kept, impossible dates rejected
+    outright (never silently coerced to a nearby valid date)."""
+    assert standardize_capture_date("2024-02-29") == "2024-02-29"  # 2024 is leap
+    assert standardize_capture_date("2023-02-29") is None  # 2023 is not
+    assert standardize_capture_date("2024-02-30") is None  # never a real day
+    assert standardize_capture_date("2024-13") is None  # month 13
+    assert standardize_capture_date("2024-00") is None  # month 0
+
+
+def test_year_precision_capture_date_age_integration():
+    """A year-only provider date is pinned to Jan 1, and the age math then
+    treats it like any full date: '2022' → 2022-01-01, and
+    2022-01-01 → 2026-01-01 = 365+365+366+365 = 1461 d = exactly 4.0 y."""
+    normalized = standardize_capture_date("2022")
+    assert normalized == "2022-01-01"
+    df = make_city_df([("y", normalized)])
+    stats = calculate_run_stats(df, date(2026, 1, 1))
+    assert stats["median_pano_age_years"] == pytest.approx(4.0, abs=1e-9)
+
+
+def test_month_precision_capture_date_age_integration():
+    """A month-only date is pinned to the 1st; captured 'this month' on a
+    run dated the 1st means age exactly 0.0."""
+    normalized = standardize_capture_date("2024-05")
+    assert normalized == "2024-05-01"
+    df = make_city_df([("m", normalized)])
+    stats = calculate_run_stats(df, date(2024, 5, 1))
+    assert stats["median_pano_age_years"] == 0.0
+
+
+# ── Run stats: status breakdown, duplicates, copyright subsets ──────────────
+
+
+def _row(lat, pano_id, capture, copyright_info, status):
+    ts = "2026-01-15T12:00:00+00:00"
+    if status in ("OK", "NO_DATE"):
+        return (lat, -121.0, ts, lat + 0.0001, -120.9999, pano_id, capture, copyright_info, status)
+    return (lat, -121.0, ts, None, None, None, None, None, status)
+
+
+def test_run_stats_status_breakdown_with_errors():
+    """5 grid points, one per status flavor: the four status counters must
+    partition total_points, and error rows join neither coverage nor panos."""
+    df = pd.DataFrame(
+        [
+            _row(44.000, "a", CAPTURE_4Y, "© Google", "OK"),
+            _row(44.001, "b", None, "© Google", "NO_DATE"),
+            _row(44.002, None, None, None, "ZERO_RESULTS"),
+            _row(44.003, None, None, None, "REQUEST_DENIED"),
+            _row(44.004, None, None, None, "ERROR"),
+        ],
+        columns=COLUMNS,
+    )
+    stats = calculate_run_stats(df, RUN_DATE)
+    assert stats["total_points"] == 5
+    assert stats["status_ok"] == 1
+    assert stats["status_no_date"] == 1
+    assert stats["status_zero_results"] == 1
+    assert stats["status_other"] == 2  # REQUEST_DENIED + ERROR
+    assert stats["unique_panos"] == 2  # a + b; error rows carry no pano
+    # coverage: 2 covered points / 5 total = 40%
+    assert stats["coverage_rate_pct"] == pytest.approx(40.0, abs=1e-9)
+    # age from the single dated pano: 2022-01-15 → 2026-01-15 = exactly 4.0 y
+    assert stats["median_pano_age_years"] == pytest.approx(4.0, abs=1e-9)
+
+    cov = calculate_coverage_stats(df)
+    assert cov.num_points_with_errors == 2
+
+
+def test_duplicate_pano_counted_once_in_ages_and_counts():
+    """Pano 'a' snapped from two adjacent grid points must contribute its age
+    ONCE: dedup gives ages {8.0, 4.0} → mean = (8+4)/2 = 6.0, not the
+    reference-weighted (8+8+4)/3 = 6.67."""
+    df = make_city_df([("a", CAPTURE_8Y), ("a", CAPTURE_8Y), ("b", CAPTURE_4Y)])
+
+    results = calculate_pano_stats(df, NOW)
+    ages = results.age_stats
+    assert ages.count == 2
+    assert ages.avg_pano_age_years == pytest.approx(6.0, abs=1e-9)
+    assert ages.median_pano_age_years == pytest.approx(6.0, abs=1e-9)
+    # sample stdev of {8, 4}: sqrt(((8-6)^2 + (4-6)^2) / 1) = sqrt(8) = 2.8284271
+    assert ages.stdev_pano_age_years == pytest.approx(2.8284271, abs=1e-6)
+    # capture-year histogram also deduplicated: one 2018, one 2022
+    assert results.yearly_distribution.counts == {2018: 1, 2022: 1}
+
+    dup = results.duplicate_stats
+    assert dup.total_unique_panos == 2
+    assert dup.total_pano_references == 3
+    assert dup.duplicate_reference_count == 1  # 3 refs - 2 unique
+    assert dup.most_referenced_count == 2  # 'a' seen from 2 points
+    assert dup.panos_with_multiple_refs == 1  # just 'a'
+    assert dup.average_references_per_pano == pytest.approx(1.5, abs=1e-9)  # 3/2
+
+    stats = calculate_run_stats(df, RUN_DATE)
+    assert stats["unique_panos"] == 2
+    assert stats["unique_google_panos"] == 2  # 'a' google-counted once too
+    assert stats["median_pano_age_years"] == pytest.approx(6.0, abs=1e-9)
+
+
+def test_all_no_date_run_counts_panos_but_ages_are_none():
+    """A run whose every pano is dateless: pano/coverage totals populated,
+    every date-derived stat None (there is no dated subset at all)."""
+    df = pd.DataFrame(
+        [
+            _row(44.000, "nd1", None, "© Google", "NO_DATE"),
+            _row(44.001, "nd2", None, "© Google", "NO_DATE"),
+            _row(44.002, None, None, None, "ZERO_RESULTS"),
+        ],
+        columns=COLUMNS,
+    )
+    stats = calculate_run_stats(df, RUN_DATE)
+    assert stats["status_no_date"] == 2
+    assert stats["unique_panos"] == 2
+    assert stats["unique_google_panos"] == 2
+    # 2 covered points / 3 = 66.667%
+    assert stats["coverage_rate_pct"] == pytest.approx(100 * 2 / 3, abs=1e-9)
+    assert stats["oldest_capture_date"] is None
+    assert stats["newest_capture_date"] is None
+    assert stats["median_pano_age_years"] is None
+
+    results = calculate_pano_stats(df, NOW)
+    assert results.duplicate_stats.total_unique_panos == 2  # headline count kept
+    assert results.age_stats.count == 0  # dated subset is empty
+    assert results.age_stats.median_pano_age_years is None
+    assert results.yearly_distribution.counts == {}
+
+
+def test_unique_google_panos_with_partially_null_copyright():
+    """unique_google_panos is None only when copyright is entirely unrecorded;
+    a MIX of null and real copyrights is a known subset — null rows simply
+    compare False, so only the exact '© Google' pano counts: 1 of 2."""
+    df = pd.DataFrame(
+        [
+            _row(44.000, "g", CAPTURE_4Y, "© Google", "OK"),
+            _row(44.001, "u", CAPTURE_8Y, None, "OK"),
+            _row(44.002, None, None, None, "ZERO_RESULTS"),
+        ],
+        columns=COLUMNS,
+    )
+    stats = calculate_run_stats(df, RUN_DATE)
+    assert stats["unique_panos"] == 2
+    assert stats["unique_google_panos"] == 1
+
+
+def test_google_only_age_stats_exclude_third_party():
+    """google_only recomputes the date stats over the '© Google' subset:
+    all-panos mean = (4+8)/2 = 6.0, google-only mean = 4.0 (the 8-year pano
+    is a third-party photographer whose name merely contains 'Google')."""
+    df = pd.DataFrame(
+        [
+            _row(44.000, "g1", CAPTURE_4Y, "© Google", "OK"),
+            _row(44.001, "t1", CAPTURE_8Y, "© MIB 360 - Google Virtual Tours Agency", "OK"),
+            _row(44.002, None, None, None, "ZERO_RESULTS"),
+        ],
+        columns=COLUMNS,
+    )
+    all_stats = calculate_pano_stats(df, NOW)
+    assert all_stats.age_stats.avg_pano_age_years == pytest.approx(6.0, abs=1e-9)
+    assert all_stats.duplicate_stats.total_unique_panos == 2
+    assert all_stats.yearly_distribution.counts == {2018: 1, 2022: 1}
+
+    google_stats = calculate_pano_stats(df, NOW, google_only=True)
+    assert google_stats.age_stats.count == 1
+    assert google_stats.age_stats.avg_pano_age_years == pytest.approx(4.0, abs=1e-9)
+    assert google_stats.duplicate_stats.total_unique_panos == 1
+    assert google_stats.yearly_distribution.counts == {2022: 1}
+    assert google_stats.photographer_stats.photographer_counts == {"© Google": 1}
+
+
+# ── json_summarizer.merge_capture_date_histograms ───────────────────────────
+
+
+def _city(all_yearly, all_daily, google_yearly=None, google_daily=None):
+    data = {
+        "all_panos": {
+            "histogram_of_capture_dates_by_year": all_yearly,
+            "histogram_of_capture_dates": all_daily,
+        }
+    }
+    if google_yearly is not None:
+        data["google_panos"] = {
+            "histogram_of_capture_dates_by_year": google_yearly,
+            "histogram_of_capture_dates": google_daily,
+        }
+    return data
+
+
+def test_merge_histograms_sums_counts_and_accepts_both_shapes():
+    """City A uses the current {'counts': {...}} shape, city B the bare-dict
+    legacy shape and has no google_panos section (non-GSV): 2019=2, 2020=3+5=8,
+    2021=7; yearly keys become sorted ints, daily keys stay ISO strings."""
+    city_a = _city(
+        {"counts": {"2019": 2, "2020": 3}},
+        {"counts": {"2019-05-01": 2, "2020-06-01": 3}},
+        google_yearly={"counts": {"2019": 1}},
+        google_daily={"counts": {"2019-05-01": 1}},
+    )
+    city_b = _city(
+        {"2021": 7, "2020": 5},
+        {"2021-07-01": 7, "2020-06-01": 5},
+    )
+    merged = merge_capture_date_histograms([city_a, city_b])
+
+    assert merged["all_panos_yearly"] == {2019: 2, 2020: 8, 2021: 7}
+    assert list(merged["all_panos_yearly"]) == [2019, 2020, 2021]  # sorted
+    assert merged["all_panos_daily"] == {"2019-05-01": 2, "2020-06-01": 8, "2021-07-01": 7}
+    # google sections only merge from the city that has them
+    assert merged["google_panos_yearly"] == {2019: 1}
+    assert merged["google_panos_daily"] == {"2019-05-01": 1}
+
+
+def test_merge_histograms_skips_city_missing_required_histograms():
+    """A city missing either all_panos histogram is skipped WHOLE — its other
+    histogram must not half-merge and skew the global totals."""
+    incomplete = {"all_panos": {"histogram_of_capture_dates_by_year": {"2010": 9}}}
+    complete = _city({"counts": {"2020": 1}}, {"counts": {"2020-06-01": 1}})
+    merged = merge_capture_date_histograms([incomplete, complete])
+
+    assert merged["all_panos_yearly"] == {2020: 1}  # no 2010 leak
+    assert merged["all_panos_daily"] == {"2020-06-01": 1}
+
+
+def test_merge_histograms_drops_unparseable_year_keys_only():
+    """A malformed year key is dropped; the city's other keys still merge."""
+    city = _city({"counts": {"unknown": 5, "2020": 1}}, {"counts": {}})
+    merged = merge_capture_date_histograms([city])
+    assert merged["all_panos_yearly"] == {2020: 1}
+
+
+def test_merge_histograms_empty_input():
+    merged = merge_capture_date_histograms([])
+    assert merged == {
+        "all_panos_yearly": {},
+        "google_panos_yearly": {},
+        "all_panos_daily": {},
+        "google_panos_daily": {},
+    }

--- a/www/js/__tests__/streetscape-utils.test.js
+++ b/www/js/__tests__/streetscape-utils.test.js
@@ -3,12 +3,19 @@
 // no browser. These cover the numeric/date edge cases behind the B1–B4
 // tooltip bugs (Infinity%/NaN) and the 0-pano epoch-date bug (#122/#69).
 
+// Pin a west-of-UTC zone so the date-only-parse tests actually exercise the
+// timezone-shift regression (CI runs in UTC, where UTC-parse bugs are
+// invisible). Node honors TZ changes for subsequently created Dates.
+process.env.TZ = "America/Los_Angeles";
+
 const test = require("node:test");
 const assert = require("node:assert/strict");
 
 const {
+  PROVIDERS,
   adaptCityRecord,
   escapeHtml,
+  getColor,
   isValidRunFilename,
   isGoogleCopyright,
   panoDateOrNull,
@@ -251,4 +258,64 @@ test("panoDateOrNull: valid ISO date parses to a Date", () => {
   assert.ok(d instanceof Date);
   assert.ok(!Number.isNaN(d.getTime()));
   assert.equal(d.getUTCFullYear(), 2020);
+});
+
+// --- getColor: YlOrRd age color scale boundaries ----------------------------
+//
+// The scale's documented stops: age 0 → rgb(255, 255, 178) (light yellow),
+// age max/2 → rgb(253, 141, 60) (orange), age >= provider max →
+// rgb(189, 0, 38) (dark red). The provider max is wall-clock-derived
+// (years since the provider's launch), so tests pin the stops with ages
+// that are max-independent: 0, an age far beyond any max, and max/2
+// recomputed from the exported PROVIDERS launch dates.
+
+test("getColor: age 0 is the light-yellow newest stop for every provider", () => {
+  assert.equal(getColor(0), "rgb(255, 255, 178)");
+  assert.equal(getColor(0, "gsv"), "rgb(255, 255, 178)");
+  assert.equal(getColor(0, "mapillary"), "rgb(255, 255, 178)");
+});
+
+test("getColor: ages at/beyond the provider max clamp to dark red", () => {
+  // 1e6 years dwarfs any provider's launch-anchored max, so the ratio must
+  // clamp to 1 instead of extrapolating past the dark-red stop.
+  assert.equal(getColor(1e6, "gsv"), "rgb(189, 0, 38)");
+  assert.equal(getColor(1e6, "mapillary"), "rgb(189, 0, 38)");
+});
+
+test("getColor: half the provider max is the orange middle stop", () => {
+  // Recompute the provider max exactly as the module does (years since
+  // launch, 365.25-day years). Both interpolation branches meet at the
+  // 0.5 boundary with the same color, so the sub-millisecond clock drift
+  // between module load and this call cannot flip the rounded result.
+  const msPerYear = 1000 * 60 * 60 * 24 * 365.25;
+  const gsvMax = (Date.now() - PROVIDERS.gsv.launchDate.getTime()) / msPerYear;
+  assert.equal(getColor(gsvMax / 2, "gsv"), "rgb(253, 141, 60)");
+});
+
+test("getColor: unknown provider falls back to the gsv scale", () => {
+  assert.equal(getColor(7, "kartaview"), getColor(7, "gsv"));
+});
+
+test("getColor: null age (0-pano run) coerces to the newest stop, not NaN", () => {
+  // index.js passes pano_age_stats.median_pano_age_years straight through,
+  // and that field is null for a 0-pano run. null/maxAge coerces to 0, so
+  // the color must be the valid age-0 stop — never "rgb(NaN, NaN, NaN)".
+  assert.equal(getColor(null), "rgb(255, 255, 178)");
+  assert.equal(getColor(null, "mapillary"), "rgb(255, 255, 178)");
+});
+
+test("panoDateOrNull: date-only strings are local calendar dates (no TZ shift)", () => {
+  // Regression: `new Date("2023-01-01")` is UTC midnight, so local getters
+  // west of UTC (TZ pinned to America/Los_Angeles above) read it back as
+  // Dec 31, 2022 — putting every Jan/year-precision capture date in the
+  // previous year's filter bucket and color.
+  const d = panoDateOrNull("2023-01-01");
+  assert.equal(d.getFullYear(), 2023);
+  assert.equal(d.getMonth(), 0);
+  assert.equal(d.getDate(), 1);
+  assert.equal(d.toLocaleDateString("en-US"), "1/1/2023");
+  // Full timestamps (with a time component) keep native parsing.
+  const ts = panoDateOrNull("2026-07-05T12:34:56+00:00");
+  assert.ok(ts instanceof Date && !Number.isNaN(ts.getTime()));
+  assert.equal(ts.getUTCHours(), 12);
 });

--- a/www/js/city.js
+++ b/www/js/city.js
@@ -24,7 +24,10 @@
  */
 
 // ── Map setup ──────────────────────────────────────────────────
-const map = L.map("map", { zoomControl: false }).setView([0, 0], 13);
+// preferCanvas: pano markers render on a shared <canvas> instead of one
+// SVG DOM node each — the difference between usable and frozen for large
+// cities (10⁵+ markers).
+const map = L.map("map", { zoomControl: false, preferCanvas: true }).setView([0, 0], 13);
 L.control.zoom({ position: "bottomleft" }).addTo(map);
 
 L.tileLayer("https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png", {
@@ -813,8 +816,12 @@ async function loadData() {
 
         processedPanos.add(row.pano_id);
 
-        const captureDate = new Date(row.capture_date);
-        if (isNaN(captureDate.getTime())) continue; // skip unparseable dates
+        // panoDateOrNull parses date-only strings as LOCAL midnight so the
+        // year bucket/color matches the calendar date in the CSV (a UTC
+        // parse shifted Jan/year-precision dates into the previous year
+        // for visitors west of UTC).
+        const captureDate = panoDateOrNull(row.capture_date);
+        if (!captureDate || isNaN(captureDate.getTime())) continue; // skip unparseable dates
 
         const year = captureDate.getFullYear();
         const age = currentYear - year;
@@ -823,8 +830,10 @@ async function loadData() {
           ? `${Math.round(ageInYears * 12)} months`
           : `${ageInYears.toFixed(1)} years`;
 
-        // Incremental temporal aggregation
-        const dateStr = captureDate.toISOString().split("T")[0];
+        // Incremental temporal aggregation, keyed by the CSV's own
+        // YYYY-MM-DD string (toISOString would shift local dates back to
+        // the previous day east of UTC)
+        const dateStr = String(row.capture_date);
         temporalMap.set(dateStr, (temporalMap.get(dateStr) || 0) + 1);
 
         // Map marker
@@ -861,6 +870,16 @@ async function loadData() {
     // quotes, or newlines) correctly on each batch because it sees a
     // well-formed CSV fragment with headers on every call.
 
+    // Per-column typing: only coordinates are numeric. Blanket
+    // dynamicTyping would coerce pano_id to a float — Mapillary IDs are
+    // numeric strings that can exceed 2^53 and would silently round,
+    // corrupting the dedup set and viewer deep-links.
+    const csvParseOptions = {
+      header: true,
+      dynamicTyping: { query_lat: true, query_lon: true, pano_lat: true, pano_lon: true },
+      skipEmptyLines: true,
+    };
+
     let buffer = "";
     let headerLine = null; // first line of the CSV (column names)
 
@@ -870,11 +889,7 @@ async function loadData() {
       if (done) {
         // Flush any remaining content after the last newline
         if (buffer.trim() && headerLine !== null) {
-          const result = Papa.parse(`${headerLine}\n${buffer}`, {
-            header: true,
-            dynamicTyping: true,
-            skipEmptyLines: true,
-          });
+          const result = Papa.parse(`${headerLine}\n${buffer}`, csvParseOptions);
           processRows(result.data);
         }
         break;
@@ -900,11 +915,7 @@ async function loadData() {
         headerLine = completeText.slice(0, firstNewline);
         const dataText = completeText.slice(firstNewline + 1);
         if (dataText.trim()) {
-          const result = Papa.parse(`${headerLine}\n${dataText}`, {
-            header: true,
-            dynamicTyping: true,
-            skipEmptyLines: true,
-          });
+          const result = Papa.parse(`${headerLine}\n${dataText}`, csvParseOptions);
           processRows(result.data);
         }
       } else {
@@ -926,7 +937,7 @@ async function loadData() {
     updateLegend(Object.keys(markersByYear).map(Number));
 
     const temporalData = Array.from(temporalMap.entries())
-      .map(([d, c]) => ({ date: new Date(d), count: c }))
+      .map(([d, c]) => ({ date: panoDateOrNull(d), count: c }))
       .sort((a, b) => a.date - b.date);
 
     createTemporalPlot(temporalData, document.getElementById("temporal-plot"));

--- a/www/js/index.js
+++ b/www/js/index.js
@@ -14,6 +14,15 @@ const mapRectangles = [];
 let allCityBounds = null;
 let rawCitiesData = null; // the fetched cities.json.gz payload (all providers)
 
+// The one live popup histogram. Popups are content-functions (built on
+// open), so at most one Chart exists at a time — destroyed on close,
+// otherwise each open leaks a Chart instance + ResizeObserver.
+let activePopupChart = null;
+map.on("popupclose", () => {
+  activePopupChart?.destroy();
+  activePopupChart = null;
+});
+
 // Active provider, persisted in the URL (?provider=mapillary)
 const providerParam = new URLSearchParams(window.location.search).get("provider");
 let currentProvider = PROVIDERS[providerParam] ? providerParam : "gsv";
@@ -38,7 +47,7 @@ function createPopupHistogram(histogramData, currentYear) {
   const counts = years.map((y) => histogramData[y]);
   const ages = years.map((y) => currentYear - y);
 
-  new Chart(canvas, {
+  activePopupChart = new Chart(canvas, {
     type: "bar",
     data: {
       labels: years,
@@ -739,7 +748,10 @@ function renderProvider(fitMap = false) {
     }).addTo(map);
 
     rect.city = city;
-    rect.bindPopup(createTooltip(city));
+    // Content function: the popup DOM (including its Chart.js histogram)
+    // is built on OPEN, not eagerly for all ~1,100 cities at render time —
+    // and rebuilt each open, so a provider toggle can't leak stale charts.
+    rect.bindPopup(() => createTooltip(city));
     mapRectangles.push(rect);
 
     rect.on("mouseover", () => highlightCity(city));

--- a/www/js/streetscape-utils.js
+++ b/www/js/streetscape-utils.js
@@ -314,11 +314,22 @@ function isGoogleCopyright(copyright) {
  * `new Date(null)` silently rendering as the Unix epoch (12/31/1969)
  * instead of a "—"/"No data" placeholder (issue #122, #69 family).
  *
+ * Date-ONLY strings ("YYYY-MM-DD") are parsed as LOCAL midnight, not UTC:
+ * `new Date("2023-01-01")` is UTC midnight, and reading it back with local
+ * getters (toLocaleDateString, getFullYear) west of UTC shifts every date
+ * back a day — and every January/year-precision capture date back a whole
+ * YEAR (standardize_capture_date pins month/year precision to the 1st), so
+ * US visitors saw those panos in the previous year's filter bucket and
+ * color. Full timestamps (with a time component) still parse natively.
+ *
  * @param {?string} v - ISO date string, or null/undefined.
- * @returns {?Date} A Date, or null when the input is falsy.
+ * @returns {?Date} A Date (local midnight for date-only), or null when falsy.
  */
 function panoDateOrNull(v) {
-  return v ? new Date(v) : null;
+  if (!v) return null;
+  const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(String(v));
+  if (m) return new Date(Number(m[1]), Number(m[2]) - 1, Number(m[3]));
+  return new Date(v);
 }
 
 /**


### PR DESCRIPTION
Stacked on #134 (Tier 1) — merge that first; GitHub will retarget this to `main` automatically. Second tranche of the 2026-07-11 pre-v2.0.0 audit. **323 Python + 19 JS tests pass** (268 + 9 when the audit began); ruff + ESLint clean.

## Core pipeline

- **Immutable-snapshot race closed.** `cli.py` refuses to overwrite an existing run file (concurrent collection or crash orphan — auto-overwrite is unsafe because the file may be seconds from being cataloged by another process). `download_gsv.py` adds a run-level `FileLock` held for the entire run (`timeout=0`, fail-fast), and **never deletes lock files** — deleting a held lock let a third acquirer create a fresh lock and interleave CSV writes. Guard tests need no HTTP mocking since both refusals fire before any request.
- **Fully-failed batch no longer kills the run** — an all-error batch used to `KeyError` on `astype` of an empty DataFrame; it now falls through to the retry pass built for exactly that case.
- **Budget ledger survives failures.** Both downloaders attach the spent request count to `DownloadError`; `cli.py` records it, so a crashed 100k-request night no longer vanishes from `api_usage` and overspends the next day's budget check.
- **Scheduler skip-margin trap defused.** `run-due` subprocesses now pass `--min-days-since-last-run 0` — the scheduler already decided dueness, and any config with `cycle_days − grace_days ≤ 80` (the CLI default) previously made every run "succeed" as a skip, stamping `last_success_at` while collecting nothing, forever, with green logs. City names now follow `--` so a leading dash can't parse as a flag.
- **Diff churn fix**: pano identity uses `PRESENT_STATUSES`, so an OK↔NO_DATE flip (common with Mapillary's bogus contributor timestamps) counts as `capture_date_changed`, not removed+added.
- **Aggregate resilience**: when a crash leaves `runs.json_filename` NULL, `generate_aggregate_v2` falls back to the derived `.json.gz` sibling instead of dropping that (city, provider) from `cities.json.gz` every night.
- **History harvester**: isolated failed points get up to 2 in-run retry passes; if holes remain it raises `HarvestIncompleteError` (subclass of `HarvestBlockedError`, so operator handling is unchanged) and keeps the checkpoint, instead of silently finalizing an incomplete census and deleting the only record of what was skipped.
- **Mapillary grid assignment**: latitude-local meters-per-degree (standard WGS84 series; dx scaled at each pano's own row latitude) replaces the global-mean constant that mis-assigned edge panos by whole grid rows (+1 row at 2.5 km from center at the equator). Accuracy pinned by tests placing panos at exact geodesic grid points 2.4 km from center. Note: the first run after this change may show a one-time burst of coverage transitions near grid edges vs pre-fix runs (assignment moved, panos didn't).

## Frontend

- **Timezone date-shift fixed**: `panoDateOrNull` parses date-only strings as *local* midnight — a UTC parse read back with local getters showed US visitors every date a day early and put every January/year-precision capture date in the *previous year's* filter bucket and color. Tests pin the behavior with `TZ=America/Los_Angeles` (CI's UTC would mask the regression).
- **`preferCanvas: true`** on the city map — pano markers share one canvas instead of one SVG node each (the known giant-city weakness).
- **Popup charts built lazily** (`bindPopup(() => …)`) and destroyed on `popupclose` — previously ~1,100 Chart.js instances + ResizeObservers were created eagerly per render and leaked on every provider toggle.
- **`pano_id` stays a string**: per-column PapaParse typing; blanket `dynamicTyping` coerced Mapillary's numeric-string IDs to floats, which silently round past 2^53 (dedup collisions, broken viewer deep-links).

## New tests

- `test_cli_policy.py` — the previously-untested policy layer: skip window, `--force`, same-date no-op, systemic-failure rejection (`.rejected` rename + exit 1 + ledger-still-charged), both-provider fail-fast before any download, one-provider-fails-other-continues, overwrite refusal.
- `test_stats.py` — hand-computed statistics suite: every AgeStats field (incl. sample-vs-population stdev discrimination and percentile interpolation), None-not-NaN zero-pano semantics, dedup-once age math, run-date pinning/determinism, leap-year and fractional-age arithmetic, reduced-precision date integration, status-breakdown partitioning, google-subset semantics with partial/null copyright, and histogram merging across both payload shapes.
- `test_config.py`, `test_download_guard.py`, plus new cases in `test_diff`, `test_gsv_history`, `test_json_v2`, `test_mapillary`, `test_scheduler`, and the JS suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QnMmVJkyvsK932aFwP62kd