### PR TITLE
Overview legend: min–max range filter with draggable window

### DIFF
--- a/tests/e2e/test_smoke.py
+++ b/tests/e2e/test_smoke.py
@@ -175,6 +175,58 @@ def test_metric_toggle_recolors_and_persists_via_query_param(page: Page, base_ur
     assert errors == []
 
 
+def test_legend_range_filter_slider(page: Page, base_url):
+    """The legend's min-max range slider filters (dims) out-of-range buckets,
+    persists via ?filter=, and legend rows snap the range to one bucket."""
+    errors = _capture_errors(page)
+    # Coverage metric: the slider span is always the full 10 deciles.
+    page.goto(f"{base_url}/index.html?metric=coverage")
+    expect(page.locator("path.leaflet-interactive")).to_have_count(2)
+
+    # Keyboard on the max thumb: 9 -> 8 activates a 0-8 decile filter.
+    hi = page.locator("#legend-slider-hi")
+    expect(hi).to_be_visible()
+    hi.focus()
+    page.keyboard.press("ArrowLeft")
+    page.wait_for_url("**filter=0-8**")
+    expect(page.locator("#legend-filter-label")).to_have_text("0–90%")
+    # Exactly the 90-100% row falls outside the range and dims.
+    expect(page.locator("button.legend-item.dimmed")).to_have_count(1)
+
+    # A row click snaps the filter to that single bucket...
+    page.locator('button.legend-item[data-bucket="0"]').click()
+    page.wait_for_url("**filter=0-0**")
+    expect(page.locator("#legend-filter-label")).to_have_text("0–10%")
+    expect(page.locator("button.legend-item.dimmed")).to_have_count(9)
+    # ...and a second click on the sole-selected row clears the filter.
+    page.locator('button.legend-item[data-bucket="0"]').click()
+    expect(page.locator("button.legend-item.dimmed")).to_have_count(0)
+    assert "filter=" not in page.url
+    expect(page.locator("#legend-filter-label")).to_have_text("all cities")
+
+    # A URL-supplied filter is pre-applied on load.
+    page.goto(f"{base_url}/index.html?metric=coverage&filter=3-7")
+    expect(page.locator("#legend-filter-label")).to_have_text("30–80%")
+    expect(page.locator("button.legend-item.dimmed")).to_have_count(5)
+
+    # Dragging the filled window itself slides it, width preserved:
+    # 3-7 dragged two deciles right becomes 5-9.
+    slider_box = page.locator("#legend .legend-slider").bounding_box()
+    fill_box = page.locator("#legend-slider-fill").bounding_box()
+    per_decile = slider_box["width"] / 9
+    x = fill_box["x"] + fill_box["width"] / 2
+    y = fill_box["y"] + fill_box["height"] / 2
+    page.mouse.move(x, y)
+    page.mouse.down()
+    page.mouse.move(x + 2 * per_decile, y, steps=8)
+    page.mouse.up()
+    page.wait_for_url("**filter=5-9**")
+    expect(page.locator("#legend-filter-label")).to_have_text("50–100%")
+    expect(page.locator("button.legend-item.dimmed")).to_have_count(5)
+
+    assert errors == []
+
+
 def test_city_page_multirun_gsv_renders_chart_and_snapshot_select(page: Page, base_url):
     errors = _capture_errors(page)
     page.goto(f"{base_url}/city.html?file={ALPHA_LATEST}")

--- a/www/css/index.css
+++ b/www/css/index.css
@@ -109,6 +109,129 @@ button.legend-item:focus-visible {
   flex-shrink: 0;
 }
 
+/* Rows outside the active filter range mirror the map's dimming */
+.legend-item.dimmed {
+  opacity: 0.45;
+}
+
+/* ── Legend range-filter slider ─────────────────────────────── */
+.legend-filter {
+  margin-bottom: 8px;
+  padding-bottom: 8px;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.15);
+}
+
+.legend-filter-readout {
+  font-size: 0.85em;
+  margin-bottom: 2px;
+}
+
+.legend-hint {
+  font-size: 0.75em;
+  color: #444;
+  margin-top: 2px;
+}
+
+/* Dual-thumb slider: two native range inputs stacked on one custom track.
+   The inputs themselves ignore pointer events; only their thumbs are
+   grabbable, so both handles work with mouse, touch, and keyboard. The
+   band between the thumbs is also draggable (slides the whole window). */
+.legend-slider {
+  position: relative;
+  height: 24px;
+  touch-action: none; /* window drags shouldn't scroll the legend on touch */
+}
+
+.legend-slider.dragging,
+.legend-slider.dragging .legend-slider-fill.draggable {
+  cursor: grabbing;
+}
+
+.legend-slider-track {
+  position: absolute;
+  top: 10px;
+  left: 0;
+  right: 0;
+  height: 4px;
+  border-radius: 2px;
+  background: rgba(0, 0, 0, 0.2);
+}
+
+.legend-slider-fill {
+  position: absolute;
+  top: 0;
+  height: 100%;
+  border-radius: 2px;
+  background: #1a73e8;
+}
+
+.legend-slider-fill.draggable {
+  cursor: grab;
+}
+
+.legend-slider input[type="range"] {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 24px;
+  margin: 0;
+  background: none;
+  pointer-events: none;
+  appearance: none;
+  -webkit-appearance: none;
+}
+
+.legend-slider input[type="range"]::-webkit-slider-runnable-track {
+  -webkit-appearance: none;
+  height: 24px;
+  background: transparent;
+  border: none;
+}
+
+.legend-slider input[type="range"]::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  pointer-events: auto;
+  box-sizing: border-box;
+  width: 14px;
+  height: 14px;
+  margin-top: 5px; /* (24px input − 14px thumb) / 2, centers on the track */
+  border-radius: 50%;
+  background: #fff;
+  border: 2px solid #1a73e8;
+  cursor: grab;
+}
+
+.legend-slider input[type="range"]::-moz-range-track {
+  background: transparent;
+  border: none;
+}
+
+.legend-slider input[type="range"]::-moz-range-thumb {
+  pointer-events: auto;
+  box-sizing: border-box;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: #fff;
+  border: 2px solid #1a73e8;
+  cursor: grab;
+}
+
+/* Focus ring on the thumb itself (outline on the input would draw a
+   full-width box since the input is transparent) */
+.legend-slider input[type="range"]:focus-visible {
+  outline: none;
+}
+
+.legend-slider input[type="range"]:focus-visible::-webkit-slider-thumb {
+  box-shadow: 0 0 0 3px rgba(26, 115, 232, 0.4);
+}
+
+.legend-slider input[type="range"]:focus-visible::-moz-range-thumb {
+  box-shadow: 0 0 0 3px rgba(26, 115, 232, 0.4);
+}
+
 /* ── Leaflet popup overrides ────────────────────────────────── */
 .leaflet-popup-content {
   width: 400px !important;

--- a/www/eslint.config.js
+++ b/www/eslint.config.js
@@ -33,6 +33,7 @@ const sharedGlobals = {
   METRICS: "readonly",
   isKnownProvider: "readonly",
   isKnownMetric: "readonly",
+  parseFilterParam: "readonly",
   getColor: "readonly",
   coverageColor: "readonly",
   escapeHtml: "readonly",

--- a/www/js/__tests__/streetscape-utils.test.js
+++ b/www/js/__tests__/streetscape-utils.test.js
@@ -21,6 +21,7 @@ const {
   getProviderFromFilename,
   isKnownProvider,
   isKnownMetric,
+  parseFilterParam,
   isValidRunFilename,
   isGoogleCopyright,
   panoDateOrNull,
@@ -462,6 +463,37 @@ test("METRICS.coverage: valueOf, decile buckets, and labels", () => {
   assert.deepEqual(METRICS.coverage.legendBuckets([]),
     [9, 8, 7, 6, 5, 4, 3, 2, 1, 0]);
   assert.equal(METRICS.coverage.formatValue(51.25), "51.3%");
+});
+
+test("METRICS rangeLabel: age singular/plural, coverage decile edges", () => {
+  // Single-bucket ranges read like the bucket rows themselves
+  assert.equal(METRICS.age.rangeLabel(1, 1), "1 year");
+  assert.equal(METRICS.age.rangeLabel(2, 2), "2 years");
+  assert.equal(METRICS.age.rangeLabel(2, 5), "2–5 years");
+  // Decile bucket b spans [10b, 10b+10) — a single decile matches its
+  // bucketLabel, and the top bucket's upper edge is 100%, never 90%
+  assert.equal(METRICS.coverage.rangeLabel(3, 3),
+    METRICS.coverage.bucketLabel(3));
+  assert.equal(METRICS.coverage.rangeLabel(2, 7), "20–80%");
+  assert.equal(METRICS.coverage.rangeLabel(0, 9), "0–100%");
+});
+
+test("parseFilterParam: valid ranges parse, hostile input is rejected", () => {
+  // URL-supplied ?filter=MIN-MAX against an age span of buckets 0..18
+  assert.deepEqual(parseFilterParam("2-5", 0, 18), { min: 2, max: 5 });
+  assert.deepEqual(parseFilterParam("0-18", 0, 18), { min: 0, max: 18 });
+  assert.deepEqual(parseFilterParam("7-7", 0, 9), { min: 7, max: 7 });
+
+  // Rejected (null), never clamped or half-applied
+  assert.equal(parseFilterParam("5-2", 0, 18), null);   // inverted
+  assert.equal(parseFilterParam("2-25", 0, 18), null);  // beyond span
+  assert.equal(parseFilterParam("-1-3", 0, 18), null);  // negative / malformed
+  assert.equal(parseFilterParam("2-", 0, 18), null);
+  assert.equal(parseFilterParam("2-5-7", 0, 18), null);
+  assert.equal(parseFilterParam("abc", 0, 18), null);
+  assert.equal(parseFilterParam("", 0, 18), null);
+  assert.equal(parseFilterParam(null, 0, 18), null);
+  assert.equal(parseFilterParam(undefined, 0, 18), null);
 });
 
 test("panoDateOrNull: date-only strings are local calendar dates (no TZ shift)", () => {

--- a/www/js/index.js
+++ b/www/js/index.js
@@ -6,11 +6,13 @@
  * fetchGzippedJson, adaptCitiesPayload, STREETSCAPE_DATA_BASE_URL) and the
  * Leaflet / Chart.js libraries.
  *
- * Two orthogonal view toggles, both persisted in the URL:
+ * View state, all persisted in the URL:
  *   ?provider= — which imagery provider's data to show (gsv / mapillary)
  *   ?metric=   — which scalar colors the view (age / coverage); the map
  *                rectangles, legend buckets, and scatter-plot y-axes all
  *                follow the active metric
+ *   ?filter=   — inclusive MIN-MAX bucket range of the active metric
+ *                (legend range slider); out-of-range cities are dimmed
  */
 
 // ── Global state ──────────────────────────────────────────────
@@ -36,6 +38,16 @@ const providerParam = overviewUrlParams.get("provider");
 let currentProvider = isKnownProvider(providerParam) ? providerParam : "gsv";
 const metricParam = overviewUrlParams.get("metric");
 let currentMetric = isKnownMetric(metricParam) ? metricParam : "age";
+
+// Active metric filter: an inclusive bucket-id range {min, max} set by the
+// legend's range slider or a legend-row click, or null (no filter). Reset
+// whenever the legend is rebuilt (provider/metric switch) because the
+// bucket space changes with it. A URL-supplied ?filter= seeds the FIRST
+// legend build only, then is consumed.
+let filterRange = null;
+let filterBucketSpan = { min: 0, max: 0 }; // slider bounds of the active legend
+let pendingFilterParam = overviewUrlParams.get("filter");
+let legendFilterEls = null; // slider DOM refs, rebuilt with each legend
 
 // Fill color for cities with no value for the active metric (e.g. 0 dated
 // panos → null median age). Previously they fell through getColor(null) →
@@ -200,9 +212,11 @@ function createTooltip(city) {
 // ── Legend ─────────────────────────────────────────────────────
 
 /**
- * Populate the legend panel with one row per bucket of the active metric
- * (integer years for age, deciles for coverage), plus a non-interactive
- * "No data" row when any city lacks a value.
+ * Populate the legend panel: a min–max range-filter slider over the active
+ * metric's buckets, one row per bucket (integer years for age, deciles for
+ * coverage), plus a non-interactive "No data" row when any city lacks a
+ * value. Rows double as filter shortcuts — clicking one snaps the range to
+ * that single bucket.
  *
  * @param {Object[]} cities - Array of city records.
  */
@@ -225,8 +239,48 @@ function createLegend(cities) {
     bucketCounts.set(bucket, (bucketCounts.get(bucket) || 0) + 1);
   });
 
+  const buckets = metric.legendBuckets(values);
+  filterBucketSpan = { min: Math.min(...buckets), max: Math.max(...buckets) };
+
+  // A new legend means a new bucket space — drop any previous filter. The
+  // URL-supplied ?filter= (validated against the real span) seeds the very
+  // first build only; anything invalid is dropped from the URL rather than
+  // half-applied.
+  filterRange = null;
+  if (pendingFilterParam != null) {
+    filterRange = parseFilterParam(
+      pendingFilterParam, filterBucketSpan.min, filterBucketSpan.max);
+    pendingFilterParam = null;
+  }
+  updateFilterUrl();
+
   let html = `<h4>${metric.legendTitle}</h4>`;
-  metric.legendBuckets(values).forEach((bucket) => {
+
+  // Range-filter slider: two overlaid native range inputs (keyboard
+  // accessible for free) with a filled track segment marking the selected
+  // span. Skipped in the degenerate one-bucket case.
+  const hasSlider = filterBucketSpan.max > filterBucketSpan.min;
+  if (hasSlider) {
+    html += `
+      <div class="legend-filter">
+        <div class="legend-filter-readout">Filter:
+          <span id="legend-filter-label" aria-live="polite"></span></div>
+        <div class="legend-slider">
+          <div class="legend-slider-track" aria-hidden="true">
+            <div class="legend-slider-fill" id="legend-slider-fill"></div>
+          </div>
+          <input type="range" id="legend-slider-lo"
+                 min="${filterBucketSpan.min}" max="${filterBucketSpan.max}" step="1"
+                 aria-label="Minimum ${metric.sliderLabel}">
+          <input type="range" id="legend-slider-hi"
+                 min="${filterBucketSpan.min}" max="${filterBucketSpan.max}" step="1"
+                 aria-label="Maximum ${metric.sliderLabel}">
+        </div>
+        <div class="legend-hint">Drag handles or slide the bar &middot; click a row to filter</div>
+      </div>`;
+  }
+
+  buckets.forEach((bucket) => {
     const color = metric.bucketColor(bucket, currentProvider);
     const n = bucketCounts.get(bucket) || 0;
     const label = n > 0 ? `(${n} ${n === 1 ? "city" : "cities"})` : "(no cities)";
@@ -236,7 +290,7 @@ function createLegend(cities) {
     html += `
       <button type="button" class="legend-item" data-bucket="${bucket}"
               aria-pressed="false"
-              aria-label="Highlight cities with ${metric.label.toLowerCase()} ${metric.bucketLabel(bucket)} ${label}">
+              aria-label="Filter to cities with ${metric.label.toLowerCase()} ${metric.bucketLabel(bucket)} ${label}">
         <span class="legend-color" style="background:${color}" aria-hidden="true"></span>
         ${metric.bucketLabel(bucket)} ${label}
       </button>`;
@@ -250,63 +304,200 @@ function createLegend(cities) {
   }
   legend.innerHTML = html;
 
-  // Click handlers (the "No data" row is a plain div and stays
-  // non-interactive; buttons handle keyboard activation natively)
-  legend.querySelectorAll("button.legend-item").forEach((item) => {
-    item.addEventListener("click", () => {
-      const isAlreadySelected = item.classList.contains("selected");
+  legendFilterEls = hasSlider ? {
+    lo: legend.querySelector("#legend-slider-lo"),
+    hi: legend.querySelector("#legend-slider-hi"),
+    fill: legend.querySelector("#legend-slider-fill"),
+    label: legend.querySelector("#legend-filter-label"),
+  } : null;
 
-      // Clear selection from all items
-      legend.querySelectorAll("button.legend-item").forEach((i) => {
-        i.classList.remove("selected");
-        i.setAttribute("aria-pressed", "false");
-      });
+  if (legendFilterEls) {
+    const { lo, hi } = legendFilterEls;
+    // Each thumb clamps against the other, so lo ≤ hi always holds
+    lo.addEventListener("input", () => {
+      const hiV = parseInt(hi.value, 10);
+      setFilterRange({ min: Math.min(parseInt(lo.value, 10), hiV), max: hiV });
+    });
+    hi.addEventListener("input", () => {
+      const loV = parseInt(lo.value, 10);
+      setFilterRange({ min: loV, max: Math.max(parseInt(hi.value, 10), loV) });
+    });
 
-      if (isAlreadySelected) {
-        resetHighlights();
-      } else {
-        item.classList.add("selected");
-        item.setAttribute("aria-pressed", "true");
-        highlightCitiesByBucket(parseInt(item.dataset.bucket, 10));
+    // Dragging the selected window itself (the band between the thumbs)
+    // slides min and max together, width preserved. The thumbs' native
+    // pointer handling is untouched — their pointerdowns target the range
+    // INPUTs and are excluded here.
+    const sliderEl = legend.querySelector(".legend-slider");
+    const span = filterBucketSpan.max - filterBucketSpan.min;
+    let windowDrag = null; // {startX, startMin, width, pxPerBucket}
+
+    sliderEl.addEventListener("pointerdown", (e) => {
+      if (!filterRange || e.target.tagName === "INPUT") return;
+      const rect = sliderEl.getBoundingClientRect();
+      const bucketAt = filterBucketSpan.min +
+        ((e.clientX - rect.left) / rect.width) * span;
+      // Only grabs inside the window (±half a bucket of slack) start a drag
+      if (bucketAt < filterRange.min - 0.5 || bucketAt > filterRange.max + 0.5) return;
+      windowDrag = {
+        startX: e.clientX,
+        startMin: filterRange.min,
+        width: filterRange.max - filterRange.min,
+        pxPerBucket: rect.width / span,
+      };
+      sliderEl.setPointerCapture(e.pointerId);
+      sliderEl.classList.add("dragging");
+      e.preventDefault();
+    });
+    sliderEl.addEventListener("pointermove", (e) => {
+      if (!windowDrag || !filterRange) return;
+      const delta = Math.round((e.clientX - windowDrag.startX) / windowDrag.pxPerBucket);
+      const min = Math.max(filterBucketSpan.min,
+        Math.min(windowDrag.startMin + delta,
+          filterBucketSpan.max - windowDrag.width));
+      if (min !== filterRange.min) {
+        setFilterRange({ min, max: min + windowDrag.width });
       }
     });
+    const endWindowDrag = () => {
+      windowDrag = null;
+      sliderEl.classList.remove("dragging");
+    };
+    sliderEl.addEventListener("pointerup", endWindowDrag);
+    sliderEl.addEventListener("pointercancel", endWindowDrag);
+  }
+
+  // Row clicks snap the filter to that single bucket, or clear it when the
+  // row is already the sole selection. (The "No data" row is a plain div
+  // and stays non-interactive; buttons handle keyboard activation natively.)
+  legend.querySelectorAll("button.legend-item").forEach((item) => {
+    item.addEventListener("click", () => {
+      const bucket = parseInt(item.dataset.bucket, 10);
+      const isSoleSelection = filterRange != null &&
+        filterRange.min === bucket && filterRange.max === bucket;
+      setFilterRange(isSoleSelection ? null : { min: bucket, max: bucket });
+    });
   });
+
+  updateLegendFilterUI();
+}
+
+/**
+ * Sync the legend's filter UI — slider thumbs, filled track, readout, and
+ * row selected/dimmed states — to the current filterRange.
+ */
+function updateLegendFilterUI() {
+  const metric = METRICS[currentMetric];
+  const legend = document.getElementById("legend");
+  const range = filterRange ?? filterBucketSpan;
+
+  if (legendFilterEls) {
+    const { lo, hi, fill, label } = legendFilterEls;
+    lo.value = String(range.min);
+    hi.value = String(range.max);
+    lo.setAttribute("aria-valuetext", metric.bucketLabel(range.min));
+    hi.setAttribute("aria-valuetext", metric.bucketLabel(range.max));
+
+    // hi paints on top (later in the DOM). If both thumbs sit together at
+    // the span's top, only lo can still move — raise it so it's grabbable.
+    lo.style.zIndex =
+      range.min === range.max && range.max === filterBucketSpan.max ? "1" : "";
+    label.textContent = filterRange
+      ? metric.rangeLabel(range.min, range.max)
+      : "all cities";
+
+    // The window is only draggable while a filter is active (a full-span
+    // fill has nowhere to slide) — the class carries the grab cursor
+    fill.classList.toggle("draggable", filterRange != null);
+
+    const span = filterBucketSpan.max - filterBucketSpan.min;
+    const loPct = ((range.min - filterBucketSpan.min) / span) * 100;
+    const hiPct = ((range.max - filterBucketSpan.min) / span) * 100;
+    fill.style.left = `${loPct}%`;
+    fill.style.width = `${hiPct - loPct}%`;
+  }
+
+  legend.querySelectorAll("button.legend-item").forEach((item) => {
+    const bucket = parseInt(item.dataset.bucket, 10);
+    const inRange = filterRange != null &&
+      bucket >= filterRange.min && bucket <= filterRange.max;
+    item.classList.toggle("selected", inRange);
+    item.classList.toggle("dimmed", filterRange != null && !inRange);
+    item.setAttribute("aria-pressed", String(inRange));
+  });
+}
+
+/** Reflect filterRange in the URL (?filter=MIN-MAX), mirroring setProvider. */
+function updateFilterUrl() {
+  const url = new URL(window.location);
+  if (filterRange) {
+    url.searchParams.set("filter", `${filterRange.min}-${filterRange.max}`);
+  } else {
+    url.searchParams.delete("filter");
+  }
+  history.replaceState(null, "", url);
+}
+
+/**
+ * Set (or clear, with null) the active metric filter and update every
+ * dependent surface: URL, legend UI, map rectangles, and scatter plots.
+ *
+ * @param {?{min: number, max: number}} range - Inclusive bucket range.
+ */
+function setFilterRange(range) {
+  // Selecting the full span means "no filter"
+  if (range != null &&
+      range.min <= filterBucketSpan.min && range.max >= filterBucketSpan.max) {
+    range = null;
+  }
+  filterRange = range;
+  updateFilterUrl();
+  updateLegendFilterUI();
+  if (filterRange) {
+    lastHighlightedCity = FILTER_HIGHLIGHT;
+    applyFilterStyles();
+  } else {
+    lastHighlightedCity = null;
+    applyDefaultStyles();
+  }
 }
 
 // ── Highlighting helpers ──────────────────────────────────────
 
 /**
- * Dim everything except cities whose active-metric bucket matches
- * {@link targetBucket} (integer years for age, deciles for coverage).
- *
- * @param {number} targetBucket
+ * Restyle the map and both scatter plots for the active filterRange: cities
+ * inside the range go opaque with a ring, everything else fades. Callers
+ * own lastHighlightedCity bookkeeping.
  */
-function highlightCitiesByBucket(targetBucket) {
+function applyFilterStyles() {
   const metric = METRICS[currentMetric];
-  lastHighlightedCity = BUCKET_HIGHLIGHT; // supersedes any hover
+  const { min, max } = filterRange;
 
-  // Null value (no data) never matches a bucket
-  const inBucket = (city) => {
+  // Null value (no data) never falls inside a range
+  const inRange = (city) => {
     const value = metric.valueOf(city);
-    return value != null && metric.bucketOf(value) === targetBucket;
+    if (value == null) return false;
+    const bucket = metric.bucketOf(value);
+    return bucket >= min && bucket <= max;
   };
 
+  // Charts are null while a provider with no cities is shown
   [charts.pano, charts.area].forEach((chart) => {
+    if (!chart) return;
     const ds = chart.data.datasets[0];
     ds.pointBackgroundColor = ds.data.map((pt) =>
       // Selected points go fully opaque (base points sit at 0.8)
-      inBucket(pt.city) ? withAlpha(pt.backgroundColor, 1) : withAlpha(pt.backgroundColor, 0.3)
+      inRange(pt.city) ? withAlpha(pt.backgroundColor, 1) : withAlpha(pt.backgroundColor, 0.3)
     );
-    ds.pointRadius = ds.data.map((pt) => (inBucket(pt.city) ? 6 : 3));
-    ds.borderWidth = ds.data.map((pt) => (inBucket(pt.city) ? 2 : 0));
+    ds.pointRadius = ds.data.map((pt) => (inRange(pt.city) ? 6 : 3));
+    ds.borderWidth = ds.data.map((pt) => (inRange(pt.city) ? 2 : 0));
     ds.borderColor = ds.data.map((pt) =>
-      inBucket(pt.city) ? "rgba(0,0,0,0.8)" : "rgba(0,0,0,0)"
+      inRange(pt.city) ? "rgba(0,0,0,0.8)" : "rgba(0,0,0,0)"
     );
     chart.update();
   });
 
   mapRectangles.forEach((rect) => {
-    if (inBucket(rect.city)) {
+    if (inRange(rect.city)) {
       // Selected state
       rect.setStyle({
         fillOpacity: 0.8,
@@ -326,10 +517,10 @@ function highlightCitiesByBucket(targetBucket) {
 }
 
 // The current highlight state: null (defaults), a city record (hover), or
-// BUCKET_HIGHLIGHT (legend selection). Hover events fire per mousemove;
+// FILTER_HIGHLIGHT (range filter baseline). Hover events fire per mousemove;
 // restyling ~1,100 rectangles and updating two charts on every one froze
 // the map, so highlightCity/resetHighlights no-op when nothing changed.
-const BUCKET_HIGHLIGHT = Symbol("metric-bucket");
+const FILTER_HIGHLIGHT = Symbol("metric-filter");
 let lastHighlightedCity = null;
 
 /**
@@ -362,12 +553,11 @@ function highlightCity(city) {
   });
 }
 
-/** Reset all chart and map highlights back to their defaults. */
-function resetHighlights() {
-  if (lastHighlightedCity === null) return;
-  lastHighlightedCity = null;
-
+/** Restyle the map and both scatter plots to their unfiltered defaults. */
+function applyDefaultStyles() {
+  // Charts are null while a provider with no cities is shown
   [charts.pano, charts.area].forEach((chart) => {
+    if (!chart) return;
     const ds = chart.data.datasets[0];
     ds.pointBackgroundColor = ds.data.map((pt) => pt.backgroundColor);
     ds.pointRadius = ds.data.map(() => 3);
@@ -379,6 +569,23 @@ function resetHighlights() {
   mapRectangles.forEach((rect) => {
     rect.setStyle({ fillOpacity: 0.6, weight: 1 });
   });
+}
+
+/**
+ * Return chart and map highlights to the baseline view: the filtered state
+ * while a range filter is active (so a hover can't silently wipe the
+ * filter dimming), otherwise the defaults.
+ */
+function resetHighlights() {
+  if (filterRange) {
+    if (lastHighlightedCity === FILTER_HIGHLIGHT) return;
+    lastHighlightedCity = FILTER_HIGHLIGHT;
+    applyFilterStyles();
+  } else {
+    if (lastHighlightedCity === null) return;
+    lastHighlightedCity = null;
+    applyDefaultStyles();
+  }
 }
 
 // ── City search ──────────────────────────────────────────────
@@ -577,11 +784,13 @@ function initCitySearch(cities) {
     }
   });
 
-  // Reset button: clear search, reset highlights, zoom to all cities
+  // Reset button: clear search AND the metric filter, reset highlights,
+  // zoom to all cities
   document.getElementById("city-search-reset").addEventListener("click", () => {
     input.value = "";
     matches = [];
     showDropdown(false);
+    setFilterRange(null);
     resetHighlights();
     map.closePopup();
     if (allCityBounds) map.flyToBounds(allCityBounds, { duration: 1.2 });
@@ -773,6 +982,12 @@ function renderProvider(fitMap = false) {
   `;
 
   if (cities.length === 0) {
+    // No legend → no filter (clear any range left over from the previous
+    // provider, and its URL param)
+    filterRange = null;
+    legendFilterEls = null;
+    lastHighlightedCity = null;
+    updateFilterUrl();
     document.getElementById("legend").innerHTML =
       `<h4>No ${providerInfo.label} data yet</h4>`;
     return;
@@ -807,6 +1022,16 @@ function renderProvider(fitMap = false) {
   });
 
   createScatterPlots(cities);
+
+  // A filter seeded from the URL (first render only — createLegend clears
+  // it otherwise) dims the freshly built rectangles and charts
+  if (filterRange) {
+    lastHighlightedCity = FILTER_HIGHLIGHT;
+    applyFilterStyles();
+  } else {
+    lastHighlightedCity = null;
+  }
+
   initCitySearch(cities);
 
   allCityBounds = cities.map((c) => [

--- a/www/js/streetscape-utils.js
+++ b/www/js/streetscape-utils.js
@@ -143,6 +143,10 @@ function coverageColor(pct) {
  *   bucketLabel/bucketColor(bucket[, provider]) → legend row text/swatch
  *   legendBuckets(values) → bucket ids in display order (given the
  *                    non-null values present, for data-driven ranges)
+ *   rangeLabel(minBucket, maxBucket) → filter-readout text for an inclusive
+ *                    bucket range, e.g. "2–5 years" / "30–80%"
+ *   sliderLabel    → metric noun for the range-slider thumbs' aria-labels,
+ *                    e.g. "Minimum median age (years)"
  *   formatValue(value) → tooltip text, e.g. "4.2 years" / "51.2%"
  *   yMax           → scatter y-axis cap (null = auto)
  */
@@ -163,6 +167,10 @@ const METRICS = {
       const maxYears = Math.ceil(Math.max(0, ...values));
       return Array.from({ length: maxYears + 1 }, (_, i) => i);
     },
+    rangeLabel: (min, max) => min === max
+      ? `${min} year${min !== 1 ? "s" : ""}`
+      : `${min}–${max} years`,
+    sliderLabel: "median age (years)",
     formatValue: (v) => `${v.toFixed(1)} years`,
   },
   coverage: {
@@ -182,6 +190,9 @@ const METRICS = {
     bucketColor: (bucket) => coverageColor(bucket * 10 + 5),
     // 90–100% first — best-coverage top, mirroring newest-first for age
     legendBuckets: () => Array.from({ length: 10 }, (_, i) => 9 - i),
+    // Decile bucket b spans [10b, 10b+10), so the upper edge is (max+1)*10
+    rangeLabel: (min, max) => `${min * 10}–${(max + 1) * 10}%`,
+    sliderLabel: "grid coverage (%)",
     formatValue: (v) => `${v.toFixed(1)}%`,
   },
 };
@@ -196,6 +207,28 @@ const METRICS = {
  */
 function isKnownMetric(key) {
   return typeof key === "string" && Object.hasOwn(METRICS, key);
+}
+
+/**
+ * Parse a URL-supplied `?filter=MIN-MAX` value (inclusive bucket ids for
+ * the active metric) into a validated range. Like isKnownMetric, this
+ * treats the input as hostile: anything malformed, inverted, or outside
+ * [minBucket, maxBucket] is rejected rather than clamped, so a stale or
+ * hand-edited URL can't produce a half-applied filter.
+ *
+ * @param {*} str - Raw parameter value, e.g. "2-5".
+ * @param {number} minBucket - Lowest valid bucket id for the metric.
+ * @param {number} maxBucket - Highest valid bucket id for the metric.
+ * @returns {?{min: number, max: number}} The range, or null if invalid.
+ */
+function parseFilterParam(str, minBucket, maxBucket) {
+  if (typeof str !== "string") return null;
+  const match = /^(\d+)-(\d+)$/.exec(str);
+  if (!match) return null;
+  const min = parseInt(match[1], 10);
+  const max = parseInt(match[2], 10);
+  if (min > max || min < minBucket || max > maxBucket) return null;
+  return { min, max };
 }
 
 /**
@@ -548,6 +581,7 @@ if (typeof module !== "undefined" && module.exports) {
     METRICS,
     isKnownProvider,
     isKnownMetric,
+    parseFilterParam,
     getColor,
     coverageColor,
     escapeHtml,


### PR DESCRIPTION
## Summary

The overview map's legend rows were single-select only (one age year or one coverage decile at a time), and nothing signaled they were interactive at all. This PR turns the legend into a proper range filter:

- **Dual-thumb range slider** at the top of the legend panel, operating in bucket units of the active metric (1-year buckets for median age, deciles for coverage). Out-of-range cities **dim** on the map and both scatter plots — same visual language as the old single-bucket highlight.
- **Draggable window**: grab the filled bar between the thumbs and slide the whole range left/right, width preserved, clamped at the span edges. The full-height slider band is the hit area, so it's easy to grab.
- **Legend rows still click** — now snapping the range to that single bucket (and a second click on the sole-selected row clears the filter), so the old behavior is a special case of the new one. Rows inside the range show selected; rows outside dim to mirror the map.
- **Discoverability**: visible `Filter:` readout, the slider itself, and a hint line ("Drag handles or slide the bar · click a row to filter") make the panel read as a control rather than a static key.
- **URL persistence**: `?filter=MIN-MAX` alongside `?provider=`/`?metric=`, validated defensively (`parseFilterParam` rejects malformed/inverted/out-of-span values outright) and reset on provider/metric switch. The search ✕ button clears it too.
- **Accessibility**: two overlaid native `<input type="range">` elements, so the thumbs are keyboard-operable (arrow keys) with `aria-valuetext` bucket labels and focus rings; no slider library.

Also fixes a latent interaction bug: hovering a rectangle while a legend bucket was selected silently wiped the bucket dimming on mouseout while the legend row still showed selected. `resetHighlights` now restores the *filtered* state as the baseline.

## Testing

- `npm test`: 33/33 pass (new: `rangeLabel` singular/plural + decile edges, `parseFilterParam` hostile-input matrix)
- `npm run lint`: clean (new shared global registered in `eslint.config.js`)
- Playwright e2e (`pytest -m e2e`): 6/6 pass, including a new test driving the slider by keyboard, row-click snap/clear, a URL-preseeded filter, and dragging the 30–80% window two deciles right to 50–100%

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P9EFbJdaEBWjHxF22Jg6iE