### PR TITLE
Fix Mapillary tile auth: token as ?access_token= query param, not OAuth header

### DIFF
--- a/streetscape_metadata_tracker/download_mapillary.py
+++ b/streetscape_metadata_tracker/download_mapillary.py
@@ -49,10 +49,13 @@ from .fileutils import load_city_csv_file
 logger = logging.getLogger(__name__)
 
 TILE_ZOOM = 14  # the only zoom level whose tiles carry per-image metadata
-# The access token is sent as an `Authorization: OAuth <token>` header, NOT
-# a query parameter: HTTP-client exceptions stringify with the full request
-# URL, so a URL-borne token would leak into logs (and from log tails into
-# the scheduler's alert emails).
+# The tiles CDN only accepts the token as an `?access_token=` query
+# parameter — it rejects the `Authorization: OAuth <token>` header the Graph
+# API uses (verified: header -> HTTP 403, query param -> 200). This matches
+# how download_gsv.py carries `key=` in the URL. A URL-borne token would
+# otherwise leak into logs via HTTP-client exceptions that stringify the
+# full request URL, so every raised/logged error text must pass through
+# download_common.redact_credentials (which scrubs `access_token=`).
 TILE_URL_TEMPLATE = "https://tiles.mapillary.com/maps/vtp/mly1_computed_public/2/{z}/{x}/{y}"
 IMAGE_LAYER = "image"
 
@@ -341,7 +344,7 @@ async def download_mapillary_metadata_async(
 
     async def fetch_one(x: int, y: int) -> list[dict[str, Any]]:
         nonlocal api_requests
-        url = TILE_URL_TEMPLATE.format(z=TILE_ZOOM, x=x, y=y)
+        url = f"{TILE_URL_TEMPLATE.format(z=TILE_ZOOM, x=x, y=y)}?access_token={access_token}"
         async with semaphore:
             api_requests += 1
             tile_bytes = await _fetch_tile(session, url, timeout)
@@ -349,10 +352,9 @@ async def download_mapillary_metadata_async(
         return decode_image_features(tile_bytes, x, y)
 
     try:
-        # Token in a header, not the URL — see TILE_URL_TEMPLATE comment.
-        async with aiohttp.ClientSession(
-            headers={"Authorization": f"OAuth {access_token}"}
-        ) as session:
+        # Token rides in each tile URL as ?access_token= — see TILE_URL_TEMPLATE
+        # comment (the tiles CDN 403s the Authorization header).
+        async with aiohttp.ClientSession() as session:
             results = await asyncio.gather(*(fetch_one(x, y) for x, y in tiles))
     except DownloadError as e:
         # e.g. the rejected-token error from _fetch_tile; attach the spent

--- a/tests/test_mapillary.py
+++ b/tests/test_mapillary.py
@@ -287,12 +287,14 @@ def _run_download(
     served = []
 
     async def fake_fetch(session, url, timeout):
-        # The token must travel as an Authorization header, never in the
-        # URL (URL-borne credentials leak via exception text into logs).
-        m = re.search(r"/2/14/(\d+)/(\d+)$", url)
+        # The tiles CDN requires the token as a ?access_token= query param
+        # (it 403s the Authorization header the Graph API uses). URL-borne
+        # credentials are scrubbed from logged exception text by
+        # download_common.redact_credentials (see test_credential_redaction).
+        m = re.search(r"/2/14/(\d+)/(\d+)\?access_token=MLY", url)
         assert m, f"unexpected tile URL: {url}"
-        assert "access_token" not in url
-        assert session.headers.get("Authorization") == "OAuth MLY|test|token"
+        assert "access_token=MLY|test|token" in url
+        assert session.headers.get("Authorization") is None
         xy = (int(m.group(1)), int(m.group(2)))
         served.append(xy)
         return tiles_by_xy.get(xy, mapbox_vector_tile.encode([]))


### PR DESCRIPTION
## Problem

Every Mapillary collection was failing with `Mapillary rejected the access token (HTTP 403)`, and `--provider both` runs exited non-zero, **even with a valid token**. Surfaced while adding Appleton, WI as a tracked city (the "Mapillary smoke test" ops follow-up).

## Root cause

`download_mapillary.py` sent the token as an `Authorization: OAuth <token>` header. The **tiles CDN** (`tiles.mapillary.com/.../mly1_computed_public`) rejects that header with 403 and requires the token as an `?access_token=` **query parameter**. The Graph API accepts either scheme, which masked the difference during development.

Verified empirically against the live endpoint with a valid token:

| Request | Result |
|---|---|
| Graph API + `Authorization: OAuth` header | 200 |
| Graph API + `?access_token=` query | 200 |
| **Tiles** + `?access_token=` query | **200** |
| **Tiles** + `Authorization: OAuth` header | **403** |

## Fix

Carry the token in each tile URL as `?access_token=`. This matches `download_gsv.py`, which already puts `key=` in the request URL. The token-in-URL leak risk that motivated the original header approach is handled the same way GSV handles it — `download_common.redact_credentials` scrubs `key|access_token|token=` from any exception text bound for logs or scheduler alert emails (covered by `test_credential_redaction`).

## Why tests didn't catch it

The Mapillary tests monkeypatch `_fetch_tile`, so real endpoint auth was never exercised. The mocked test had actually **asserted the buggy behavior** (token in a header, never in the URL). Updated it to assert the token rides in the tile URL query param with no `Authorization` header.

## Verification

- Live probe through the real `_fetch_tile` + `decode_image_features` path over dense-coverage cities: **Amsterdam 17,475**, Berlin 3,704, Paris 2,923 `is_pano` images extracted from a single z14 tile each, with valid coordinates + capture timestamps.
- End-to-end CLI run for Appleton, WI now completes cleanly (0 panos there is genuine — no Mapillary 360° coverage), exit 0.
- Full fast suite: **347 tests pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)