### PR TITLE
Street-coverage review fixes: reciprocal-edge double-count + legacy-CSV crash (for #141)

### DIFF
--- a/streetscape_street_analyzer/analyze.py
+++ b/streetscape_street_analyzer/analyze.py
@@ -43,14 +43,13 @@ def _warn_no_panos(df, provider: str) -> None:
     (0% coverage) artifact isn't mistaken for a real coverage gap.
 
     The common GSV cause is a legacy pre-copyright baseline CSV: ``copyright_info``
-    is entirely empty, so nothing matches the official ``© Google`` filter. This
-    reflects missing metadata, not missing imagery. Otherwise the run genuinely
-    carries no imagery this provider counts (e.g. only third-party GSV panos).
+    is missing (either absent as a column or entirely empty), so nothing matches
+    the official ``© Google`` filter. This reflects missing metadata, not missing
+    imagery. Otherwise the run genuinely carries no imagery this provider counts
+    (e.g. only third-party GSV panos).
     """
-    legacy_no_copyright = (
-        provider == "gsv"
-        and "copyright_info" in df.columns
-        and df["copyright_info"].notna().sum() == 0
+    legacy_no_copyright = provider == "gsv" and (
+        "copyright_info" not in df.columns or df["copyright_info"].notna().sum() == 0
     )
     if legacy_no_copyright:
         logger.warning(
@@ -60,11 +59,17 @@ def _warn_no_panos(df, provider: str) -> None:
             "missing metadata, NOT missing imagery. Consider re-collecting this "
             "city before publishing a streets artifact for it."
         )
-    else:
+    elif provider == "gsv":
         logger.warning(
             "0 panos selected; the coverage artifact will be entirely uncovered "
             "(0% coverage). For GSV this means the run has no official "
             "'© Google' imagery (e.g. only third-party contributor panos)."
+        )
+    else:
+        logger.warning(
+            "0 panos selected; the coverage artifact will be entirely uncovered "
+            "(0%% coverage). This %s run has no located panos to score against.",
+            provider,
         )
 
 

--- a/streetscape_street_analyzer/download_street_network.py
+++ b/streetscape_street_analyzer/download_street_network.py
@@ -21,6 +21,7 @@ import sqlite3
 import geopandas as gpd
 import networkx as nx
 import osmnx as ox
+import pandas as pd
 from tenacity import retry, stop_after_attempt, wait_exponential
 
 from streetscape_metadata_tracker import db
@@ -152,17 +153,26 @@ def graph_to_edges(graph: nx.MultiDiGraph) -> gpd.GeoDataFrame:
     """
     Flatten a street graph to a WGS84 edge GeoDataFrame for coverage matching.
 
-    Keeps one row per undirected edge (osmnx returns both directions of a
-    two-way street; they share geometry, so we drop duplicates) with ``highway``,
-    ``length`` (metres), and LineString ``geometry``.
+    Keeps one row per *undirected* edge with ``highway``, ``length`` (metres),
+    and LineString ``geometry``. osmnx emits both directions of a two-way
+    street as two directed edges; we collapse them by their unordered (u, v)
+    node pair. We deliberately do NOT dedup on geometry WKB: osmnx orients each
+    directed edge's geometry in its own travel direction, so the reciprocal
+    edge's LineString is coordinate-reversed and its WKB differs — a WKB compare
+    would keep both and double-count every two-way segment.
     """
     edges = ox.graph_to_gdfs(graph, nodes=False)
-    keep = [c for c in ("highway", "length", "geometry") if c in edges.columns]
-    edges = edges[keep].reset_index(drop=True)
+    # graph_to_gdfs indexes edges by (u, v, key); collapse reciprocal directed
+    # edges (v, u) onto (u, v) via an order-independent node-pair key.
+    u = edges.index.get_level_values("u")
+    v = edges.index.get_level_values("v")
+    undirected_key = pd.Series(
+        [frozenset((a, b)) for a, b in zip(u, v, strict=True)], index=edges.index
+    )
 
-    # Collapse reciprocal directed edges (identical geometry) to avoid
-    # double-counting segments in the coverage stats.
-    edges = edges.loc[~edges.geometry.apply(lambda g: g.wkb).duplicated()].reset_index(drop=True)
+    keep = [c for c in ("highway", "length", "geometry") if c in edges.columns]
+    edges = edges[keep]
+    edges = edges.loc[~undirected_key.duplicated()].reset_index(drop=True)
     return edges
 
 

--- a/streetscape_street_analyzer/street_coverage.py
+++ b/streetscape_street_analyzer/street_coverage.py
@@ -77,7 +77,14 @@ def select_pano_points(df: pd.DataFrame, provider: str) -> gpd.GeoDataFrame:
     """
     mask = (df["status"] == "OK") & df["pano_lat"].notna() & df["pano_lon"].notna()
     if provider == "gsv":
-        mask = mask & is_google_copyright(df["copyright_info"])
+        # A legacy pre-copyright baseline CSV may lack the column entirely (not
+        # just be all-NaN); treat that as "no official Google imagery" (empty
+        # mask) rather than crashing — analyze._warn_no_panos then explains the
+        # 0% result. When present, the exact '© Google' filter applies as usual.
+        if "copyright_info" in df.columns:
+            mask = mask & is_google_copyright(df["copyright_info"])
+        else:
+            mask = mask & False
 
     panos = df.loc[mask, ["pano_lat", "pano_lon", "capture_date"]].copy()
     if not pd.api.types.is_datetime64_any_dtype(panos["capture_date"]):

--- a/tests/test_street_coverage.py
+++ b/tests/test_street_coverage.py
@@ -190,6 +190,20 @@ def test_select_pano_points_gsv_google_only():
     assert len(pts) == 1
 
 
+def test_select_pano_points_gsv_missing_copyright_column():
+    """A legacy pre-copyright baseline CSV may lack the copyright_info column
+    entirely. GSV selection must treat that as 'no official Google imagery'
+    (empty result) rather than raising KeyError."""
+    df = _run_df(
+        [
+            ("OK", LAT0, LON0, "2024-01-01", "© Google"),
+            ("OK", LAT0, LON0, "2024-01-01", "© Google"),
+        ]
+    ).drop(columns=["copyright_info"])
+    pts = select_pano_points(df, "gsv")
+    assert len(pts) == 0
+
+
 def test_select_pano_points_mapillary_keeps_all_located():
     df = _run_df(
         [
@@ -407,8 +421,11 @@ def test_network_cache_filename_types():
 
 
 def test_graph_to_edges_collapses_reciprocal_edges():
-    """osmnx returns both directions of a two-way street; identical geometry
-    must be collapsed to one row so segments aren't double-counted."""
+    """osmnx returns both directions of a two-way street, and orients each
+    directed edge's geometry in its own travel direction — so the reciprocal
+    edge's LineString is coordinate-REVERSED. graph_to_edges must still collapse
+    the pair to one row (by unordered node pair, not geometry WKB) so segments
+    aren't double-counted."""
     import networkx as nx
 
     from streetscape_street_analyzer.download_street_network import graph_to_edges
@@ -417,9 +434,10 @@ def test_graph_to_edges_collapses_reciprocal_edges():
     g.add_node(1, x=-121.310, y=44.050)
     g.add_node(2, x=-121.309, y=44.050)
     g.add_node(3, x=-121.308, y=44.050)
-    two_way = LineString([(-121.310, 44.050), (-121.309, 44.050)])
-    g.add_edge(1, 2, highway="residential", length=80.0, geometry=two_way)
-    g.add_edge(2, 1, highway="residential", length=80.0, geometry=two_way)  # reciprocal
+    forward = LineString([(-121.310, 44.050), (-121.309, 44.050)])
+    reverse = LineString([(-121.309, 44.050), (-121.310, 44.050)])  # osmnx reverses it
+    g.add_edge(1, 2, highway="residential", length=80.0, geometry=forward)
+    g.add_edge(2, 1, highway="residential", length=80.0, geometry=reverse)  # reciprocal
     g.add_edge(
         2,
         3,

--- a/www/js/street-coverage.js
+++ b/www/js/street-coverage.js
@@ -50,6 +50,12 @@ const STREET_PANEL_BG = "#1b1f24";
  * to OSM highway classes in importance order. Any class outside this set
  * (living_street, other, unknown) folds into a neutral "minor" gray rather than
  * cycling a hue — per the dataviz rule that a 9th category is never a new color.
+ *
+ * This is DELIBERATELY narrower than the Python side's `_HIGHWAY_BUCKETS`
+ * (street_coverage.py), which recognizes `living_street` as its own bucket.
+ * Don't "sync" them by adding a 9th color here: the analyzer may emit a
+ * `living_street` bucket, and it is meant to render as the minor gray. Only
+ * these eight get a dedicated hue.
  */
 const STREET_TYPE_COLORS = {
   motorway: "#3987e5",


### PR DESCRIPTION
Review fixes for #141. Targets the feature branch so the fixes are reviewable in isolation before landing in #141.

## What & why

**1. 🔴 Two-way streets double-counted (`graph_to_edges`)**
`graph_to_edges` deduped reciprocal directed edges by geometry **WKB**. osmnx orients each directed edge's geometry in its own travel direction, so the reciprocal `(v,u)` edge is coordinate-**reversed** — its WKB differs and the dedup collapsed *nothing*. Now deduped by the unordered `(u, v)` node pair.

Verified end-to-end on a real Overpass network (Sawpit, CO):
| | segments |
|---|---|
| osmnx directed edges | 24 |
| **old** WKB dedup | 24 ❌ (double-counted) |
| **new** node-pair dedup | 12 ✅ |

Every `totals.segments` / `length_km` in the published artifact was ~2× reality (coverage *percentages* were unaffected). Hardened the unit test to use a reversed reciprocal geometry — the case the old identical-geometry test missed.

**2. 🟠 Legacy-CSV KeyError (`select_pano_points`)**
A pre-copyright baseline CSV can lack the `copyright_info` column entirely (not just be all-NaN). GSV selection indexed it unconditionally → `KeyError`, crashing before `_warn_no_panos` could explain the 0% result. Now a missing column → empty selection. Added a regression test.

**3. 🟡 `_warn_no_panos`** now treats an absent `copyright_info` column as the legacy case, and gives non-GSV providers provider-neutral wording instead of a GSV-specific "© Google" message.

**4. 🟡 `street-coverage.js`** comment: the 8-color type palette is deliberately narrower than Python's `_HIGHWAY_BUCKETS` (`living_street` folds to minor gray) — documented so the two tables aren't mistakenly "synced".

## Testing
- 380 pytest + 34 JS unit tests pass; ruff clean.
- Fix 1 validated end-to-end with a real OSM download (24→12 above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)