### PR TITLE
Record why a collection failed, not just that it did

### DIFF
--- a/streetscape_metadata_tracker/scheduler.py
+++ b/streetscape_metadata_tracker/scheduler.py
@@ -654,6 +654,11 @@ def cmd_notify_failure(cfg: SchedulerConfig) -> int:
     return 0 if sent or not cfg.alerts.enabled else 1
 
 
+# Cap the failure list in `status` so one systemically bad night (every city
+# failing the same way) doesn't bury the budget summary underneath it.
+_STATUS_MAX_FAILURES = 40
+
+
 def cmd_status(cfg: SchedulerConfig) -> int:
     """Print a per-(city, provider) schedule table plus today's budgets."""
     conn = db.connect(cfg.db_path)
@@ -715,6 +720,28 @@ def cmd_status(cfg: SchedulerConfig) -> int:
             tablefmt="simple",
         )
     )
+
+    # Failing (city, channel) pairs with their recorded cause. The main table is
+    # ~1200 rows, so a last_error column there would be noise on every healthy
+    # row; what an operator actually wants after a bad night is just this list
+    # (issue #169).
+    failing = [
+        [r["city_id"], r["provider"], r["consecutive_failures"], (r["last_error"] or "—")[:90]]
+        for r in rows
+        if (r["consecutive_failures"] or 0) > 0 and (r["provider"] in providers)
+    ]
+    if failing:
+        failing.sort(key=lambda row: (-row[2], row[0]))
+        print(f"\n{len(failing)} failing (city, channel) pairs:")
+        print(
+            tabulate(
+                failing[:_STATUS_MAX_FAILURES],
+                headers=["city", "provider", "failures", "last error"],
+                tablefmt="simple",
+            )
+        )
+        if len(failing) > _STATUS_MAX_FAILURES:
+            print(f"... and {len(failing) - _STATUS_MAX_FAILURES} more.")
 
     n_cities = conn.execute("SELECT COUNT(*) FROM cities").fetchone()[0]
     due_str = ", ".join(f"{due_counts[p]} {p}" for p in providers)
