### PR TITLE
Run the scheduler on makelab2 (data-local, portable venv) (#148)

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -140,9 +140,48 @@ loginctl enable-linger $USER       # user services must survive logout
 ```
 
 The service ships with resource caps (`MemoryMax=8G`, `CPUQuota=400%`,
-`Nice=10`) so nightly collection can't starve the other lab services that
-share the box and the storage array. If `enable-linger` is disallowed by policy,
-ask CSE IT to enable lingering for your account.
+`Nice=10`, `CPUWeight=50`) so nightly collection can't starve the other lab
+services that share the box and the storage array. If `enable-linger` is
+disallowed by policy, ask CSE IT to enable lingering for your account.
+
+### Host = makelab2, and the shared-home cutover model
+
+The collection job runs on **makelab2** (its ZFS pool holds `data/` + the
+catalog, so compute is data-local — no NFS hop). Two facts drive how the host
+is selected:
+
+- `$HOME` (`~/.config/systemd/user/`, `~/streetscape-tracker`, `.env`) is
+  **shared NFS across makelab1 and makelab2** — so the unit files, their
+  enablement, and `timers.target.wants` are identical on both boxes. Only
+  `loginctl` **linger** is per-host.
+- The scheduler must run on **exactly one** box (both share one SQLite catalog).
+
+So the active host is pinned two ways: `ConditionHost=makelab2*` in the service
+unit (collection is a no-op on any other host) **and** linger only on makelab2:
+
+```bash
+# on makelab2 (make it the active host):
+loginctl enable-linger jonf
+systemctl --user daemon-reload && systemctl --user start streetscape-tracker.timer
+# on makelab1 (stand it down; leave the timer enabled — it's the shared symlink):
+loginctl disable-linger jonf
+systemctl --user daemon-reload
+systemd-analyze condition 'ConditionHost=makelab2*'   # verify: fails on makelab1, passes on makelab2
+```
+
+The venv is **`.venv-makelab2/`**, a `uv`-managed CPython whose base interpreter
+lives on the shared ZFS checkout (`.tooling/`), so it runs on **both** boxes —
+unlike a stock `python3.11 -m venv .venv`, whose base `/usr/bin/python3.11`
+exists only on makelab1. Provision it with:
+
+```bash
+export UV_INSTALL_DIR=$PWD/.tooling/bin UV_PYTHON_INSTALL_DIR=$PWD/.tooling/python UV_CACHE_DIR=$PWD/.tooling/cache
+curl -LsSf https://astral.sh/uv/install.sh | sh
+.tooling/bin/uv venv .venv-makelab2 --python 3.11
+.tooling/bin/uv pip sync --python .venv-makelab2/bin/python requirements.lock
+```
+
+To fail back to makelab1: flip `ConditionHost` and move linger the other way.
 
 ## 6. Operate
 

--- a/deploy/systemd/streetscape-tracker.service
+++ b/deploy/systemd/streetscape-tracker.service
@@ -1,9 +1,20 @@
 # Streetscape Tracker daily collection service (user unit).
 # Install: see deploy/README.md
+#
+# HOST MODEL (important): jonf's $HOME is shared NFS across makelab1 AND
+# makelab2, so THIS unit file, its enablement, and timers.target.wants are
+# identical on both boxes — only `loginctl` linger is per-host. The scheduler
+# must run on exactly ONE box (both share the same SQLite catalog on ZFS), so
+# the active host is pinned two ways: ConditionHost below + linger only on the
+# active box. Cutover to a different host = flip ConditionHost + move linger.
+# Current active host: makelab2 (data-local on its ZFS pool; see issue #148).
 [Unit]
 Description=Streetscape Tracker: collect today's due cities
 Wants=network-online.target
 After=network-online.target
+# Only ever collect on the designated host, regardless of the shared-home
+# enablement above. Glob matches both the short and FQDN forms.
+ConditionHost=makelab2*
 # Opt-in raw safety net: email whenever this unit exits nonzero. run-due
 # returns nonzero on ANY failed city, so the scheduler's own threshold email
 # ([alerts] in scheduler.toml) is usually the better signal; enable this too
@@ -19,8 +30,13 @@ WorkingDirectory=%h/streetscape-tracker
 EnvironmentFile=%h/streetscape-tracker/.env
 # Publish straight to the NFS-mounted docroot (no SSH) — see sync_data_to_server.sh
 Environment=STREETSCAPE_PUBLISH_LOCAL=1
-# NB: --config is a global arg and MUST precede the subcommand (argparse).
-ExecStart=%h/streetscape-tracker/.venv/bin/python -m streetscape_metadata_tracker.scheduler --config %h/streetscape-tracker/config/scheduler.makelab1.toml run-due
+# .venv-makelab2 is a uv-managed venv whose base CPython lives on the shared ZFS
+# checkout (.tooling/), so it runs on BOTH boxes — unlike the old %h/.../.venv,
+# whose base /usr/bin/python3.11 exists only on makelab1. See deploy/README.md.
+# NB: --config is a global arg and MUST precede the subcommand (argparse). The
+# config file is named makelab1 for historical reasons but is the single shared
+# production config (paths are identical on both boxes via the shared ZFS).
+ExecStart=%h/streetscape-tracker/.venv-makelab2/bin/python -m streetscape_metadata_tracker.scheduler --config %h/streetscape-tracker/config/scheduler.makelab1.toml run-due
 # A full day of cities can legitimately take hours
 TimeoutStartSec=12h
 
@@ -51,10 +67,11 @@ ReadWritePaths=/projects/makeabilitylab/streetscape-tracker
 ReadWritePaths=/cse/web/research/makelab/public/streetscape-tracker
 
 # ── Resource guardrails ────────────────────────────────────────────────
-# This host is shared with other lab services (and storage is on a shared NFS
-# array). These STATIC caps keep nightly collection from starving co-tenants;
-# the scheduler's [resource_guard] adds a DYNAMIC pre-flight backoff on top
-# (lowers --connection-limit when load/RAM are already tight — issue #146).
+# This host (makelab2) is shared with other lab services AND is the lab
+# fileserver (its ZFS pool is NFS-exported to other boxes), so a heavy nightly
+# run could degrade NFS serving too. These STATIC caps keep it from starving
+# co-tenants; the scheduler's [resource_guard] adds a DYNAMIC pre-flight backoff
+# on top (lowers --connection-limit when load/RAM are already tight — issue #146).
 # The workload is I/O-bound async HTTP + pandas, so real peaks are modest;
 # validate after a live night and tune:
 #   systemctl --user show streetscape-tracker.service -p MemoryPeak -p CPUUsageNSec
@@ -69,5 +86,6 @@ CPUQuota=400%
 # co-tenant WHEN the CPU is contended, but still use the full CPUQuota when the
 # box is otherwise idle (as it usually is at 02:00). Cooperative, not a hard cap.
 CPUWeight=50
-# Note: data lives on NFS, so IO is network, not block-device —
-# IOWeight would not govern it; CPU/Memory caps + Nice are the real levers.
+# Note: on makelab2 our data is on a LOCAL ZFS pool, so disk IO IS block-device
+# here — add IOWeight= if a night is ever found to compete with NFS serving;
+# for now CPU/Memory caps + Nice + CPUWeight are the real levers.


### PR DESCRIPTION
Part of #148. Makes **makelab2** the collection host.

## Why
makelab2 is the lab fileserver — running the scheduler there puts compute next to the data (**local ZFS, no NFS hop**) and off makelab1 (busier + 2 unclean reboots in 11 days). Profiled idle (load 0.22, GPU 0%); coexists with saugstad's GPU service on a different resource axis. Cleared with Saugstad; CSE IT supportive.

## The shared-home subtlety
`$HOME` is shared NFS across both boxes, so `~/.config/systemd/user/` (unit files, enablement, `timers.target.wants`) is **identical on both** — only `loginctl` linger is per-host. The scheduler must run on exactly one box (shared SQLite catalog). So the active host is pinned two ways:
- **`ConditionHost=makelab2*`** on the service → a no-op on any other host.
- **linger only on makelab2** → only its user manager persists to fire the timer.

## Portable venv
`ExecStart` now uses `.venv-makelab2/bin/python` — a `uv`-managed CPython whose base interpreter lives on the shared ZFS checkout (`.tooling/`), so it runs on **both** boxes. (The old `.venv`'s base `/usr/bin/python3.11` exists only on makelab1 — it's a broken symlink on makelab2.) Provisioning + cutover documented in `deploy/README.md`.

## Validation already done on makelab2
- uv → CPython 3.11.15, locked deps installed (isolated under `.tooling/`)
- full test suite green on the box
- live `--force` collection (Jacksonburg, OH): `status_other 0`, cataloged to local ZFS

Deploy-config only (no Python changed). After merge: pull on the shared checkout, install the unit, then flip linger (makelab2 on / makelab1 off).

🤖 Generated with [Claude Code](https://claude.com/claude-code)