### PR TITLE
Fix GSV scheduler timeout that stranded large-city runs

### DIFF
--- a/streetscape_metadata_tracker/json_summarizer.py
+++ b/streetscape_metadata_tracker/json_summarizer.py
@@ -9,6 +9,7 @@ import numpy as np
 import pandas as pd
 from tqdm import tqdm
 
+from . import db
 from .analysis import (
     PRESENT_STATUSES,
     calculate_coverage_stats,
@@ -412,6 +413,71 @@ def generate_city_metadata_summary_as_json(
 
     logger.info(f"Saved compressed JSON to: {json_filename_with_path}")
     return json_filename_with_path
+
+
+def regenerate_run_json(conn, run_id: int, data_dir: str) -> str | None:
+    """
+    Rebuild the per-run summary JSON for an already-cataloged run from its CSV
+    and set ``runs.json_filename`` to match.
+
+    Recovery path for a run whose row was committed (``register_run``) but whose
+    pipeline tail was interrupted before the JSON was written — e.g. a scheduler
+    subprocess SIGKILLed a few seconds after the download finished but during
+    the diff/JSON step, leaving a valid run with ``json_filename = NULL`` that
+    the aggregate then skips. The scheduler calls this to self-heal (see
+    ``cmd_run_due``); it is also usable as a manual repair.
+
+    Reuses the exact functions the live pipeline uses
+    (``generate_city_metadata_summary_as_json``), so the output is identical to
+    a normal run's JSON. The diff change-block is intentionally omitted
+    (``change_from_previous_run=None``): it is cosmetic and self-heals on the
+    city's next run, and recomputing it would re-load the previous run's CSV —
+    the very cost that caused the interruption.
+
+    Returns the JSON basename, or ``None`` if the run's CSV is missing on disk.
+    """
+    from datetime import date
+
+    row = conn.execute(
+        "SELECT run_id, city_id, provider, run_date, csv_filename, is_baseline "
+        "FROM runs WHERE run_id = ?",
+        (run_id,),
+    ).fetchone()
+    if row is None:
+        logger.warning(f"regenerate_run_json: run {run_id} not found")
+        return None
+
+    csv_path = os.path.join(data_dir, row["csv_filename"])
+    if not os.path.exists(csv_path):
+        logger.warning(f"regenerate_run_json: CSV missing, cannot rebuild: {csv_path}")
+        return None
+
+    city = db.resolve_city(conn, row["city_id"])
+    if city is None:
+        logger.warning(f"regenerate_run_json: city {row['city_id']} unresolvable")
+        return None
+
+    df = load_city_csv_file(csv_path)
+    y, m, d = (int(x) for x in row["run_date"].split("-"))
+    json_path = generate_city_metadata_summary_as_json(
+        csv_path,
+        df,
+        city.city_name,
+        city.state_name,
+        city.country_name,
+        city.grid_width_m,
+        city.grid_height_m,
+        city.step_m,
+        force_recreate_file=True,
+        run_date=date(y, m, d),
+        is_baseline=bool(row["is_baseline"]),
+        change_from_previous_run=None,
+        provider=row["provider"],
+    )
+    basename = os.path.basename(json_path)
+    db.update_run_json_filename(conn, run_id, basename)
+    logger.info(f"regenerate_run_json: rebuilt {basename} for run {run_id}")
+    return basename
 
 
 def _load_city_json(json_path: str) -> dict[str, Any] | None:

--- a/streetscape_metadata_tracker/scheduler.py
+++ b/streetscape_metadata_tracker/scheduler.py
@@ -37,7 +37,7 @@ from . import db
 from .alerting import AlertConfig, send_alert, should_alert
 from .download_common import redact_credentials
 from .download_mapillary import estimate_tile_count
-from .json_summarizer import generate_aggregate_v2
+from .json_summarizer import generate_aggregate_v2, regenerate_run_json
 from .naming import KNOWN_PROVIDERS
 
 # Isolated street-coverage budget channels (issue #99). Valid api_usage
@@ -294,29 +294,40 @@ def estimate_requests(city: db.CityRow, provider: str = "gsv") -> int:
 
 
 # Wall-clock headroom over the paced-request estimate: covers retry passes,
-# per-request overhead, and the rate limiter's real-world undershoot.
+# per-request overhead, and the diff+JSON pipeline tail after the download.
 _TIMEOUT_HEADROOM = 1.5
 # Fixed slack (seconds) for process startup, geocode reuse, compression, and
 # the inter-pass retry sleeps that are not part of the paced request time.
 _TIMEOUT_FIXED_SLACK_S = 600
+# max_requests_per_minute is a client-side *ceiling*, not the achieved rate: the
+# async engine undershoots it (connection limit, ~30 ms metadata latency, the
+# resource guard lowering concurrency on a busy host). makelab2 sustained
+# ~24.6k/min against a 48k cap across large runs on 2026-07 — roughly half. The
+# timeout derivation must budget for the achieved rate, or a big city's download
+# alone eats the whole floor and the child is SIGKILLed during the diff/JSON
+# tail (leaving a valid run row with no JSON — see cmd_run_due reconciliation).
+_ACHIEVED_RATE_FRACTION = 0.5
 
 
 def city_timeout_seconds(cfg: SchedulerConfig, city: db.CityRow, provider: str) -> int:
     """
     Per-city subprocess timeout, derived from the estimated request count and
-    the configured pacing rate rather than a single flat cap.
+    the *achieved* download rate rather than a single flat cap.
 
-    A GSV run is paced at ``max_requests_per_minute``, so its wall-clock scales
-    with grid size; a flat ``city_timeout_minutes`` SIGKILLs large cities
-    mid-run (Houston/NYC/Tulsa …), and a killed child records no api_usage, so
-    its already-spent requests vanish from the budget ledger. The derived value
-    never drops below the configured floor, so small cities and the (fast,
-    bulk-metadata) Mapillary provider keep the flat timeout.
+    A GSV run is paced under ``max_requests_per_minute``, so its wall-clock
+    scales with grid size; a flat ``city_timeout_minutes`` SIGKILLs large cities
+    mid-run (Austin/Houston/NYC …), and a killed child records no api_usage, so
+    its already-spent requests vanish from the budget ledger. The estimate uses
+    ``max_requests_per_minute * _ACHIEVED_RATE_FRACTION`` because the pacing cap
+    is not actually achieved (see the constant). The derived value never drops
+    below the configured floor, so small cities and the (fast, bulk-metadata)
+    Mapillary provider keep the flat timeout.
     """
     floor = cfg.city_timeout_minutes * 60
     if provider != "gsv" or cfg.max_requests_per_minute <= 0:
         return floor
-    paced_seconds = estimate_requests(city, provider) / cfg.max_requests_per_minute * 60.0
+    effective_rate = cfg.max_requests_per_minute * _ACHIEVED_RATE_FRACTION
+    paced_seconds = estimate_requests(city, provider) / effective_rate * 60.0
     return int(max(floor, paced_seconds * _TIMEOUT_HEADROOM + _TIMEOUT_FIXED_SLACK_S))
 
 
@@ -554,6 +565,49 @@ def _run_one_city(
         return False
 
 
+def _reconcile_orphaned_run(
+    conn, cfg: SchedulerConfig, city: db.CityRow, provider: str, today: date
+) -> bool:
+    """
+    Salvage a run whose subprocess reported failure but which actually cataloged
+    a valid run row for today.
+
+    The download is the expensive, budgeted part of the pipeline; once it
+    finishes, ``register_run`` commits the row *before* the diff and per-run
+    JSON. A subprocess killed in that tail (e.g. a large city SIGKILLed right at
+    the timeout boundary) leaves a complete, valid run whose only defect is a
+    missing JSON — which the aggregate then skips. Discarding it as a failure
+    would re-spend the whole download next cycle and strand the row.
+
+    Returns True if a valid run row for (city, provider, today) exists and was
+    reconciled (JSON rebuilt if it was missing). Returns False when there is no
+    such row — a genuine failure the caller should record normally.
+    """
+    row = conn.execute(
+        "SELECT run_id, json_filename FROM runs "
+        "WHERE city_id = ? AND provider = ? AND run_date = ?",
+        (city.city_id, provider, today.isoformat()),
+    ).fetchone()
+    if row is None:
+        return False
+
+    if not row["json_filename"]:
+        # Tail was interrupted before the JSON was written; rebuild it from the
+        # cataloged CSV. If the CSV is somehow gone, treat it as a real failure.
+        if regenerate_run_json(conn, row["run_id"], cfg.data_dir) is None:
+            logger.error(
+                f"{city.city_id} [{provider}]: run row exists but JSON could not "
+                f"be rebuilt (CSV missing); recording failure"
+            )
+            return False
+
+    logger.info(
+        f"{city.city_id} [{provider}]: subprocess reported failure but run "
+        f"{row['run_id']} is cataloged for {today}; reconciled as success"
+    )
+    return True
+
+
 def _collect_due(conn, cfg: SchedulerConfig, today: date):
     """
     Due work for today: an ordered city list (stalest-first, gsv's order
@@ -678,6 +732,11 @@ def cmd_run_due(
             ok = _run_one_city(cfg, city, today, provider, connection_limit=conn_limit)
             ran_any = True
             attempted += 1
+            # A subprocess can report failure yet still have cataloged a valid
+            # run (killed in the diff/JSON tail after register_run committed);
+            # salvage it rather than re-spending the whole download next cycle.
+            if not ok and _reconcile_orphaned_run(conn, cfg, city, provider, today):
+                ok = True
             if ok:
                 succeeded += 1
                 db.record_attempt(conn, city.city_id, success=True, provider=provider)

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -8,11 +8,13 @@ from streetscape_metadata_tracker.scheduler import (
     ResourceGuardConfig,
     SchedulerConfig,
     SystemPressure,
+    _reconcile_orphaned_run,
     build_parser,
     estimate_requests,
     load_scheduler_config,
     plan_connection_limit,
 )
+from tests.conftest import make_city_df, write_city_csv_gz
 
 _PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
@@ -89,7 +91,12 @@ def test_estimate_requests_mapillary_counts_tiles(conn):
 def test_city_timeout_scales_with_grid_size(conn):
     """A huge GSV grid gets a timeout derived from points ÷ rate (so it is not
     SIGKILLed mid-run by the flat floor); a small city keeps the floor."""
-    from streetscape_metadata_tracker.scheduler import city_timeout_seconds
+    from streetscape_metadata_tracker.scheduler import (
+        _ACHIEVED_RATE_FRACTION,
+        _TIMEOUT_FIXED_SLACK_S,
+        _TIMEOUT_HEADROOM,
+        city_timeout_seconds,
+    )
 
     cfg = SchedulerConfig(city_timeout_minutes=180, max_requests_per_minute=24_000)
     floor = 180 * 60
@@ -98,9 +105,28 @@ def test_city_timeout_scales_with_grid_size(conn):
     assert city_timeout_seconds(cfg, small, "gsv") == floor  # 2601 pts, well under floor
 
     big = db.resolve_city(conn, _register(conn, "Metropolis", width=40000, height=40000, step=20))
-    # ~4M points at 24k/min ≈ 167 min of paced requests; with headroom this
-    # must exceed the flat floor rather than clamp to it.
-    assert city_timeout_seconds(cfg, big, "gsv") > floor
+    pts = estimate_requests(big)  # (40000//20 + 1)^2 = 4_004_001
+    # The timeout budgets for the *achieved* rate, not the pacing ceiling: at
+    # 24k/min the engine really sustains ~12k/min, so paced time roughly doubles
+    # and must clear the flat floor with headroom for the diff/JSON tail.
+    effective_rate = cfg.max_requests_per_minute * _ACHIEVED_RATE_FRACTION
+    expected = int(pts / effective_rate * 60.0 * _TIMEOUT_HEADROOM + _TIMEOUT_FIXED_SLACK_S)
+    assert city_timeout_seconds(cfg, big, "gsv") == expected
+    assert expected > floor
+
+
+def test_city_timeout_covers_observed_austin_download(conn):
+    """Regression for the Austin timeout bug (#3599 investigation): at makelab2's
+    real config (48k/min cap, ~24.6k achieved) an Austin-sized grid must derive a
+    timeout well above the ~170-min download that used to eat the whole 180-min
+    floor and get SIGKILLed during the diff/JSON tail."""
+    from streetscape_metadata_tracker.scheduler import city_timeout_seconds
+
+    cfg = SchedulerConfig(city_timeout_minutes=180, max_requests_per_minute=48_000)
+    austin = db.resolve_city(conn, _register(conn, "Austin", width=36189, height=46350, step=20))
+    # Observed download was ~170 min; require comfortable margin over 240 min so
+    # the whole pipeline (download + diff + JSON) fits.
+    assert city_timeout_seconds(cfg, austin, "gsv") > 240 * 60
 
 
 def test_city_timeout_floor_for_mapillary_and_disabled_pacing(conn):
@@ -112,6 +138,61 @@ def test_city_timeout_floor_for_mapillary_and_disabled_pacing(conn):
     assert city_timeout_seconds(SchedulerConfig(), big, "mapillary") == floor
     # No client-side pacing -> no basis to scale, keep the floor.
     assert city_timeout_seconds(SchedulerConfig(max_requests_per_minute=0), big, "gsv") == floor
+
+
+def _orphan_run(conn, data_dir, *, run_date=date(2026, 4, 15), write_csv=True):
+    """A cataloged run with json_filename=NULL, mimicking a subprocess killed in
+    the pipeline tail after register_run committed. When write_csv is False the
+    CSV is absent (the run is unrecoverable)."""
+    cid = _register(conn, "Bend", width=1000, height=1000, step=20)
+    csv_filename = "bend--oregon--united-states_width_1000_height_1000_step_20_2026-04-15.csv.gz"
+    if write_csv:
+        df = make_city_df([("p1", "2020-06-15"), ("p2", "2024-01-10")], run_date=run_date)
+        write_city_csv_gz(df, os.path.join(data_dir, csv_filename))
+    run_id = db.register_run(
+        conn,
+        city_id=cid,
+        run_date=run_date,
+        csv_filename=csv_filename,
+        provider="gsv",
+        json_filename=None,  # the defect: tail was killed before JSON
+        total_points=3,
+        status_ok=2,
+    )
+    return db.resolve_city(conn, cid), run_id, run_date
+
+
+def test_reconcile_rebuilds_missing_json_for_cataloged_run(conn, data_dir):
+    """A subprocess 'failure' that nonetheless cataloged a valid run is salvaged:
+    the missing per-run JSON is rebuilt from the CSV and the run counts as a
+    success (the Austin bug, automated)."""
+    cfg = SchedulerConfig(data_dir=data_dir)
+    city, run_id, run_date = _orphan_run(conn, data_dir)
+
+    assert _reconcile_orphaned_run(conn, cfg, city, "gsv", run_date) is True
+
+    row = conn.execute("SELECT json_filename FROM runs WHERE run_id = ?", (run_id,)).fetchone()
+    assert row["json_filename"]  # now populated
+    assert os.path.exists(os.path.join(data_dir, row["json_filename"]))
+
+
+def test_reconcile_no_row_is_genuine_failure(conn, data_dir):
+    """No run row for (city, provider, today) → nothing to salvage; the caller
+    must record a real failure."""
+    cfg = SchedulerConfig(data_dir=data_dir)
+    cid = _register(conn, "Bend", width=1000, height=1000, step=20)
+    city = db.resolve_city(conn, cid)
+    assert _reconcile_orphaned_run(conn, cfg, city, "gsv", date(2026, 4, 15)) is False
+
+
+def test_reconcile_missing_csv_is_genuine_failure(conn, data_dir):
+    """A run row exists but its CSV is gone → cannot rebuild JSON, so it is a
+    real failure rather than a false success."""
+    cfg = SchedulerConfig(data_dir=data_dir)
+    city, run_id, run_date = _orphan_run(conn, data_dir, write_csv=False)
+    assert _reconcile_orphaned_run(conn, cfg, city, "gsv", run_date) is False
+    row = conn.execute("SELECT json_filename FROM runs WHERE run_id = ?", (run_id,)).fetchone()
+    assert not row["json_filename"]  # still unrepaired
 
 
 def test_config_defaults_when_file_missing(tmp_path):


### PR DESCRIPTION
## Problem

The scheduler's per-city subprocess timeout bounds the **whole** pipeline (download → `register_run` → diff → per-run JSON), but the derived budget only modeled the paced **download** — and it assumed the pacing *ceiling* (`max_requests_per_minute`) was achieved. makelab2 actually sustains ~half that (**~24.6k/min against a 48k cap**), so a large city's download alone ate the entire 180-min floor and the child was SIGKILLed during the diff/JSON tail — *after* `register_run` had already committed the row.

Result: a valid, complete run with `json_filename = NULL` (skipped by the aggregate) and `schedule_state` stuck in failure, needing manual repair. Observed on **Austin, three nights running**, during the #3599 site-candidate investigation.

## Changes

**A1 — realistic timeout** (`scheduler.py`): `city_timeout_seconds` budgets for the *achieved* rate via a documented `_ACHIEVED_RATE_FRACTION = 0.5`. An Austin-sized grid now derives **~272 min** instead of clamping to the 180-min floor, comfortably covering the ~170-min download plus the diff/JSON tail. Small cities and Mapillary keep the flat floor.

**A2 — JSON-regen helper** (`json_summarizer.py`): `regenerate_run_json(conn, run_id, data_dir)` rebuilds a cataloged run's per-run JSON from its CSV, reusing the exact live-pipeline summary function. Productizes the one-off manual Austin repair.

**A3 — reconciliation** (`scheduler.py`): after a subprocess "failure", `_reconcile_orphaned_run` checks for a valid run row for today; if the JSON is missing it rebuilds it and counts the run as success, rather than re-spending the whole download next cycle. Automates the manual repair for any future near-boundary kill.

## Tests

`tests/test_scheduler.py`: pinned effective-rate math, an Austin-sized regression guard, and reconciliation cases (heal / no-row / missing-CSV). Full suite: **461 passed**; `ruff check`/`format` clean.

## Not included (tracked separately)

Anchorage's 22M-point Mapillary timeout is a **data** anomaly (grid registered before the 80 km clamp) to be fixed by re-bboxing its frozen geometry, not by this code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)