### PR TITLE
Sandbox-safe smtplib SMTP alert transport (#144)

### DIFF
--- a/config/scheduler.makelab1.toml
+++ b/config/scheduler.makelab1.toml
@@ -52,10 +52,20 @@ publish_script = "/projects/makeabilitylab/streetscape-tracker/sync_data_to_serv
 
 [alerts]
 # Email on an unhealthy night (>= failure_threshold failed collections) or crash.
-# makelab1's /usr/bin/mail delivers to cs.uw.edu with no relay setup.
+# transport = "smtp" (not "mail"): the local mailer is silently BLOCKED under
+# the systemd sandbox — its setgid postdrop path trips NoNewPrivileges, so the
+# alert never sends even though the failure is detected (#144). The stdlib
+# smtplib path talks to the campus relay directly and works in the sandbox.
 enabled = true
 recipient = "jonf@cs.uw.edu"
-transport = "mail"
+transport = "smtp"
+# Campus relay: reachable from makelab2, unauthenticated for on-campus hosts,
+# plain port 25 (verified 2026-07-17). smtp_from MUST be a real deliverable
+# address — the relay rejects streetscape-tracker@<hostname> as "Address
+# unknown", so alerts appear to come from jonf@ (Reply-To not needed).
+smtp_host = "smtp.cs.washington.edu"
+smtp_port = 25
+smtp_from = "jonf@cs.washington.edu"
 failure_threshold = 1
 subject_prefix = "[streetscape-tracker]"
 

--- a/config/scheduler.toml
+++ b/config/scheduler.toml
@@ -85,12 +85,28 @@ enabled = false
 # optional systemd OnFailure= hook — see deploy/README.md.
 enabled = false
 #recipient = "jonf@cs.uw.edu"
-# Transport: "mail" (uses a local relay), "msmtp"/"sendmail" (SMTP), or
-# "command" (an arbitrary shell command; body on stdin, subject/recipient in
+# Transport: "smtp" (stdlib smtplib straight to a relay — the sandbox-safe
+# choice, see below), "mail" (uses a local relay), "msmtp"/"sendmail" (SMTP),
+# or "command" (an arbitrary shell command; body on stdin, subject/recipient in
 # $STREETSCAPE_ALERT_SUBJECT/$STREETSCAPE_ALERT_TO — e.g. a Slack webhook curl). Confirm which
 # works on the box first:  echo test | mail -s test jonf@cs.uw.edu
 transport = "mail"
 #command = ""
+# --- transport = "smtp" settings (issue #144) ---
+# Prefer this under systemd: it never touches the local setgid mailer, so a
+# hardened unit (NoNewPrivileges / ProtectSystem=strict) can't break the send.
+# smtp_host is the only required field; the rest are opt-in for the relay.
+#smtp_host = "smtp.cs.washington.edu"   # UW CSE relay: no-auth for on-campus hosts
+#smtp_port = 25                          # 587 for a submission port
+# smtp_from defaults to streetscape-tracker@<hostname>, but many relays (incl.
+# smtp.cs.washington.edu) reject a non-deliverable sender with "550 Address
+# unknown" — set a real mailbox there.
+#smtp_from = "you@cs.washington.edu"
+#smtp_starttls = false                   # true on a submission/TLS port
+#smtp_user = ""                          # set with a password to authenticate
+# Password for smtp_user. Prefer the env var over the toml so no secret is
+# committed: STREETSCAPE_ALERT_SMTP_PASSWORD (env wins if both are set).
+#smtp_password = ""
 # Alert when at least this many (city, provider) collections failed. Raise it
 # to avoid paging on the occasional flaky single city.
 failure_threshold = 1

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -209,13 +209,39 @@ Data lives on NFS, so IO is network (not block-device) — CPU/memory caps and
 
 ### Failure alerts (email)
 
-Enabled in `config/scheduler.makelab1.toml` (`transport = "mail"`, which
-delivers on makelab1 with no relay setup). Test end-to-end without waiting for
-a failure:
+Enabled in `config/scheduler.makelab1.toml`. Test end-to-end without waiting
+for a failure:
 
 ```bash
 .venv/bin/python -m streetscape_metadata_tracker.scheduler --config config/scheduler.makelab1.toml notify-failure
 ```
+
+**Transport under the sandbox (issue #144).** `transport = "mail"` delivers via
+the local mailer, but that goes through a setgid `postdrop` binary that the
+unit's `NoNewPrivileges=yes` blocks — so alerts are *silently lost* from the
+hardened unit even though the failure was detected. Use **`transport =
+"smtp"`** (now the default in `scheduler.makelab1.toml`): it uses stdlib
+`smtplib` to talk to a relay directly, touching no setgid path and no
+read-only `$HOME`, so it works unchanged inside the sandbox (and identically
+on makelab1 or makelab2).
+
+Confirmed working relay (verified from makelab2, 2026-07-17):
+
+```toml
+transport  = "smtp"
+smtp_host  = "smtp.cs.washington.edu"   # UW CSE relay, no auth for on-campus hosts, plain port 25
+smtp_port  = 25
+smtp_from  = "jonf@cs.washington.edu"   # MUST be a real mailbox — see below
+```
+
+Gotchas that already bit us: (1) the relay **rejects a non-deliverable
+envelope sender** (`550 <streetscape-tracker@makelab2…> Address unknown`), so
+`smtp_from` must be a real address — the code's `streetscape-tracker@<hostname>`
+default won't work here. (2) `localmail.cs.washington.edu` (the box's own
+sendmail smarthost) does **not** resolve for a direct connect; use
+`smtp.cs.washington.edu`. For a relay that needs auth, set `smtp_user` +
+`smtp_starttls` and keep the password in `$STREETSCAPE_ALERT_SMTP_PASSWORD`
+(not the toml). Test end-to-end with the `notify-failure` command above.
 
 **Optional systemd safety net** — for an email even when the process dies
 before it can send its own (OOM, kill): install the notify unit and uncomment

--- a/streetscape_metadata_tracker/alerting.py
+++ b/streetscape_metadata_tracker/alerting.py
@@ -126,15 +126,18 @@ def _send_smtp(cfg: AlertConfig, subject: str, full_subject: str, body: str) -> 
         logger.error('Alert not sent — transport "smtp" requires [alerts] smtp_host')
         return False
     password = os.environ.get(SMTP_PASSWORD_ENV) or cfg.smtp_password
-    msg = build_smtp_message(cfg.smtp_from, cfg.recipient, full_subject, body)
     try:
+        # build_smtp_message is inside the try: EmailMessage header assignment
+        # raises ValueError on e.g. a newline in the subject, and alerting must
+        # never take down a collection run.
+        msg = build_smtp_message(cfg.smtp_from, cfg.recipient, full_subject, body)
         with smtplib.SMTP(cfg.smtp_host, cfg.smtp_port, timeout=30) as smtp:
             if cfg.smtp_starttls:
                 smtp.starttls()
             if cfg.smtp_user:
                 smtp.login(cfg.smtp_user, password)
             smtp.send_message(msg)
-    except (OSError, smtplib.SMTPException) as e:
+    except (OSError, smtplib.SMTPException, ValueError) as e:
         logger.error(f"Alert send failed (smtp {cfg.smtp_host}:{cfg.smtp_port}): {e}")
         return False
     logger.info(f"Alert emailed to {cfg.recipient} via smtp {cfg.smtp_host}: {subject}")

--- a/streetscape_metadata_tracker/alerting.py
+++ b/streetscape_metadata_tracker/alerting.py
@@ -15,16 +15,25 @@ logs its own errors and always returns a bool.
 """
 
 import logging
+import os
+import smtplib
 import socket
 import subprocess
 from dataclasses import dataclass
+from email.message import EmailMessage
 
 logger = logging.getLogger(__name__)
 
 # Known transports. "command" is the escape hatch: an arbitrary shell command
 # that receives the body on stdin and the subject/recipient via the
 # STREETSCAPE_ALERT_SUBJECT / STREETSCAPE_ALERT_TO environment variables.
-TRANSPORTS = ("mail", "msmtp", "sendmail", "command")
+# "smtp" talks to a relay directly via stdlib smtplib — no local mailer,
+# so it survives a hardened systemd sandbox (NoNewPrivileges blocks the
+# setgid postdrop path that "mail"/sendmail need). See issue #144.
+TRANSPORTS = ("mail", "msmtp", "sendmail", "command", "smtp")
+
+# Env var an SMTP password may be read from, so the toml can stay secret-free.
+SMTP_PASSWORD_ENV = "STREETSCAPE_ALERT_SMTP_PASSWORD"
 
 
 @dataclass
@@ -40,11 +49,40 @@ class AlertConfig:
     # occasional flaky single city.
     failure_threshold: int = 1
     subject_prefix: str = "[streetscape-tracker]"
+    # --- transport == "smtp" only (all optional but smtp_host) ---
+    smtp_host: str = ""
+    smtp_port: int = 25
+    smtp_from: str = ""  # defaults to streetscape-tracker@<hostname>
+    smtp_starttls: bool = False
+    smtp_user: str = ""  # set together with a password to authenticate
+    # Password for smtp_user. Prefer the SMTP_PASSWORD_ENV env var over the
+    # toml; the env value wins when both are set.
+    smtp_password: str = ""
 
 
 def _message_with_headers(recipient: str, subject: str, body: str) -> str:
     """An RFC-822-ish message for SMTP-style transports (msmtp/sendmail)."""
     return f"To: {recipient}\nSubject: {subject}\nFrom: streetscape-tracker@{socket.gethostname()}\n\n{body}\n"
+
+
+def _default_smtp_from() -> str:
+    """Sender used when [alerts] smtp_from is unset."""
+    return f"streetscape-tracker@{socket.gethostname()}"
+
+
+def build_smtp_message(sender: str, recipient: str, subject: str, body: str) -> EmailMessage:
+    """
+    Build the EmailMessage sent by the ``smtp`` transport.
+
+    Side-effect-free (no network) so tests can assert the headers/body without
+    a relay. ``sender`` empty falls back to ``streetscape-tracker@<hostname>``.
+    """
+    msg = EmailMessage()
+    msg["From"] = sender or _default_smtp_from()
+    msg["To"] = recipient
+    msg["Subject"] = subject
+    msg.set_content(body)
+    return msg
 
 
 def build_send_plan(
@@ -79,6 +117,30 @@ def should_alert(failures: int, threshold: int) -> bool:
     return failures >= max(1, threshold)
 
 
+def _send_smtp(cfg: AlertConfig, subject: str, full_subject: str, body: str) -> bool:
+    """
+    Send via stdlib smtplib straight to a relay — no local mailer, so a
+    hardened systemd sandbox can't break it (issue #144). Never raises.
+    """
+    if not cfg.smtp_host:
+        logger.error('Alert not sent — transport "smtp" requires [alerts] smtp_host')
+        return False
+    password = os.environ.get(SMTP_PASSWORD_ENV) or cfg.smtp_password
+    msg = build_smtp_message(cfg.smtp_from, cfg.recipient, full_subject, body)
+    try:
+        with smtplib.SMTP(cfg.smtp_host, cfg.smtp_port, timeout=30) as smtp:
+            if cfg.smtp_starttls:
+                smtp.starttls()
+            if cfg.smtp_user:
+                smtp.login(cfg.smtp_user, password)
+            smtp.send_message(msg)
+    except (OSError, smtplib.SMTPException) as e:
+        logger.error(f"Alert send failed (smtp {cfg.smtp_host}:{cfg.smtp_port}): {e}")
+        return False
+    logger.info(f"Alert emailed to {cfg.recipient} via smtp {cfg.smtp_host}: {subject}")
+    return True
+
+
 def send_alert(cfg: AlertConfig, subject: str, body: str) -> bool:
     """
     Best-effort send. Returns True only if the transport command exited 0.
@@ -91,6 +153,10 @@ def send_alert(cfg: AlertConfig, subject: str, body: str) -> bool:
         return False
 
     full_subject = f"{cfg.subject_prefix} {subject}".strip()
+
+    if cfg.transport == "smtp":
+        return _send_smtp(cfg, subject, full_subject, body)
+
     try:
         cmd, stdin_text, use_shell = build_send_plan(
             cfg.transport, cfg.recipient, full_subject, body, cfg.command
@@ -101,8 +167,6 @@ def send_alert(cfg: AlertConfig, subject: str, body: str) -> bool:
 
     env = None
     if use_shell:
-        import os
-
         env = {
             **os.environ,
             "STREETSCAPE_ALERT_SUBJECT": full_subject,

--- a/streetscape_metadata_tracker/scheduler.py
+++ b/streetscape_metadata_tracker/scheduler.py
@@ -177,6 +177,12 @@ def load_scheduler_config(path: str | None = None) -> SchedulerConfig:
             command=al.get("command", ""),
             failure_threshold=al.get("failure_threshold", 1),
             subject_prefix=al.get("subject_prefix", "[streetscape-tracker]"),
+            smtp_host=al.get("smtp_host", ""),
+            smtp_port=al.get("smtp_port", 25),
+            smtp_from=al.get("smtp_from", ""),
+            smtp_starttls=al.get("smtp_starttls", False),
+            smtp_user=al.get("smtp_user", ""),
+            smtp_password=al.get("smtp_password", ""),
         ),
         resource_guard=ResourceGuardConfig(
             enabled=rg.get("enabled", True),

--- a/tests/test_alerting.py
+++ b/tests/test_alerting.py
@@ -5,11 +5,15 @@ mail is ever sent. Also round-trips an [alerts] TOML section through the
 scheduler config loader to confirm the wiring.
 """
 
+import smtplib
+
 import pytest
 
 from streetscape_metadata_tracker.alerting import (
+    SMTP_PASSWORD_ENV,
     AlertConfig,
     build_send_plan,
+    build_smtp_message,
     send_alert,
     should_alert,
 )
@@ -89,6 +93,122 @@ class TestSendAlert:
         assert out.read_text().strip() == "[p] boom -> x@y.z"
 
 
+class _FakeSMTP:
+    """
+    Stand-in for smtplib.SMTP that records what it was asked to do instead of
+    touching the network. Supports the context-manager protocol send_alert uses.
+    """
+
+    def __init__(self, host, port, timeout=None, raise_on=None):
+        self.host, self.port, self.timeout = host, port, timeout
+        self._raise_on = raise_on or set()
+        self.started_tls = False
+        self.login_args = None
+        self.sent = []
+        if "connect" in self._raise_on:
+            raise OSError("connection refused")
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def starttls(self):
+        self.started_tls = True
+
+    def login(self, user, password):
+        if "login" in self._raise_on:
+            raise smtplib.SMTPAuthenticationError(535, b"bad creds")
+        self.login_args = (user, password)
+
+    def send_message(self, msg):
+        self.sent.append(msg)
+
+
+def _patch_smtp(monkeypatch, raise_on=None):
+    """Patch alerting's smtplib.SMTP to a recording fake; return a captor list."""
+    captured = []
+
+    def factory(host, port, timeout=None):
+        smtp = _FakeSMTP(host, port, timeout, raise_on=raise_on)
+        captured.append(smtp)
+        return smtp
+
+    monkeypatch.setattr("streetscape_metadata_tracker.alerting.smtplib.SMTP", factory)
+    return captured
+
+
+class TestBuildSmtpMessage:
+    def test_headers_and_body(self):
+        msg = build_smtp_message("noreply@host", "a@b.c", "subj", "line one")
+        assert msg["From"] == "noreply@host"
+        assert msg["To"] == "a@b.c"
+        assert msg["Subject"] == "subj"
+        assert msg.get_content().strip() == "line one"
+
+    def test_empty_sender_defaults_to_hostname(self):
+        msg = build_smtp_message("", "a@b.c", "s", "b")
+        assert msg["From"].startswith("streetscape-tracker@")
+
+
+class TestSendAlertSmtp:
+    def _cfg(self, **kw):
+        base = dict(
+            enabled=True,
+            recipient="ops@example.edu",
+            transport="smtp",
+            smtp_host="relay.example.edu",
+            subject_prefix="[p]",
+        )
+        base.update(kw)
+        return AlertConfig(**base)
+
+    def test_plain_relay_sends(self, monkeypatch):
+        captured = _patch_smtp(monkeypatch)
+        assert send_alert(self._cfg(smtp_port=2525), "boom", "body") is True
+        (smtp,) = captured
+        assert (smtp.host, smtp.port) == ("relay.example.edu", 2525)
+        assert smtp.started_tls is False and smtp.login_args is None
+        (msg,) = smtp.sent
+        assert msg["To"] == "ops@example.edu"
+        assert msg["Subject"] == "[p] boom"
+
+    def test_missing_host_is_noop(self, monkeypatch):
+        captured = _patch_smtp(monkeypatch)
+        assert send_alert(self._cfg(smtp_host=""), "s", "b") is False
+        assert captured == []
+
+    def test_starttls_and_auth_when_configured(self, monkeypatch):
+        captured = _patch_smtp(monkeypatch)
+        cfg = self._cfg(smtp_starttls=True, smtp_user="u", smtp_password="pw")
+        assert send_alert(cfg, "s", "b") is True
+        (smtp,) = captured
+        assert smtp.started_tls is True
+        assert smtp.login_args == ("u", "pw")
+
+    def test_password_env_overrides_toml(self, monkeypatch):
+        captured = _patch_smtp(monkeypatch)
+        monkeypatch.setenv(SMTP_PASSWORD_ENV, "from-env")
+        cfg = self._cfg(smtp_user="u", smtp_password="from-toml")
+        assert send_alert(cfg, "s", "b") is True
+        assert captured[0].login_args == ("u", "from-env")
+
+    def test_connect_failure_swallowed(self, monkeypatch):
+        _patch_smtp(monkeypatch, raise_on={"connect"})
+        assert send_alert(self._cfg(), "s", "b") is False
+
+    def test_auth_failure_swallowed(self, monkeypatch):
+        _patch_smtp(monkeypatch, raise_on={"login"})
+        cfg = self._cfg(smtp_user="u", smtp_password="pw")
+        assert send_alert(cfg, "s", "b") is False
+
+    def test_smtp_still_requires_recipient(self, monkeypatch):
+        captured = _patch_smtp(monkeypatch)
+        assert send_alert(self._cfg(recipient=""), "s", "b") is False
+        assert captured == []
+
+
 def test_config_loader_reads_alerts_section(tmp_path):
     from streetscape_metadata_tracker.scheduler import load_scheduler_config
 
@@ -97,14 +217,22 @@ def test_config_loader_reads_alerts_section(tmp_path):
         "[alerts]\n"
         "enabled = true\n"
         'recipient = "ops@example.edu"\n'
-        'transport = "msmtp"\n'
+        'transport = "smtp"\n'
         "failure_threshold = 3\n"
+        'smtp_host = "relay.example.edu"\n'
+        "smtp_port = 587\n"
+        "smtp_starttls = true\n"
+        'smtp_user = "svc"\n'
     )
     cfg = load_scheduler_config(str(p))
     assert cfg.alerts.enabled is True
     assert cfg.alerts.recipient == "ops@example.edu"
-    assert cfg.alerts.transport == "msmtp"
+    assert cfg.alerts.transport == "smtp"
     assert cfg.alerts.failure_threshold == 3
+    assert cfg.alerts.smtp_host == "relay.example.edu"
+    assert cfg.alerts.smtp_port == 587
+    assert cfg.alerts.smtp_starttls is True
+    assert cfg.alerts.smtp_user == "svc"
 
 
 def test_config_loader_alerts_default_off(tmp_path):

--- a/tests/test_alerting.py
+++ b/tests/test_alerting.py
@@ -208,6 +208,13 @@ class TestSendAlertSmtp:
         assert send_alert(self._cfg(recipient=""), "s", "b") is False
         assert captured == []
 
+    def test_bad_header_is_swallowed(self, monkeypatch):
+        # A newline in the subject makes EmailMessage header assignment raise
+        # ValueError; alerting must catch it, not crash the run.
+        captured = _patch_smtp(monkeypatch)
+        assert send_alert(self._cfg(), "line one\nInjected: header", "b") is False
+        assert captured == []
+
 
 def test_config_loader_reads_alerts_section(tmp_path):
     from streetscape_metadata_tracker.scheduler import load_scheduler_config

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -247,7 +247,10 @@ def test_makelab1_production_config_is_wired():
     assert cfg.enabled_providers() == ["gsv", "mapillary"]
     assert cfg.publish_enabled
     assert cfg.publish_script.endswith("sync_data_to_server.sh")
-    assert cfg.alerts.enabled and cfg.alerts.transport == "mail" and cfg.alerts.recipient
+    # smtp transport (not "mail"): the local mailer is blocked by the systemd
+    # sandbox, so alerts go straight to the campus relay (issue #144).
+    assert cfg.alerts.enabled and cfg.alerts.transport == "smtp" and cfg.alerts.recipient
+    assert cfg.alerts.smtp_host and cfg.alerts.smtp_from
     # Data/DB live on lab storage (makelab2), not in the web docroot.
     assert "/projects/makeabilitylab/streetscape-tracker" in cfg.db_path
     assert "/cse/web/" not in cfg.db_path and "/cse/web/" not in cfg.data_dir


### PR DESCRIPTION
## What

Adds an `smtp` alert transport to the scheduler (stdlib `smtplib`, talks to a relay directly), and flips the makelab1 production config to use it. Fixes #144.

## Why

`transport = "mail"` is **silently blocked under the systemd sandbox**: local submission goes through the setgid `postdrop` binary that `NoNewPrivileges=yes` rejects, and `ProtectSystem=strict` makes `$HOME` (the dead-letter path) read-only. On the first live night (2026-07-16) the failure *policy* worked — it correctly detected the failed publish — but the alert send itself failed and the operator heard nothing.

The `smtp` transport sidesteps the local mailer entirely: no setgid path, no `$HOME` write, so it works unchanged inside the hardened unit and identically on makelab1/makelab2.

## Changes

- **`alerting.py`** — new `"smtp"` transport. `AlertConfig` gains `smtp_host/port/from/starttls/user/password`; password can come from `$STREETSCAPE_ALERT_SMTP_PASSWORD` (env wins) so no secret lands in the toml. Pure `build_smtp_message()` is split from the `smtplib` send, matching the existing `build_send_plan`/`send_alert` separation; `send_alert` still never raises.
- **`scheduler.py`** — wired the new toml keys.
- **`tests/test_alerting.py`** — +11 tests with an in-memory `smtplib.SMTP` fake (headers/body, plain-relay send, STARTTLS+auth only when configured, env-password precedence, connect/auth failures swallowed → `False`, missing-host/recipient no-ops, config round-trip).
- **`config/scheduler.makelab1.toml`** — flipped `transport` to `smtp` with the confirmed relay values.
- **`config/scheduler.toml`, `deploy/README.md`** — documented the transport and gotchas.

## Verified

Sent end-to-end from makelab2 through the UW CSE relay **`smtp.cs.washington.edu:25`** (no auth, on-campus) using the exact smtplib path this code uses — three test emails received. Two gotchas the probe caught, now documented:

1. The relay **rejects a non-deliverable envelope sender** (`550 <streetscape-tracker@makelab2…> Address unknown`), so `smtp_from` must be a real mailbox — the code's `streetscape-tracker@<hostname>` default won't work with this relay. Production config sets `smtp_from = "jonf@cs.washington.edu"`.
2. `localmail.cs.washington.edu` (the box's sendmail smarthost) does **not** resolve for a direct connect — use `smtp.cs.washington.edu`.

Full suite: 384 passing, ruff clean.

## Deploy note

Takes effect on makelab2 only once `config/scheduler.makelab1.toml` is copied to the box (`git pull` alone doesn't apply it). To be done post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)