### PR TITLE
Cap dense-city marker rendering, add a minimizable capture-date chart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,10 @@ cities/~$SUB-IP-EST2023-POP.xlsx
 cities/SUB-IP-EST2023-POP.csv
 *.log
 /duplicates
-.env
+# Credentials: .env plus any variant (.env.bak.*, .env.local, ...). Only a
+# committed-by-design template is exempt.
+.env*
+!.env.example
 /logs/
 *.db
 *.db-wal

--- a/docs/city_sampling.md
+++ b/docs/city_sampling.md
@@ -8,7 +8,7 @@ methodology is citable in publications.
 The catalog (`data/gsv_tracker.db`, table `cities`) is the source of truth for
 what is tracked; this doc explains *how that set was assembled*.
 
-## Current composition (snapshot: 2026-07-08 — provisional, see [#112](https://github.com/jonfroehlich/gsv-tracker/issues/112))
+## Current composition (snapshot: 2026-07-08 — counts reconciled, see [#112](https://github.com/jonfroehlich/gsv-tracker/issues/112))
 
 Numbers below are from the live catalog and will drift as collection continues —
 regenerate them with the queries in [Reproducing these numbers](#reproducing-these-numbers).
@@ -31,15 +31,15 @@ regenerate them with the queries in [Reproducing these numbers](#reproducing-the
 > ~1,132 cities of data" are both true at once. Do not read these counts as v2
 > collection.
 
-> **⚠️ Caveat — the counts here are provisional and under investigation
-> ([#112](https://github.com/jonfroehlich/gsv-tracker/issues/112)).** An earlier
-> working estimate of **"~488 cities"** does not match anything in the catalog
-> (which lands at 1,132/1,143) and has **not yet been reconciled** — it may be a
-> pre-import snapshot, the count actually published/synced to the web server, or
-> a different subset. Until #112 resolves it, treat every number in this section
-> as a raw catalog readout, not a settled project figure, and prefer explicit
-> definitions (`registered` vs `has archival baseline` vs `collected live under
-> v2` vs `published to web`) over a single "cities tracked" number. Note also
+> **Count reconciliation ([#112](https://github.com/jonfroehlich/gsv-tracker/issues/112), resolved).**
+> The catalog figures — **1,143 registered / 1,132 with pano data** — are
+> canonical. The earlier working estimate of **"~488 cities"** does **not**
+> correspond to anything in the catalog and is a **stale pre-import / working
+> estimate** (likely a pre-migration snapshot or a since-superseded published
+> subset); it is not a real project count and there is no data discrepancy to
+> reconcile. Always prefer explicit definitions (`registered` vs `has archival
+> baseline` vs `collected live under v2` vs `published to web`) over a single
+> "cities tracked" number. Note also
 > that catalog `created_at` is *not* a history: the migration rebuilt every row
 > in July 2026, so all rows share a `2026-07` timestamp.
 

--- a/www/city.html
+++ b/www/city.html
@@ -26,7 +26,14 @@
   <div id="map" role="application" aria-label="City panorama age map"></div>
 
   <div id="temporal-plot-container">
-    <canvas id="temporal-plot"></canvas>
+    <div id="temporal-plot-head">
+      <span id="temporal-plot-title">Panoramas by capture date</span>
+      <button type="button" id="temporal-plot-toggle" aria-expanded="true"
+              aria-controls="temporal-plot-body" aria-label="Minimize capture-date chart">–</button>
+    </div>
+    <div id="temporal-plot-body">
+      <canvas id="temporal-plot"></canvas>
+    </div>
   </div>
 
   <!-- OSM street-coverage panel (populated by street-coverage.js; stays

--- a/www/css/city.css
+++ b/www/css/city.css
@@ -252,18 +252,71 @@
   margin-top: 5px;
 }
 
-/* ── Temporal chart (bottom-right) ──────────────────────────── */
+/* ── Temporal chart (bottom-right, collapsible) ─────────────── */
 #temporal-plot-container {
   position: absolute;
   bottom: 20px;
   right: 20px;
   background: rgba(80, 80, 80, 0.9);
   border-radius: 4px;
-  padding: 10px;
   box-shadow: 0 0 15px rgba(0, 0, 0, 0.2);
   z-index: 1000;
   width: 400px;
-  height: 200px;
+  overflow: hidden;
+}
+
+#temporal-plot-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 6px 6px 6px 10px;
+}
+
+#temporal-plot-title {
+  font-size: 12px;
+  font-weight: 600;
+  color: #eee;
+}
+
+#temporal-plot-toggle {
+  flex: none;
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  font-size: 16px;
+  line-height: 1;
+  color: #eee;
+  background: transparent;
+  border: 1px solid #999;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+#temporal-plot-toggle:hover {
+  background: rgba(255, 255, 255, 0.12);
+}
+
+#temporal-plot-toggle:focus-visible {
+  outline: 2px solid #1a73e8;
+  outline-offset: 1px;
+}
+
+/* Body holds the Chart.js canvas; needs an explicit height so the chart
+   (maintainAspectRatio:false) has a box to fill. */
+#temporal-plot-body {
+  position: relative;
+  height: 190px;
+  padding: 0 10px 10px;
+}
+
+/* Collapsed: only the header bar shows, and the panel shrinks to its width. */
+#temporal-plot-container.collapsed {
+  width: auto;
+}
+
+#temporal-plot-container.collapsed #temporal-plot-body {
+  display: none;
 }
 
 /* ── OSM street-coverage panel (top-left, below back link) ─────

--- a/www/css/city.css
+++ b/www/css/city.css
@@ -10,6 +10,13 @@
   box-shadow: 0 0 15px rgba(0, 0, 0, 0.2);
   border-radius: 5px;
   min-width: 180px;
+  /* Bound the panel so content-heavy cities (many capture years, the cap
+     notice, snapshot/imagery sections) scroll inside it instead of growing
+     past the viewport. Scroll propagation to the map is already disabled in
+     legendControl.onAdd, so wheel-scrolling the legend won't zoom the map. */
+  max-width: 300px;
+  max-height: calc(100vh - 90px);
+  overflow-y: auto;
 }
 
 .legend h4 {
@@ -106,6 +113,20 @@
 /* Keep the parenthetical count legible on the active (blue) button */
 .gsv-mode-btn.active .year-count {
   color: #dbe8ff;
+}
+
+/* ── Render-cap notice (issues #77/#58) ─────────────────────── */
+/* Shown for cities above RENDER_CAP: reports drawn-vs-total and the opt-in
+   "Render all" override. Reuses .legend-meta typography and the .gsv-mode-btn
+   pill (which gets a real focus outline and hover/active styling for free). */
+.legend-cap-notice {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.legend-cap-notice .gsv-mode-btn {
+  width: 100%;
 }
 
 /* ── Year filter section header ─────────────────────────────── */

--- a/www/eslint.config.js
+++ b/www/eslint.config.js
@@ -29,6 +29,7 @@ const vendorGlobals = {
 // streetscape-utils.js's own definitions aren't flagged as `no-redeclare`.
 const sharedGlobals = {
   STREETSCAPE_DATA_BASE_URL: "readonly",
+  RENDER_CAP: "readonly",
   PROVIDERS: "readonly",
   METRICS: "readonly",
   isKnownProvider: "readonly",
@@ -49,6 +50,9 @@ const sharedGlobals = {
   withAlpha: "readonly",
   fmtYears: "readonly",
   formatChangeSummary: "readonly",
+  spatialStrideSample: "readonly",
+  computeVisibilityDelta: "readonly",
+  markerDateStyle: "readonly",
 };
 
 const browserRules = {

--- a/www/js/__tests__/streetscape-utils.test.js
+++ b/www/js/__tests__/streetscape-utils.test.js
@@ -30,6 +30,10 @@ const {
   withAlpha,
   fmtYears,
   formatChangeSummary,
+  RENDER_CAP,
+  spatialStrideSample,
+  computeVisibilityDelta,
+  markerDateStyle,
 } = require("../streetscape-utils.js");
 
 // --- adaptCityRecord: v1/v2/v3 aggregate flattening ------------------------
@@ -580,4 +584,119 @@ test("panoDateOrNull: date-only strings are local calendar dates (no TZ shift)",
   const ts = panoDateOrNull("2026-07-05T12:34:56+00:00");
   assert.ok(ts instanceof Date && !Number.isNaN(ts.getTime()));
   assert.equal(ts.getUTCHours(), 12);
+});
+
+// --- Render cap: spatialStrideSample (issues #77/#58) ---------------------
+
+test("spatialStrideSample: returns all indices when total <= cap", () => {
+  const pts = [[0, 0], [1, 1], [2, 2]];
+  assert.deepEqual(spatialStrideSample(pts, 5), [0, 1, 2]);
+  assert.deepEqual(spatialStrideSample(pts, 3), [0, 1, 2]); // exactly at cap
+  assert.deepEqual(spatialStrideSample([], 10), []);
+});
+
+test("spatialStrideSample: caps to exactly `cap` indices when total > cap", () => {
+  const pts = Array.from({ length: 100 }, (_, i) => [i, 0]);
+  const idx = spatialStrideSample(pts, 10);
+  assert.equal(idx.length, 10);
+  // Every index is valid and unique.
+  assert.equal(new Set(idx).size, 10);
+  idx.forEach((i) => assert.ok(i >= 0 && i < 100));
+});
+
+test("spatialStrideSample: guards non-positive / non-finite cap", () => {
+  const pts = [[0, 0], [1, 1]];
+  assert.deepEqual(spatialStrideSample(pts, 0), []);
+  assert.deepEqual(spatialStrideSample(pts, -5), []);
+  assert.deepEqual(spatialStrideSample(pts, Infinity), []);
+  assert.deepEqual(spatialStrideSample(pts, NaN), []);
+});
+
+test("spatialStrideSample: deterministic for the same input", () => {
+  const pts = Array.from({ length: 50 }, (_, i) => [Math.sin(i), Math.cos(i)]);
+  assert.deepEqual(spatialStrideSample(pts, 12), spatialStrideSample(pts, 12));
+});
+
+test("spatialStrideSample: subset spans the full spatial extent (no clumping)", () => {
+  // Points laid out along a diagonal; a head-of-list or single-corner sample
+  // would collapse the lat/lon range. The stride must keep near-full spread.
+  const n = 1000;
+  const pts = Array.from({ length: n }, (_, i) => [i / n, i / n]);
+  const idx = spatialStrideSample(pts, 20);
+  const lats = idx.map((i) => pts[i][0]);
+  assert.ok(Math.min(...lats) <= 0.05, "samples reach the low end");
+  assert.ok(Math.max(...lats) >= 0.95, "samples reach the high end");
+});
+
+test("spatialStrideSample: orders by latitude then longitude before striding", () => {
+  // Reverse-sorted input; a cap of 2 over 4 points strides the SORTED order,
+  // so it must pick from the low end first, not the input's head.
+  const pts = [[9, 0], [8, 0], [1, 0], [0, 0]];
+  const idx = spatialStrideSample(pts, 2);
+  const lats = idx.map((i) => pts[i][0]).sort((a, b) => a - b);
+  // Lowest-latitude point (0) is always the first stride pick.
+  assert.equal(lats[0], 0);
+});
+
+// --- Render cap: computeVisibilityDelta -----------------------------------
+
+test("computeVisibilityDelta: identical sets → no work", () => {
+  const a = {}, b = {}, c = {};
+  const onMap = new Set([a, b, c]);
+  const { toAdd, toRemove } = computeVisibilityDelta(onMap, new Set([a, b, c]));
+  assert.deepEqual(toAdd, []);
+  assert.deepEqual(toRemove, []);
+});
+
+test("computeVisibilityDelta: empty on-map → add everything (initial render)", () => {
+  const a = {}, b = {};
+  const { toAdd, toRemove } = computeVisibilityDelta(new Set(), [a, b]);
+  assert.deepEqual(new Set(toAdd), new Set([a, b]));
+  assert.deepEqual(toRemove, []);
+});
+
+test("computeVisibilityDelta: disjoint sets → full swap", () => {
+  const a = {}, b = {}, c = {}, d = {};
+  const { toAdd, toRemove } = computeVisibilityDelta(new Set([a, b]), new Set([c, d]));
+  assert.deepEqual(new Set(toAdd), new Set([c, d]));
+  assert.deepEqual(new Set(toRemove), new Set([a, b]));
+});
+
+test("computeVisibilityDelta: overlap → only the difference moves", () => {
+  const a = {}, b = {}, c = {};
+  const { toAdd, toRemove } = computeVisibilityDelta(new Set([a, b]), new Set([b, c]));
+  assert.deepEqual(toAdd, [c]);
+  assert.deepEqual(toRemove, [a]);
+});
+
+test("computeVisibilityDelta: accepts an array target", () => {
+  const a = {}, b = {};
+  const { toAdd, toRemove } = computeVisibilityDelta(new Set([a]), [a, b]);
+  assert.deepEqual(toAdd, [b]);
+  assert.deepEqual(toRemove, []);
+});
+
+// --- Render cap: markerDateStyle ------------------------------------------
+
+test("markerDateStyle: no selected date → default style", () => {
+  assert.deepEqual(markerDateStyle("Mon Jan 02 2023", null), { fillOpacity: 0.8, radius: 3 });
+  assert.deepEqual(markerDateStyle("Mon Jan 02 2023", ""), { fillOpacity: 0.8, radius: 3 });
+});
+
+test("markerDateStyle: matching date → emphasized", () => {
+  assert.deepEqual(
+    markerDateStyle("Mon Jan 02 2023", "Mon Jan 02 2023"),
+    { fillOpacity: 1, radius: 4 },
+  );
+});
+
+test("markerDateStyle: non-matching date → dimmed", () => {
+  assert.deepEqual(
+    markerDateStyle("Tue Jan 03 2023", "Mon Jan 02 2023"),
+    { fillOpacity: 0.05, radius: 3 },
+  );
+});
+
+test("RENDER_CAP is a positive finite number", () => {
+  assert.ok(Number.isFinite(RENDER_CAP) && RENDER_CAP > 0);
 });

--- a/www/js/city.js
+++ b/www/js/city.js
@@ -846,6 +846,7 @@ function createTemporalPlot(canvas) {
     plugins: [verticalLinePlugin],
   });
   temporalChartGlobal = chart;
+  setupTemporalToggle(chart);
 
   /** Apply (or toggle off) the date filter for one capture date. */
   function selectFilterDate(date) {
@@ -918,6 +919,40 @@ function createTemporalPlot(canvas) {
     selectFilterDate(d.date);
     liveRegion.textContent =
       `${d.date.toLocaleDateString()}: ${d.count.toLocaleString()} panoramas highlighted`;
+  });
+}
+
+/**
+ * Wire the temporal panel's minimize/expand button. Collapsing hides the chart
+ * body so it stops covering the map; the choice persists across runs/reloads in
+ * localStorage. Chart.js is resized on expand because it can't measure a
+ * display:none parent.
+ *
+ * @param {Chart} chart - The temporal Chart.js instance.
+ */
+function setupTemporalToggle(chart) {
+  const container = document.getElementById("temporal-plot-container");
+  const toggle = document.getElementById("temporal-plot-toggle");
+  if (!container || !toggle) return;
+
+  const KEY = "streetscape-temporal-collapsed";
+  const apply = (collapsed) => {
+    container.classList.toggle("collapsed", collapsed);
+    toggle.setAttribute("aria-expanded", String(!collapsed));
+    toggle.setAttribute("aria-label",
+      collapsed ? "Expand capture-date chart" : "Minimize capture-date chart");
+    toggle.textContent = collapsed ? "+" : "–";
+    if (!collapsed) chart.resize();
+  };
+
+  let collapsed = false;
+  try { collapsed = localStorage.getItem(KEY) === "1"; } catch { /* storage may be blocked */ }
+  apply(collapsed);
+
+  toggle.addEventListener("click", () => {
+    collapsed = !collapsed;
+    try { localStorage.setItem(KEY, collapsed ? "1" : "0"); } catch { /* storage may be blocked */ }
+    apply(collapsed);
   });
 }
 

--- a/www/js/city.js
+++ b/www/js/city.js
@@ -1,5 +1,5 @@
-/* exported switchRun, toggleYear, setGsvMode, toggleFlatOnly */
-// (switchRun/toggleYear/setGsvMode/toggleFlatOnly are invoked from onchange/onclick
+/* exported switchRun, toggleYear, setGsvMode, toggleFlatOnly, setRenderAll */
+// (switchRun/toggleYear/setGsvMode/toggleFlatOnly/setRenderAll are invoked from onchange/onclick
 // attributes in the HTML this file generates, so ESLint can't see those
 // string references.)
 /**
@@ -66,6 +66,29 @@ let flatOnlyMarkers = [];
 let showFlatOnly = false;
 const FLAT_ONLY_COLOR = "#9aa0a6"; // muted gray — visibly not a dated pano
 
+// ── Render-cap / visibility model (issues #77, #58) ─────────────
+// `markersByYear` holds every streamed pano marker (both GSV modes). What is
+// actually *drawn* is reconciled through a single desired→onMap delta so no
+// interaction re-touches all N markers, and so dense cities can draw only a
+// spatial subsample. Reported stats/counts/plot always use the full set.
+let onMap = new Set();          // markers currently added to the Leaflet map
+let desiredShown = new Set();   // markers that SHOULD be drawn right now
+let renderAllOverride = false;  // user opted out of the cap ("Render all")
+let panoDotsHidden = false;     // streets overlay hid the pano layer
+
+// Mode-scoped caches, rebuilt by rebuildModeCaches() on load and on setGsvMode.
+// "In mode" = markerInMode(): Google-only (default) vs all-GSV; for non-GSV and
+// archival runs every marker is in mode.
+let inModeAll = [];             // all in-mode markers
+let inModeByYear = new Map();   // year -> in-mode markers[]
+let inModeCountByYear = new Map(); // year -> count (legend, avoids O(N) per row)
+let inModeByDateStr = new Map();   // captureDate.toDateString() -> in-mode markers[]
+let totalInMode = 0;
+let globalCapped = [];          // spatial-stride subsample of inModeAll (<= RENDER_CAP)
+let cappedByYear = new Map();   // year -> stride subsample (lazy)
+let allMarkerCount = 0;         // both modes; fixed per run (legend "All GSV" count)
+let googleMarkerCount = 0;      // official-Google markers; fixed per run
+
 // Temporal-plot handles, kept at module scope so setGsvMode() can rebuild the
 // plot in place (updating the existing chart/handlers rather than re-creating
 // them and duplicating the keyboard listeners / live region).
@@ -85,12 +108,8 @@ let changeGlobal = null;    // change_from_previous_run block of this run
 map.on("click", (e) => {
   if (e.originalEvent.target !== map._container) return;
   selectedDate = null;
-  Object.values(markersByYear).flat().forEach((m) => {
-    m.setStyle({ fillOpacity: 0.8 });
-    m.setRadius(3);
-  });
   activeYears.clear();
-  showInModeMarkers();
+  applyDesired(); // reconcile drawn set + reset any date dimming (over onMap only)
   updateLegend(Object.keys(markersByYear).map(Number));
 });
 
@@ -108,17 +127,135 @@ function markerInMode(m) {
   return m.options.isGoogle || showAllGsv;
 }
 
+// ── Reconcile model (issues #77, #58) ──────────────────────────
+//
+// One path decides what is drawn: compute the desired set (mode ∧ year ∧ cap,
+// plus the honesty union for a selected date), then add/remove only the delta
+// against what is already on the map. Every interaction routes through
+// applyDesired(), so no click ever re-touches all N markers.
+
 /**
- * Add every in-mode marker to the map and remove every out-of-mode one.
- * The single place that reconciles the drawn marker set with `showAllGsv`;
- * callers that clear a year/date filter delegate the "show everything again"
- * step here so contributor markers stay hidden in Google-only mode.
+ * Spatially-strided subsample of a marker list, or the list itself when it is
+ * already within the cap. Deterministic (see spatialStrideSample) so the drawn
+ * dots stay spread across the city rather than clumping.
+ *
+ * @param {L.CircleMarker[]} markers
+ * @returns {L.CircleMarker[]} At most RENDER_CAP markers.
  */
-function showInModeMarkers() {
-  Object.values(markersByYear).flat().forEach((m) => {
-    if (markerInMode(m)) m.addTo(map);
-    else m.remove();
+function strideSubset(markers) {
+  if (markers.length <= RENDER_CAP) return markers;
+  const pts = markers.map((m) => {
+    const ll = m.getLatLng();
+    return [ll.lat, ll.lng];
   });
+  return spatialStrideSample(pts, RENDER_CAP).map((i) => markers[i]);
+}
+
+/**
+ * Rebuild the in-mode caches after the marker set's mode changes (initial load
+ * and setGsvMode). Everything downstream reads these instead of re-filtering
+ * all markers on every interaction.
+ */
+function rebuildModeCaches() {
+  inModeAll = [];
+  inModeByYear = new Map();
+  inModeCountByYear = new Map();
+  inModeByDateStr = new Map();
+  for (const [y, markers] of Object.entries(markersByYear)) {
+    const year = Number(y);
+    for (const m of markers) {
+      if (!markerInMode(m)) continue;
+      inModeAll.push(m);
+      if (!inModeByYear.has(year)) inModeByYear.set(year, []);
+      inModeByYear.get(year).push(m);
+      inModeCountByYear.set(year, (inModeCountByYear.get(year) || 0) + 1);
+      const dk = m.options.captureDate.toDateString();
+      if (!inModeByDateStr.has(dk)) inModeByDateStr.set(dk, []);
+      inModeByDateStr.get(dk).push(m);
+    }
+  }
+  totalInMode = inModeAll.length;
+  globalCapped = strideSubset(inModeAll);
+  cappedByYear = new Map();
+}
+
+/**
+ * The set of markers that should currently be drawn. Base membership is the
+ * in-mode set, narrowed to an active year and capped (unless the user chose
+ * "Render all"); a selected date additionally unions in EVERY in-mode marker of
+ * that date at full opacity, so the map never under-shows a date relative to the
+ * temporal plot's count (the render-cap honesty trap).
+ *
+ * @returns {Set<L.CircleMarker>}
+ */
+function computeDesiredShown() {
+  let base;
+  if (activeYears.size) {
+    const y = [...activeYears][0];
+    const yearMarkers = inModeByYear.get(y) ?? [];
+    if (renderAllOverride) {
+      base = yearMarkers;
+    } else {
+      if (!cappedByYear.has(y)) cappedByYear.set(y, strideSubset(yearMarkers));
+      base = cappedByYear.get(y);
+    }
+  } else {
+    base = renderAllOverride ? inModeAll : globalCapped;
+  }
+  const set = new Set(base);
+  if (selectedDate) {
+    for (const m of (inModeByDateStr.get(selectedDate.toDateString()) ?? [])) set.add(m);
+  }
+  return set;
+}
+
+/**
+ * Reconcile the map to `desiredShown` (or nothing, when the streets overlay has
+ * hidden the pano layer) by adding/removing only the delta. Bounded by the
+ * symmetric difference, i.e. ≤ RENDER_CAP work, never O(N).
+ */
+function reconcile() {
+  const target = panoDotsHidden ? new Set() : desiredShown;
+  const { toAdd, toRemove } = computeVisibilityDelta(onMap, target);
+  for (const m of toRemove) { m.remove(); onMap.delete(m); }
+  for (const m of toAdd) { m.addTo(map); onMap.add(m); }
+}
+
+/**
+ * Style every on-map marker for the current date filter (default when no date
+ * is selected). Iterates only what is drawn (≤ cap), so it stays cheap; a
+ * re-added marker that carried a stale dimmed style is corrected here.
+ */
+function restyleOnMap() {
+  const selKey = selectedDate ? selectedDate.toDateString() : null;
+  for (const m of onMap) {
+    const s = markerDateStyle(m.options.captureDate.toDateString(), selKey);
+    m.setStyle({ fillOpacity: s.fillOpacity });
+    m.setRadius(s.radius);
+  }
+}
+
+/**
+ * The single entry point every interaction uses: recompute the desired set,
+ * reconcile the map to it, and restyle what is drawn.
+ */
+function applyDesired() {
+  desiredShown = computeDesiredShown();
+  reconcile();
+  restyleOnMap();
+}
+
+/**
+ * Toggle the render cap off ("Render all") or back on ("Show subset").
+ * Shown only for cities above the cap; see updateLegend's cap notice.
+ *
+ * @param {boolean} on - true = draw all in-mode panos; false = re-apply the cap.
+ */
+function setRenderAll(on) {
+  if (on === renderAllOverride) return;
+  renderAllOverride = on;
+  applyDesired();
+  updateLegend(Object.keys(markersByYear).map(Number));
 }
 
 // ── Legend (Leaflet control) ───────────────────────────────────
@@ -204,6 +341,24 @@ function updateLegend(years) {
     html += `<p class="legend-meta">Dated panos: ${totalPanosGlobal.toLocaleString()}</p>`;
   }
 
+  // ── Cap notice (issues #77/#58) ───────────────────────────
+  // Only for cities above the render cap. The stat table above always shows the
+  // full count; this line is the one place the *drawn* count is exposed, plus
+  // the opt-in override. A year filter usually drops below the cap (full detail
+  // for that year), so the notice is framed around the whole-run picture.
+  if (totalInMode > RENDER_CAP) {
+    const shown = renderAllOverride ? totalInMode : Math.min(RENDER_CAP, totalInMode);
+    html += `
+      <div class="legend-divider"></div>
+      <div class="legend-cap-notice">
+        <p class="legend-meta">Drawing ${shown.toLocaleString()} of
+          ${totalInMode.toLocaleString()} panos${renderAllOverride ? "" : "; filter or zoom for detail"}.</p>
+        <button type="button" class="gsv-mode-btn" onclick="setRenderAll(${!renderAllOverride})">
+          ${renderAllOverride ? `Show ~${RENDER_CAP.toLocaleString()}` : "Render all"}
+        </button>
+      </div>`;
+  }
+
   // ── Section 2: Snapshot history (v2 temporal data) ────────
   if (runsGlobal.length > 1) {
     const options = runsGlobal
@@ -243,9 +398,10 @@ function updateLegend(years) {
   // drawn without any refetch. Other providers' rows are all provider
   // imagery, so there is nothing to toggle.
   if (providerGlobal === "gsv" && copyrightAvailableGlobal) {
-    const allMarkers = Object.values(markersByYear).flat();
-    const allCount = allMarkers.length;
-    const googleCount = allMarkers.filter((m) => m.options.isGoogle).length;
+    // Counts are fixed per run (computed once at finalize), not re-derived from
+    // all N markers on every legend rebuild.
+    const allCount = allMarkerCount;
+    const googleCount = googleMarkerCount;
     html += `
       <div class="legend-divider"></div>
       <div class="legend-year-header">Imagery</div>
@@ -293,8 +449,10 @@ function updateLegend(years) {
       const color = getColor(age, providerGlobal);
       const isActive = activeYears.has(year);
       // Count only markers visible in the current mode, so the year rows
-      // never advertise contributor panos that are hidden in Google-only.
-      const count = (markersByYear[year] || []).filter(markerInMode).length;
+      // never advertise contributor panos that are hidden in Google-only. Uses
+      // the per-year cache (O(years), not O(N) per legend rebuild).
+      const count = inModeCountByYear.get(year)
+        ?? (markersByYear[year] || []).filter(markerInMode).length;
       if (count === 0) return; // a year that is all-contributor drops out in Google-only mode
 
       // Real <button>s (native Enter/Space + focus) with aria-pressed
@@ -355,15 +513,8 @@ function switchRun(dataFile) {
 function toggleYear(year) {
   const wasActive = activeYears.has(year);
   activeYears.clear();
-  showInModeMarkers();
-
-  if (!wasActive) {
-    activeYears.add(year);
-    Object.entries(markersByYear).forEach(([y, markers]) => {
-      if (parseInt(y, 10) !== year) markers.forEach((m) => m.remove());
-    });
-  }
-
+  if (!wasActive) activeYears.add(year);
+  applyDesired();
   updateLegend(Object.keys(markersByYear).map(Number));
 }
 
@@ -393,16 +544,17 @@ function setGsvMode(showAll) {
   oldestDateGlobal = panoDateOrNull(panoStatsGlobal.age_stats.oldest_pano_date);
   newestDateGlobal = panoDateOrNull(panoStatsGlobal.age_stats.newest_pano_date);
 
-  // Clear the year/date filters and reconcile the drawn marker set with the
-  // new mode. resetMarkerStyles undoes any dimming left by an active date
-  // filter; refreshTemporalPlot rebuilds the plot with fresh (un-dimmed)
-  // colors, so the chart needs no separate reset.
+  // Clear the year/date filters, reset the "Render all" override (a new mode is
+  // a fresh honesty budget), rebuild the in-mode caches for the new marker set,
+  // and reconcile the map. applyDesired restyles the drawn set (undoing any date
+  // dimming); refreshTemporalPlot rebuilds the plot with fresh colors.
   activeYears.clear();
   selectedDate = null;
-  resetMarkerStyles();
-  showInModeMarkers();
+  renderAllOverride = false;
+  rebuildModeCaches();
 
-  totalPanosGlobal = Object.values(markersByYear).flat().filter(markerInMode).length;
+  totalPanosGlobal = totalInMode;
+  applyDesired();
   refreshTemporalPlot();
   updateLegend(Object.keys(markersByYear).map(Number));
 }
@@ -701,13 +853,12 @@ function createTemporalPlot(canvas) {
       date = null; // re-selecting the active date clears the filter
     }
     selectedDate = date;
-    if (date) {
-      highlightMarkersForDate(date);
-      updateChartColorsForDate(chart, date);
-    } else {
-      resetMarkerStyles();
-      resetChartColors(chart);
-    }
+    // applyDesired unions in every in-mode marker of the date (so the map can't
+    // under-show it under the render cap) and restyles the drawn set — matching
+    // dots emphasized, the rest dimmed, or all reset when the filter clears.
+    applyDesired();
+    if (date) updateChartColorsForDate(chart, date);
+    else resetChartColors(chart);
   }
 
   // Date-selection click handler
@@ -771,28 +922,9 @@ function createTemporalPlot(canvas) {
 }
 
 // ── Marker / chart style helpers ───────────────────────────────
-
-/** Reset all map markers to their default style. */
-function resetMarkerStyles() {
-  Object.values(markersByYear).flat().forEach((m) => {
-    m.setStyle({ fillOpacity: 0.8 });
-    m.setRadius(3);
-  });
-}
-
-/**
- * Highlight only map markers whose capture date matches the given date.
- *
- * @param {Date} date
- */
-function highlightMarkersForDate(date) {
-  const dateStr = date.toDateString();
-  Object.values(markersByYear).flat().forEach((m) => {
-    const match = new Date(m.options.captureDate).toDateString() === dateStr;
-    m.setStyle({ fillOpacity: match ? 1 : 0.05 });
-    m.setRadius(match ? 4 : 3);
-  });
-}
+// Map-marker styling for the date filter now lives in restyleOnMap() (which
+// iterates only the drawn set, ≤ cap) via the pure markerDateStyle() helper;
+// the chart-color helpers below are unchanged.
 
 /**
  * Reset chart point colors and opacities to defaults.
@@ -1083,6 +1215,12 @@ async function loadData() {
     const currentYear = new Date().getFullYear();
     const processedPanos = new Set();
     const validPoints = [];
+    // Progressive render: draw in-mode markers as they stream in, but stop once
+    // the cap is reached (a dense city's first rows are one geographic band, so
+    // the honest spatial subsample is applied once at finalize instead). Small
+    // cities never hit the cap and simply fill in live.
+    let streamedInMode = 0;
+    let streamCapReached = false;
 
     /**
      * Process a batch of parsed CSV rows, creating a map marker per pano.
@@ -1164,7 +1302,14 @@ async function loadData() {
           captureDateStr: String(row.capture_date),
           isGoogle,
         });
-        if (markerInMode(marker)) marker.addTo(map);
+        if (markerInMode(marker)) {
+          validPoints.push([row.pano_lat, row.pano_lon]);
+          if (!streamCapReached) {
+            marker.addTo(map);
+            onMap.add(marker);
+            if (++streamedInMode >= RENDER_CAP) streamCapReached = true;
+          }
+        }
 
         const photographer = providerGlobal !== "gsv"
           ? (row.copyright_info || PROVIDERS[providerGlobal].label)
@@ -1176,7 +1321,6 @@ async function loadData() {
 
         if (!markersByYear[year]) markersByYear[year] = [];
         markersByYear[year].push(marker);
-        if (markerInMode(marker)) validPoints.push([row.pano_lat, row.pano_lon]);
       }
     }
 
@@ -1257,10 +1401,20 @@ async function loadData() {
     progressFill.setAttribute("aria-valuenow", 100);
     progressContainer.style.display = "none";
 
-    // Dated-pano count reflects the current mode (Google-only by default);
-    // it and the plot are recomputed from the in-mode markers, matching what
-    // is drawn on the map.
-    totalPanosGlobal = Object.values(markersByYear).flat().filter(markerInMode).length;
+    // Fixed per-run marker counts (both GSV modes) for the legend's imagery
+    // toggle — computed once here, not re-derived on every legend rebuild.
+    const flatMarkers = Object.values(markersByYear).flat();
+    allMarkerCount = flatMarkers.length;
+    googleMarkerCount = flatMarkers.filter((m) => m.options.isGoogle).length;
+
+    // Build the in-mode caches, then reconcile the drawn set to the honest
+    // spatial subsample (a no-op for cities under the cap, which already filled
+    // in progressively during streaming). Stats/count/plot use the FULL in-mode
+    // set, so the cap never changes a reported number.
+    rebuildModeCaches();
+    totalPanosGlobal = totalInMode;
+    applyDesired();
+
     updateLegend(Object.keys(markersByYear).map(Number));
 
     createTemporalPlot(document.getElementById("temporal-plot"));
@@ -1272,12 +1426,12 @@ async function loadData() {
     // Optional OSM street-coverage overlay (issue #24); a no-op when the
     // run has no "_streets.json.gz" artifact. The setPanoDotsVisible hook lets
     // its panel show/hide the pano markers (a coarse show-all/hide-all, like
-    // the map-background reset) so the streets can be read on their own.
+    // the map-background reset) so the streets can be read on their own. Goes
+    // through the reconcile model so re-showing respects the mode/year/date/cap.
     renderStreetCoverage(map, targetFile, providerGlobal, {
       setPanoDotsVisible: (visible) => {
-        Object.values(markersByYear)
-          .flat()
-          .forEach((m) => (visible ? m.addTo(map) : m.remove()));
+        panoDotsHidden = !visible;
+        applyDesired();
       },
     });
 

--- a/www/js/streetscape-utils.js
+++ b/www/js/streetscape-utils.js
@@ -15,6 +15,16 @@ const STREETSCAPE_DATA_BASE_URL =
   "https://makeabilitylab.cs.washington.edu/public/streetscape-tracker/data/";
 
 /**
+ * Max pano dots the city map draws at once (issues #77/#58). Dense cities hold
+ * 10^5–10^6 panos; drawing one Leaflet marker layer each makes the map
+ * unreadable at low zoom and freezes on every interaction. Above this count the
+ * detail view draws a deterministic spatial subsample (spatialStrideSample) and
+ * offers an opt-in "Render all" override. Reported stats/counts/plot always use
+ * the FULL in-memory set — only the drawn dots are capped.
+ */
+const RENDER_CAP = 40000;
+
+/**
  * Imagery provider registry. Each provider's color scale is anchored to
  * its launch date (oldest possible imagery = dark red), and each supplies
  * its own pano viewer deep-link and required attribution.
@@ -596,11 +606,87 @@ function formatChangeSummary(change) {
   };
 }
 
+/**
+ * Deterministic spatial-stride subsample used by the city map's render cap
+ * (issues #77/#58). Orders the points spatially (by latitude, then longitude)
+ * and takes an even stride so the drawn subset stays spread across the city —
+ * density and coverage gaps remain honest, unlike a random or head-of-list
+ * drop that would clump in whatever order the CSV happened to arrive.
+ *
+ * Pure and Leaflet-free so it is node-testable (mirrors METRICS/adaptCityRecord).
+ *
+ * @param {Array<[number, number]>} points - [lat, lon] pairs (index-aligned to
+ *   the caller's marker array).
+ * @param {number} cap - Maximum indices to return.
+ * @returns {number[]} Indices INTO `points`: all of them when `points.length <=
+ *   cap` (or the input is empty), otherwise exactly `cap` spatially-strided
+ *   indices. Returns `[]` when `cap <= 0` or is not finite.
+ */
+function spatialStrideSample(points, cap) {
+  const n = points.length;
+  if (!Number.isFinite(cap) || cap <= 0) return [];
+  if (n <= cap) return points.map((_, i) => i);
+
+  // Order indices spatially so an even stride samples across the whole extent.
+  const order = points.map((_, i) => i).sort((a, b) => {
+    const pa = points[a];
+    const pb = points[b];
+    return pa[0] - pb[0] || pa[1] - pb[1];
+  });
+
+  const stride = n / cap;
+  const out = [];
+  for (let k = 0; k < cap; k++) {
+    out.push(order[Math.floor(k * stride)]);
+  }
+  return out;
+}
+
+/**
+ * Diff the currently-drawn marker set against a desired target set, returning
+ * exactly which markers to add and remove. Lets every map interaction touch
+ * only the delta instead of re-adding/removing all N markers (the O(N)-per-click
+ * churn behind the forced-reflow jank in #58). Compares by object identity, so
+ * the same marker instances must be shared across the caller's caches.
+ *
+ * @param {Set} onMapSet - Markers currently on the map.
+ * @param {Iterable} target - Desired drawn set (Set or array).
+ * @returns {{toAdd: Array, toRemove: Array}}
+ */
+function computeVisibilityDelta(onMapSet, target) {
+  const targetSet = target instanceof Set ? target : new Set(target);
+  const toAdd = [];
+  const toRemove = [];
+  for (const m of targetSet) if (!onMapSet.has(m)) toAdd.push(m);
+  for (const m of onMapSet) if (!targetSet.has(m)) toRemove.push(m);
+  return { toAdd, toRemove };
+}
+
+/**
+ * Leaflet circle style for a pano marker under the temporal date filter. When a
+ * date is selected, matching panos are emphasized and the rest dimmed; with no
+ * date, every marker gets the default style. Kept pure (returns a plain style
+ * object, no Leaflet) so the date-filter styling is node-testable; the caller
+ * maps date values to comparable strings (both sides use the same convention).
+ *
+ * @param {?string} captureDateStr - The marker's capture-date key.
+ * @param {?string} selectedDateStr - The selected date key, or null/"" when no
+ *   date filter is active.
+ * @returns {{fillOpacity: number, radius: number}}
+ */
+function markerDateStyle(captureDateStr, selectedDateStr) {
+  if (!selectedDateStr) return { fillOpacity: 0.8, radius: 3 };
+  return captureDateStr === selectedDateStr
+    ? { fillOpacity: 1, radius: 4 }
+    : { fillOpacity: 0.05, radius: 3 };
+}
+
 // Node/CommonJS export shim for the unit tests (issue #123). This is a no-op
 // in the browser, where these symbols are plain globals loaded via <script>.
 if (typeof module !== "undefined" && module.exports) {
   module.exports = {
     STREETSCAPE_DATA_BASE_URL,
+    RENDER_CAP,
     PROVIDERS,
     METRICS,
     isKnownProvider,
@@ -621,5 +707,8 @@ if (typeof module !== "undefined" && module.exports) {
     withAlpha,
     fmtYears,
     formatChangeSummary,
+    spatialStrideSample,
+    computeVisibilityDelta,
+    markerDateStyle,
   };
 }


### PR DESCRIPTION
Makes the city page usable for dense cities (#77) and removes the forced-reflow interaction cost (#58), plus two smaller UI/doc fixes that were sitting in the same working tree.

## Why

Large cities drew *every* pano marker, and every interaction — year toggle, date select, GSV-mode switch, streets-overlay show/hide — walked `markersByYear` and re-added/removed all N of them. That is what made dense cities unreadable and janky.

## What changed

**1. Render cap behind a reconcile model (#77, #58)** — `06c2b3a`

One path now decides what is drawn:

- `computeDesiredShown()` derives the drawn set from mode ∧ year ∧ cap, then **unions in every in-mode marker of a selected date** so the map can never under-show a date relative to the temporal plot's count (the honesty trap a naive cap walks straight into).
- `reconcile()` applies only the symmetric difference (≤ `RENDER_CAP` work); `restyleOnMap()` styles only what is drawn.
- Mode-scoped caches (in-mode markers by year / by date string, per-year counts, fixed per-run counts) replace the O(N) re-filters that ran on every legend rebuild.
- Above the cap the drawn set is a **deterministic spatial-stride subsample**, so dots stay spread across the city instead of clumping into whatever band streamed in first.
- **Stats, counts and the temporal plot always use the full in-mode set** — the cap never changes a reported number. The legend gains a cap notice stating drawn-vs-total with an opt-in "Render all" override.

New pure helpers (`spatialStrideSample`, `computeVisibilityDelta`, `markerDateStyle`) live in `streetscape-utils.js` with node tests. Also bounds the legend panel (`max-width`/`max-height` + `overflow-y`) so content-heavy cities scroll inside it rather than growing past the viewport.

**2. Minimizable capture-date chart** — `81e9758`

The temporal panel is a fixed 400×200 box pinned bottom-right with no way to dismiss it. It now has a header bar with a −/+ toggle; collapsing hides the chart body and shrinks the panel to the header. Choice persists in `localStorage` (guarded — storage can be blocked), `aria-expanded` + matching `aria-label` for screen readers, and Chart.js is resized on expand since it can't measure a `display:none` parent.

**3. #112 doc reconciliation** — `c667124`

Replaces the "provisional / under investigation" caveat in `docs/city_sampling.md` with the resolved finding: the catalog figures (1,143 registered / 1,132 with pano data) are canonical and the old "~488 cities" estimate is a stale pre-import snapshot, not a data discrepancy. (#112 is already closed; this just lands the doc side.)

**4. Ignore all `.env` variants** — `f3022e5`

`.gitignore` matched only the literal `.env`, leaving a real key file (`.env.bak.streets-cutover`, from the streets credential cutover) untracked-but-visible and one `git add -A` from being committed. Now `.env*` with `!.env.example`. Never-tracked, so nothing leaked and no history rewrite was needed.

## Testing

`npm run lint` clean and 62/62 node tests pass (including on the intermediate commit-1 state, since commits 1 and 2 were split out of interleaved changes in the same files). Not yet exercised against a live dense city in the browser — worth a manual pass on one of the big ones before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)