@@ -906,6 +933,25 @@ def _street_collect_cmd(
 _CHILD_LOG_TAIL_LINES = 25
 
 
+@dataclass(frozen=True)
+class CollectionOutcome:
+    """Whether one collection subprocess worked, and if not, why.
+
+    Deliberately truthy/falsy like the plain bool it replaced, so callers (and
+    the test fakes that still return bare bools) read unchanged. The point is
+    ``reason``: it is what finally reaches ``schedule_state.last_error``, which
+    until now recorded only "subprocess failed on <date>" for every failure in
+    the catalog — so a bad night had to be re-derived from scratch the next
+    morning, if the daily-rotated logs still had it (issue #169).
+    """
+
+    ok: bool
+    reason: str | None = None
+
+    def __bool__(self) -> bool:
+        return self.ok
+
+
 def _child_log_path(cfg: SchedulerConfig, city: db.CityRow, provider: str, today: date) -> Path:
     """Per-attempt log for one (city, channel) collection subprocess."""
     return Path(cfg.log_dir) / f"collect_{city.city_id}_{provider}_{today.isoformat()}.log"
@@ -927,7 +973,7 @@ def _run_collection_subprocess(
     city: db.CityRow,
     provider: str,
     today: date,
-) -> bool:
+) -> CollectionOutcome:
     """
     Run one collection subprocess with its output captured to a per-attempt log.
 
@@ -961,7 +1007,7 @@ def _run_collection_subprocess(
                 stderr=subprocess.STDOUT,
             )
         if result.returncode == 0:
-            return True
+            return CollectionOutcome(True)
         why = f"exited {result.returncode}"
     except subprocess.TimeoutExpired:
         why = f"timed out after {timeout_s // 60} minutes"
@@ -971,7 +1017,9 @@ def _run_collection_subprocess(
     if tail:
         message += f"\n--- last {_CHILD_LOG_TAIL_LINES} lines of {log_path.name} ---\n{tail}"
     logger.error(message)
-    return False
+    # The log name, not the full path: the catalog outlives any given checkout
+    # location, and `logs/<name>` is what an operator actually greps for.
+    return CollectionOutcome(False, f"{why} (see {log_path.name})")
 
 
 def _run_one_city(
@@ -983,7 +1031,7 @@ def _run_one_city(
     daily_budget: int = 0,
     conn=None,
     remaining_s: float | None = None,
-) -> bool:
+) -> CollectionOutcome:
     """Collect one (city, channel) in a subprocess.
 
     Grid providers run ``streetscape_tracker.py``; street channels (issue #99)
@@ -1431,6 +1479,11 @@ def _run_city_loop(
                 )
                 ran_any = True
                 attempted += 1
+                # getattr, not attribute access: tests (and any future caller)
+                # may hand back a plain bool, which CollectionOutcome is
+                # deliberately compatible with.
+                reason = getattr(ok, "reason", None)
+                ok = bool(ok)
                 # A subprocess can report failure yet still have done the expensive,
                 # budgeted part of its job; salvage that rather than re-spending the
                 # whole crawl next cycle. The two channel kinds fail differently: a
@@ -1450,7 +1503,7 @@ def _run_city_loop(
                         conn,
                         city.city_id,
                         success=False,
-                        error=f"subprocess failed on {today}",
+                        error=reason or f"subprocess failed on {today}",
                         provider=provider,
                     )
                     logger.error(f"{city.city_id} [{provider}]: collection failed")

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1445,7 +1445,9 @@ def test_failed_collection_captures_child_output_and_surfaces_the_tail(conn, tmp
     with caplog.at_level(logging.ERROR):
         ok = sched._run_collection_subprocess(cfg, cmd, 60, city, "gsv", date(2026, 7, 1))
 
-    assert ok is False
+    assert not ok, "a nonzero exit is a failed collection"
+    # The reason rides back to the caller so it can reach schedule_state.
+    assert "exited 3" in ok.reason and "collect_" in ok.reason
     log_path = tmp_path / f"collect_{city.city_id}_gsv_2026-07-01.log"
     assert "TRACEBACK MARKER" in log_path.read_text()
     assert "exited 3" in caplog.text
@@ -1604,3 +1606,68 @@ def test_city_timeout_is_clamped_to_the_remaining_batch_budget(conn):
     assert clamped == 1800
     # Never clamp below the floor that lets a child reach its first request.
     assert sched.city_timeout_seconds(cfg, city, "gsv", remaining_s=1) == 300
+
+
+def test_last_error_records_the_real_cause_not_a_generic_string(conn, tmp_path, monkeypatch):
+    """Every failure in the catalog used to read "subprocess failed on <date>",
+    so a bad night had to be re-derived from daily-rotated logs the next
+    morning. The recorded cause must name what actually happened and which log
+    to read (issue #169)."""
+    from streetscape_metadata_tracker import scheduler as sched
+
+    _register(conn, "Alpha", width=1000, height=1000, step=20)
+    db.assign_schedule(conn, 90)
+    conn.execute("UPDATE schedule_state SET last_success_at = NULL")
+    conn.commit()
+
+    monkeypatch.setattr(
+        sched,
+        "_run_one_city",
+        lambda *a, **k: sched.CollectionOutcome(
+            False, "timed out after 180 minutes (see collect_alpha_mapillary_2026-07-02.log)"
+        ),
+    )
+    monkeypatch.setattr(sched.db, "connect", lambda path: conn)
+    monkeypatch.setattr(sched.time, "sleep", lambda s: None)
+    monkeypatch.setattr(sched, "generate_aggregate_v2", lambda c, d: None)
+    monkeypatch.setattr(sched, "generate_streetwalk_manifest", lambda c, d: {"walks": []})
+    monkeypatch.setattr(sched, "_reconcile_orphaned_run", lambda *a, **k: False)
+
+    sched.cmd_run_due(
+        SchedulerConfig(publish_enabled=False, log_dir=str(tmp_path)), today=date(2026, 7, 2)
+    )
+
+    recorded = conn.execute(
+        "SELECT last_error FROM schedule_state WHERE provider = 'gsv'"
+    ).fetchone()["last_error"]
+    assert "timed out after 180 minutes" in recorded
+    assert "collect_alpha_mapillary_2026-07-02.log" in recorded, "must name the log to read"
+    assert "subprocess failed on" not in recorded
+
+
+def test_a_plain_bool_from_run_one_city_still_works(conn, tmp_path, monkeypatch):
+    """CollectionOutcome is deliberately bool-compatible; a caller returning a
+    bare False must still record a failure rather than crash."""
+    from streetscape_metadata_tracker import scheduler as sched
+
+    _register(conn, "Alpha", width=1000, height=1000, step=20)
+    db.assign_schedule(conn, 90)
+    conn.execute("UPDATE schedule_state SET last_success_at = NULL")
+    conn.commit()
+
+    monkeypatch.setattr(sched, "_run_one_city", lambda *a, **k: False)
+    monkeypatch.setattr(sched.db, "connect", lambda path: conn)
+    monkeypatch.setattr(sched.time, "sleep", lambda s: None)
+    monkeypatch.setattr(sched, "generate_aggregate_v2", lambda c, d: None)
+    monkeypatch.setattr(sched, "generate_streetwalk_manifest", lambda c, d: {"walks": []})
+    monkeypatch.setattr(sched, "_reconcile_orphaned_run", lambda *a, **k: False)
+
+    sched.cmd_run_due(
+        SchedulerConfig(publish_enabled=False, log_dir=str(tmp_path)), today=date(2026, 7, 2)
+    )
+
+    row = conn.execute(
+        "SELECT consecutive_failures, last_error FROM schedule_state WHERE provider = 'gsv'"
+    ).fetchone()
+    assert row["consecutive_failures"] == 1
+    assert "subprocess failed on 2026-07-02" in row["last_error"]  # the fallback


### PR DESCRIPTION
Fixes #169.

## The problem

Every failure in the catalog reads exactly this:

```
subprocess failed on 2026-07-28
```

The real reason existed one frame down — `_run_collection_subprocess` computes `exited 3` or `timed out after 180 minutes` and knows which per-attempt log holds the traceback — and was dropped because the function returned a bare `bool`.

The cost is concrete: diagnosing the 2026-07-28 Mapillary failures took a day of re-running cities by hand, because by then the scheduler log had rotated and the catalog remembered nothing. Two of the hypotheses tested were wrong, which cost more time still.

## The fix

Return a `CollectionOutcome(ok, reason)` instead. It is deliberately truthy/falsy like the bool it replaces, and the caller reads `.reason` via `getattr`, so any caller handing back a bare bool keeps working and falls back to the old string. That keeps this a small change rather than a signature churn through three layers.

The reason carries the child log's **name** rather than its full path — the catalog outlives any given checkout location, and `logs/<name>` is what an operator actually greps for.

Before / after in `schedule_state.last_error`:

```
- subprocess failed on 2026-07-30
+ timed out after 180 minutes (see collect_cairo--egypt_mapillary_2026-07-30.log)
```

## Also

`scheduler status` gets a failing-pairs section. `last_error` was already selected there and then silently dropped from the rendered table. It goes in its own list rather than a column because the main table is ~1200 rows and an empty column on every healthy row is just noise; capped at 40 so one systemically bad night doesn't bury the budget summary.

## Tests

Two new: the recorded cause names both what happened and which log to read (and is *not* the generic string), plus a regression that a bare `False` from `_run_one_city` still records a failure via the fallback. The existing child-output test now asserts the reason travels back rather than `ok is False`.

Full suite: 493 passed. `ruff check`/`format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011eXNu3Aen8addoCPKKKFbG