### PR TITLE
Cap oversized frozen grids so one city can't eat a whole night

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,12 @@ python scripts/migrate_to_db.py            # dry run; --execute to apply
 # run by default, and refuses a city with real runs unless --force.
 python scripts/resize_city.py "Browning, MT" --width 2500 --height 2500 --execute
 
+# Cap every oversized frozen grid at once (issue #166). Same catalog-only,
+# dry-run-by-default contract; skips cities with real dated runs unless
+# --include-collected (that breaks their diff continuity — no files are deleted).
+python scripts/cap_oversized_grids.py                      # preview
+python scripts/cap_oversized_grids.py --execute
+
 # One-time rename of road-walk artifacts collected before streetwalk filenames
 # carried a provider token (non-gsv walks only); dry run, --execute to apply
 python scripts/repair_streetwalk_names.py

--- a/scripts/cap_oversized_grids.py
+++ b/scripts/cap_oversized_grids.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""
+Cap frozen grids that are too large for a single night's collection (issue #166).
+
+A handful of cities have frozen grids so big they are effectively uncollectable,
+and because the scheduler works a stalest-first queue serially, each one eats
+hours that the rest of the frame never gets back. Sydney is 100x99 km — nearly
+25M grid points. Cairo is 10.5M, which is more than the entire daily gsv budget,
+so the scheduler has logged "exceeds the entire daily budget ... Skipping" every
+night since it was registered and has never collected it once.
+
+This clamps each dimension to ``--max-extent-m`` (keeping the existing center),
+which bounds both the request count and the downloader's peak memory — the
+Mapillary post-decode path costs roughly 1.67 GB per 1M grid points, so an
+uncapped city is also an OOM risk (see #157).
+
+Sampling a bounded window around the core is more useful than an unbounded box
+that never completes at all.
+
+SAFETY. Geometry is frozen on purpose: re-gridding a city starts a new,
+non-comparable series because run-to-run diffs no longer align on an identical
+rectangle. So this refuses any city with a real (non-baseline) dated run unless
+``--include-collected`` is given. Cities that were never collected, or that have
+only imported baseline runs, have no diff continuity to lose and are resized
+freely.
+
+Nothing is ever deleted. This edits catalog rows only — existing run files stay
+on disk and their published URLs keep working. Makes ZERO provider API calls.
+
+Usage:
+    # See what would change (default is a dry run):
+    python scripts/cap_oversized_grids.py
+
+    # Apply to the cities that lose nothing:
+    python scripts/cap_oversized_grids.py --execute
+
+    # Also re-grid cities that already have real dated runs (breaks their diff
+    # continuity — the files remain, but new runs no longer diff against old):
+    python scripts/cap_oversized_grids.py --include-collected --execute
+"""
+
+import argparse
+import logging
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from streetscape_metadata_tracker import db  # noqa: E402
+from streetscape_metadata_tracker.paths import get_default_data_dir  # noqa: E402
+
+logger = logging.getLogger("cap_oversized_grids")
+
+# Default cap per side. At the standard 20 m step this is ~4M grid points, which
+# fits inside the production gsv daily budget (10M) with room for other cities,
+# and is still roughly twice Seattle's grid — comfortably more than an urban
+# core. Deliberately a *dimension* cap rather than a point cap so the resulting
+# rectangle stays square-ish and legible on the map.
+DEFAULT_MAX_EXTENT_M = 40_000
+
+CAP_NOTE = "grid capped to {extent} m/side (scripts/cap_oversized_grids.py, issue #166)"
+
+
+def grid_points(width_m: float, height_m: float, step_m: float) -> int:
+    """Number of grid sample points for a rectangle at a given step."""
+    return (int(width_m / step_m) + 1) * (int(height_m / step_m) + 1)
+
+
+def find_oversized(conn, max_extent_m: float) -> list[dict]:
+    """
+    Enabled cities with either dimension over the cap, largest first.
+
+    Each entry carries the proposed dimensions and the run history that decides
+    whether resizing is free: ``real_runs`` (dated, non-baseline) is what makes
+    a resize destructive to diff continuity.
+    """
+    rows = conn.execute(
+        "SELECT city_id, display_name, center_lat, center_lon, "
+        "grid_width_m, grid_height_m, step_m FROM cities WHERE enabled = 1"
+    ).fetchall()
+
+    oversized = []
+    for row in rows:
+        if row["grid_width_m"] <= max_extent_m and row["grid_height_m"] <= max_extent_m:
+            continue
+        runs = db.get_runs_for_city(conn, row["city_id"], provider=None)
+        real_runs = [r for r in runs if not r.is_baseline]
+        oversized.append(
+            {
+                "city_id": row["city_id"],
+                "display_name": row["display_name"],
+                "center_lat": row["center_lat"],
+                "center_lon": row["center_lon"],
+                "step_m": row["step_m"],
+                "old_width_m": row["grid_width_m"],
+                "old_height_m": row["grid_height_m"],
+                "new_width_m": min(row["grid_width_m"], max_extent_m),
+                "new_height_m": min(row["grid_height_m"], max_extent_m),
+                "baseline_runs": len(runs) - len(real_runs),
+                "real_runs": len(real_runs),
+            }
+        )
+
+    for c in oversized:
+        c["old_points"] = grid_points(c["old_width_m"], c["old_height_m"], c["step_m"])
+        c["new_points"] = grid_points(c["new_width_m"], c["new_height_m"], c["step_m"])
+    oversized.sort(key=lambda c: c["old_points"], reverse=True)
+    return oversized
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument(
+        "--max-extent-m",
+        type=float,
+        default=DEFAULT_MAX_EXTENT_M,
+        help=f"Cap each grid dimension at this many meters (default {DEFAULT_MAX_EXTENT_M:,})",
+    )
+    parser.add_argument(
+        "--include-collected",
+        action="store_true",
+        help="Also resize cities with real dated runs, breaking their diff continuity",
+    )
+    parser.add_argument("--data-dir", default=get_default_data_dir())
+    parser.add_argument(
+        "--db-path", default=None, help="default: {data-dir}/streetscape_tracker.db"
+    )
+    parser.add_argument("--execute", action="store_true", help="Apply (default is a dry run)")
+    parser.add_argument(
+        "--log-level", default="WARNING", choices=["DEBUG", "INFO", "WARNING", "ERROR"]
+    )
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=getattr(logging, args.log_level),
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    )
+
+    if args.max_extent_m <= 0:
+        parser.error("--max-extent-m must be positive")
+
+    db_path = args.db_path or db.get_default_db_path(args.data_dir)
+    conn = db.connect(db_path)
+
+    oversized = find_oversized(conn, args.max_extent_m)
+    mode = "EXECUTE" if args.execute else "DRY RUN"
+    print(f"=== Cap oversized grids to {int(args.max_extent_m):,} m/side ({mode}) ===")
+    print(f"Catalog: {db_path}")
+
+    if not oversized:
+        print("\nNo enabled city exceeds the cap. Nothing to do.")
+        conn.close()
+        return 0
+
+    free = [c for c in oversized if c["real_runs"] == 0]
+    collected = [c for c in oversized if c["real_runs"] > 0]
+
+    print(f"\n{len(oversized)} oversized cities: {len(free)} free to resize, ")
+    print(f"{len(collected)} with real dated runs (diff continuity at stake).\n")
+
+    header = f"{'city_id':52s} {'old':>18s} {'points':>12s} -> {'points':>12s}  runs"
+    print(header)
+    print("-" * len(header))
+    for c in oversized:
+        runs = f"{c['baseline_runs']}b/{c['real_runs']}r"
+        flag = (
+            "" if c["real_runs"] == 0 else ("  [FORCED]" if args.include_collected else "  [SKIP]")
+        )
+        print(
+            f"{c['city_id'][:52]:52s} "
+            f"{int(c['old_width_m']):>8,}x{int(c['old_height_m']):<9,} "
+            f"{c['old_points']:>12,} -> {c['new_points']:>12,}  {runs}{flag}"
+        )
+
+    targets = oversized if args.include_collected else free
+    total_before = sum(c["old_points"] for c in targets)
+    total_after = sum(c["new_points"] for c in targets)
+    print(
+        f"\nWould resize {len(targets)} cities: "
+        f"{total_before:,} -> {total_after:,} grid points "
+        f"({total_after - total_before:+,})"
+    )
+    if collected and not args.include_collected:
+        print(
+            f"Skipping {len(collected)} cities with real dated runs. "
+            f"Re-run with --include-collected to resize them too "
+            f"(no files are deleted; only diff continuity is lost)."
+        )
+
+    if not args.execute:
+        print("\nDRY RUN — no catalog changes. Re-run with --execute to apply.")
+        conn.close()
+        return 0
+
+    note = CAP_NOTE.format(extent=int(args.max_extent_m))
+    for c in targets:
+        db.update_city_geometry(
+            conn,
+            city_id=c["city_id"],
+            center_lat=c["center_lat"],
+            center_lon=c["center_lon"],
+            grid_width_m=c["new_width_m"],
+            grid_height_m=c["new_height_m"],
+            notes=note,
+        )
+    conn.close()
+    print(f"\nApplied to {len(targets)} cities.")
+    print("Run files on disk are untouched; only the catalog geometry changed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_cap_oversized_grids.py
+++ b/tests/test_cap_oversized_grids.py
@@ -1,0 +1,182 @@
+"""Tests for scripts/cap_oversized_grids.py (issue #166)."""
+
+import os
+import sys
+from datetime import date
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import pytest  # noqa: E402
+
+from scripts.cap_oversized_grids import find_oversized, grid_points, main  # noqa: E402
+from streetscape_metadata_tracker import db  # noqa: E402
+
+
+@pytest.fixture
+def db_path(data_dir):
+    return os.path.join(data_dir, "streetscape_tracker.db")
+
+
+def run_cli(monkeypatch, db_path, *args):
+    """Invoke the script's main() with argv, returning its exit code.
+
+    The script opens (and closes) its OWN connection from --db-path, so the
+    test's `conn` fixture stays usable afterwards.
+    """
+    monkeypatch.setattr(
+        "sys.argv", ["cap_oversized_grids.py", *[str(a) for a in args], "--db-path", db_path]
+    )
+    return main()
+
+
+def _register(conn, name, width, height, step=20):
+    return db.register_city(
+        conn,
+        city_name=name,
+        state_name="Somewhere",
+        state_code="SW",
+        country_name="Testland",
+        country_code="TL",
+        center_lat=44.0,
+        center_lon=-121.0,
+        grid_width_m=width,
+        grid_height_m=height,
+        step_m=step,
+    )
+
+
+def _add_run(conn, city_id, *, is_baseline, run_date="2026-07-01"):
+    db.register_run(
+        conn,
+        city_id=city_id,
+        provider="gsv",
+        run_date=date.fromisoformat(run_date),
+        csv_filename=f"{city_id}_{run_date}.csv.gz",
+        is_baseline=is_baseline,
+        total_points=2,
+    )
+
+
+def _geometry(conn, city_id):
+    row = conn.execute(
+        "SELECT grid_width_m, grid_height_m, center_lat, center_lon, notes "
+        "FROM cities WHERE city_id = ?",
+        (city_id,),
+    ).fetchone()
+    return row
+
+
+def test_only_cities_over_the_cap_are_selected(conn):
+    small = _register(conn, "Small", width=10_000, height=10_000)
+    tall = _register(conn, "Tall", width=10_000, height=60_000)
+    huge = _register(conn, "Huge", width=100_000, height=99_000)
+
+    found = {c["city_id"] for c in find_oversized(conn, 40_000)}
+
+    assert small not in found, "a city inside the cap must be left alone"
+    assert tall in found, "exceeding EITHER dimension counts as oversized"
+    assert huge in found
+
+
+def test_cap_clamps_each_dimension_independently_and_keeps_the_center(conn):
+    _register(conn, "Tall", width=10_000, height=60_000)
+
+    (c,) = find_oversized(conn, 40_000)
+
+    # The dimension already under the cap is untouched — this is a clamp, not a
+    # rescale to a square.
+    assert c["new_width_m"] == 10_000
+    assert c["new_height_m"] == 40_000
+    assert (c["center_lat"], c["center_lon"]) == (44.0, -121.0)
+    assert c["old_points"] == grid_points(10_000, 60_000, 20)
+    assert c["new_points"] == grid_points(10_000, 40_000, 20)
+    assert c["new_points"] < c["old_points"]
+
+
+def test_largest_first(conn):
+    _register(conn, "Big", width=50_000, height=50_000)
+    _register(conn, "Biggest", width=100_000, height=100_000)
+    _register(conn, "Medium", width=45_000, height=41_000)
+
+    order = [c["old_points"] for c in find_oversized(conn, 40_000)]
+
+    assert order == sorted(order, reverse=True), "worst offenders must come first"
+    assert len(order) == 3
+
+
+def test_dry_run_is_the_default_and_changes_nothing(conn, db_path, monkeypatch, capsys):
+    city_id = _register(conn, "Huge", width=100_000, height=100_000)
+
+    assert run_cli(monkeypatch, db_path) == 0
+
+    assert _geometry(conn, city_id)["grid_width_m"] == 100_000
+    assert "DRY RUN" in capsys.readouterr().out
+
+
+def test_execute_resizes_a_never_collected_city(conn, db_path, monkeypatch):
+    city_id = _register(conn, "Huge", width=100_000, height=99_000)
+
+    assert run_cli(monkeypatch, db_path, "--execute") == 0
+
+    row = _geometry(conn, city_id)
+    assert row["grid_width_m"] == 40_000
+    assert row["grid_height_m"] == 40_000
+    # The audit trail has to say WHY the frozen geometry moved.
+    assert "issue #166" in row["notes"]
+
+
+def test_baseline_only_city_resizes_freely(conn, db_path, monkeypatch):
+    """An imported baseline has no prior run to diff against, so re-gridding it
+    costs nothing."""
+    city_id = _register(conn, "Huge", width=100_000, height=100_000)
+    _add_run(conn, city_id, is_baseline=True)
+
+    assert run_cli(monkeypatch, db_path, "--execute") == 0
+
+    assert _geometry(conn, city_id)["grid_width_m"] == 40_000
+
+
+def test_city_with_real_runs_is_skipped_unless_explicitly_included(conn, db_path, monkeypatch):
+    """Resizing orphans that city's run-to-run diffs, so it must be opt-in."""
+    city_id = _register(conn, "Huge", width=100_000, height=100_000)
+    _add_run(conn, city_id, is_baseline=False)
+
+    assert run_cli(monkeypatch, db_path, "--execute") == 0
+    assert _geometry(conn, city_id)["grid_width_m"] == 100_000, "must not resize silently"
+
+    assert run_cli(monkeypatch, db_path, "--execute", "--include-collected") == 0
+    assert _geometry(conn, city_id)["grid_width_m"] == 40_000
+
+
+def test_a_collected_city_does_not_block_the_free_ones(conn, db_path, monkeypatch):
+    """The skip is per-city: one uncollectable-but-collected city must not stop
+    the rest of the frame from being fixed."""
+    collected = _register(conn, "Collected", width=100_000, height=100_000)
+    _add_run(conn, collected, is_baseline=False)
+    free = _register(conn, "Free", width=90_000, height=90_000)
+
+    assert run_cli(monkeypatch, db_path, "--execute") == 0
+
+    assert _geometry(conn, free)["grid_width_m"] == 40_000
+    assert _geometry(conn, collected)["grid_width_m"] == 100_000
+
+
+def test_capped_cairo_fits_the_production_gsv_daily_budget(conn):
+    """The operational point of the cap: Cairo's real geometry estimates
+    ~10,547,202 requests against a 10,000,000 budget, so the scheduler has
+    skipped it every night and never collected it once."""
+    city_id = _register(conn, "Cairo", width=66_453, height=63_475, step=20)
+
+    (c,) = find_oversized(conn, 40_000)
+
+    assert c["city_id"] == city_id
+    assert c["old_points"] > 10_000_000, "reproduces the unschedulable grid"
+    assert c["new_points"] < 10_000_000, "capped grid must fit the daily budget"
+
+
+def test_disabled_cities_are_left_alone(conn):
+    city_id = _register(conn, "Huge", width=100_000, height=100_000)
+    conn.execute("UPDATE cities SET enabled = 0 WHERE city_id = ?", (city_id,))
+    conn.commit()
+
+    assert find_oversized(conn, 40_000) == []


### PR DESCRIPTION
Refs #166.

## Why

The scheduler works a stalest-first queue **serially**, so a single oversized city costs the rest of the frame hours it never gets back. **50 enabled cities have a grid dimension over 40 km.**

- **Sydney** is 100x99 km — nearly **25M grid points**.
- **Cairo** is 10.5M, which is more than the entire daily `gsv` budget. Every night since it was registered the scheduler has logged `exceeds the entire daily budget (10,000,000). Skipping` — it has **never been collected once**.

## What

`scripts/cap_oversized_grids.py` clamps each dimension to `--max-extent-m` (default 40 km ≈ 4M points at the standard 20 m step), keeping the existing center. Sampling a bounded window around the core is worth more than an unbounded box that never completes.

It also bounds peak memory, which matters independently: the Mapillary post-decode path costs ~1.67 GB per 1M grid points against an 8G cgroup cap (see the re-measurement on #157).

## Dry run against the production catalog

```
50 oversized cities: 43 free to resize, 7 with real dated runs.

sydney--new-south-wales--australia      100,278x99,344   24,909,552 ->  4,004,001  0b/0r
kangding--sichuan--china                 80,000x80,000   16,008,001 ->  4,004,001  0b/0r
shanghai--china                          80,000x80,000   16,008,001 ->  4,004,001  0b/0r
moscow--russia                           73,427x80,000   14,691,672 ->  4,004,001  0b/0r
los-angeles--california--united-states   67,674x77,770   13,160,376 ->  4,004,001  1b/0r
cairo--egypt                             66,453x63,475   10,547,202 ->  4,004,001  0b/0r
...
berlin--state-of-berlin--germany         45,683x37,529    4,288,945 ->  3,755,877  0b/1r  [SKIP]
chicago--illinois--united-states         34,555x42,040    3,633,984 ->  3,457,728  2b/1r  [SKIP]

Would resize 43 cities: 323,610,582 -> 161,628,774 grid points (-161,981,808)
```

## Safety

Same contract as `resize_city.py` (#159), which this **complements rather than replaces** — that one is the single-city escape hatch for point-box bboxes, this is the systemic sweep.

- Catalog-only, **zero provider API calls**.
- **Dry run by default.**
- **Nothing is ever deleted** — run files stay on disk and their published URLs keep working.
- Refuses a city with real (non-baseline) dated runs unless `--include-collected`, because re-gridding orphans that city's run-to-run diffs.
- The skip is **per-city**, so the 7 collected cities don't block the 43 free ones.
- Every resize leaves an audit trail in `cities.notes`.

## Tests

10 new, including the dimension-independent clamp (a 10x60 km city becomes 10x40, not 40x40), the baseline-only vs real-runs guard in both directions, per-city skip isolation, disabled cities, and a regression pinning Cairo's real geometry: over the 10M budget before, under it after.

Full suite: 491 passed. `ruff check`/`format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011eXNu3Aen8addoCPKKKFbG