### PR TITLE
Stop the Mapillary post-decode step from ballooning to tens of GB

### DIFF
--- a/streetscape_metadata_tracker/download_common.py
+++ b/streetscape_metadata_tracker/download_common.py
@@ -9,10 +9,11 @@ provider importing from another's module.
 
 import asyncio
 import re
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
 from datetime import datetime
 
 import geopy.distance
+import numpy as np
 from tqdm import tqdm
 
 
@@ -106,6 +107,46 @@ def redact_credentials(text: str) -> str:
     return _CREDENTIAL_PATTERN.sub(r"\1=REDACTED", str(text))
 
 
+def grid_index_ranges(width_steps: int, height_steps: int) -> tuple[range, range]:
+    """The (i, j) index ranges of a grid, in the order points are generated."""
+    return (
+        range(-height_steps // 2, height_steps // 2 + 1),
+        range(-width_steps // 2, width_steps // 2 + 1),
+    )
+
+
+def _grid_rows(
+    origin: geopy.Point, width_steps: int, height_steps: int, step_length: float
+) -> Iterator[tuple[int, list[float], list[float]]]:
+    """
+    Yield one grid ROW at a time as ``(i, row_lats, row_lons)``.
+
+    Shared by the two public generators below so the per-point geodesic math
+    lives in exactly one place. Grid geometry is FROZEN — every future run of a
+    city re-derives these same coordinates so its diffs align on an identical
+    rectangle — so this math must never drift. The one change from the original
+    nested loop is hoisting the northward displacement out of the inner loop,
+    where it never depended on ``j``: identical output, half the geodesic
+    solves. That is worth real time on a big city (the solve is pure-Python
+    geographiclib, and a 10M-point grid spent ~13 minutes here before a single
+    tile was fetched).
+    """
+    i_values, j_values = grid_index_ranges(width_steps, height_steps)
+    total_points = (width_steps + 1) * (height_steps + 1)
+
+    with tqdm(total=total_points, desc="Generating search grid points") as pbar:
+        for i in i_values:
+            north_point = geopy.distance.distance(meters=i * step_length).destination(origin, 0)
+            row_lats: list[float] = []
+            row_lons: list[float] = []
+            for j in j_values:
+                point = geopy.distance.distance(meters=j * step_length).destination(north_point, 90)
+                row_lats.append(point.latitude)
+                row_lons.append(point.longitude)
+            pbar.update(len(j_values))
+            yield i, row_lats, row_lons
+
+
 def generate_grid_points(
     origin: geopy.Point, width_steps: int, height_steps: int, step_length: float
 ) -> list[tuple[float, float, int, int]]:
@@ -121,18 +162,41 @@ def generate_grid_points(
     Returns:
         List of tuples containing (latitude, longitude, i, j) for each point
     """
+    _, j_values = grid_index_ranges(width_steps, height_steps)
     points = []
-    total_points = (width_steps + 1) * (height_steps + 1)
-
-    with tqdm(total=total_points, desc="Generating search grid points") as pbar:
-        for i in range(-height_steps // 2, height_steps // 2 + 1):
-            for j in range(-width_steps // 2, width_steps // 2 + 1):
-                north_point = geopy.distance.distance(meters=i * step_length).destination(origin, 0)
-                point = geopy.distance.distance(meters=j * step_length).destination(north_point, 90)
-                points.append((point.latitude, point.longitude, i, j))
-                pbar.update(1)
-
+    for i, row_lats, row_lons in _grid_rows(origin, width_steps, height_steps, step_length):
+        points.extend(
+            (lat, lon, i, j) for lat, lon, j in zip(row_lats, row_lons, j_values, strict=True)
+        )
     return points
+
+
+def generate_grid_arrays(
+    origin: geopy.Point, width_steps: int, height_steps: int, step_length: float
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    """
+    The same grid as :func:`generate_grid_points`, as ``(lats, lons, i, j)``
+    arrays in the same order.
+
+    For a caller that only needs coordinates, this never materializes the list
+    of Python tuples — which at Cairo's ~10.5M points is about 2.2 GB on its
+    own, against a cgroup capped at 8 GB (issue #157). The arrays are ~24 bytes
+    per point instead of ~120.
+    """
+    i_values, j_values = grid_index_ranges(width_steps, height_steps)
+    n_i, n_j = len(i_values), len(j_values)
+
+    lats = np.empty(n_i * n_j, dtype=np.float64)
+    lons = np.empty(n_i * n_j, dtype=np.float64)
+    pos = 0
+    for _i, row_lats, row_lons in _grid_rows(origin, width_steps, height_steps, step_length):
+        lats[pos : pos + n_j] = row_lats
+        lons[pos : pos + n_j] = row_lons
+        pos += n_j
+
+    i_idx = np.repeat(np.fromiter(i_values, dtype=np.int32, count=n_i), n_j)
+    j_idx = np.tile(np.fromiter(j_values, dtype=np.int32, count=n_j), n_i)
+    return lats, lons, i_idx, j_idx
 
 
 def standardize_capture_date(date_str: str | None) -> str | None:

--- a/streetscape_metadata_tracker/download_mapillary.py
+++ b/streetscape_metadata_tracker/download_mapillary.py
@@ -52,7 +52,12 @@ from tqdm import tqdm
 
 from .analysis import FLAT_ONLY
 from .config import MAPILLARY_METADATA_DTYPES
-from .download_common import DownloadError, generate_grid_points, redact_credentials
+from .download_common import (
+    DownloadError,
+    generate_grid_arrays,
+    grid_index_ranges,
+    redact_credentials,
+)
 from .fileutils import load_city_csv_file
 
 logger = logging.getLogger(__name__)
@@ -435,8 +440,20 @@ async def download_mapillary_metadata_async(
     width_steps = int(grid_width / step_length)
     height_steps = int(grid_height / step_length)
     origin = geopy.Point(center_lat, center_lon)
-    grid_points = generate_grid_points(origin, width_steps, height_steps, step_length)
-    point_by_index = {(i, j): (lat, lon) for lat, lon, i, j in grid_points}
+    # Arrays, not a list of tuples and a dict keyed by (i, j): at Cairo's ~10.5M
+    # points those two cost ~4.5 GB between them against an 8 GB cgroup, which
+    # is most of why a big city looked like a hang here (issue #157). The grid
+    # is a regular lattice, so a point's position is arithmetic — see
+    # _grid_ordinal below — and needs no lookup table.
+    grid_lats, grid_lons, _, _ = generate_grid_arrays(
+        origin, width_steps, height_steps, step_length
+    )
+    i_values, j_values = grid_index_ranges(width_steps, height_steps)
+    i_min, n_j, num_grid_points = i_values[0], len(j_values), len(grid_lats)
+
+    def _grid_ordinal(i: np.ndarray | int, j: np.ndarray | int):
+        """Position of grid index (i, j) in the generation order."""
+        return (i - i_min) * n_j + (j - j_values[0])
 
     bbox = grid_bbox(center_lat, center_lon, grid_width, grid_height, step_length)
 
@@ -503,7 +520,8 @@ async def download_mapillary_metadata_async(
     rows = []
     pano_covered_points = set()
     for img, point in _assign(panos):
-        grid_lat, grid_lon = point_by_index[point]
+        ordinal = _grid_ordinal(*point)
+        grid_lat, grid_lon = grid_lats[ordinal], grid_lons[ordinal]
         capture_date = captured_at_to_iso_date(img["captured_at_ms"])
         # Mirror GSV's convention: a pano without a usable capture date is
         # present but doesn't count toward dated stats (NO_DATE).
@@ -526,7 +544,8 @@ async def download_mapillary_metadata_async(
     for point, img in flat_representative.items():
         if point in pano_covered_points:
             continue  # the pano already covers this grid point
-        grid_lat, grid_lon = point_by_index[point]
+        ordinal = _grid_ordinal(*point)
+        grid_lat, grid_lon = grid_lats[ordinal], grid_lons[ordinal]
         # capture_date is deliberately null for FLAT_ONLY: this row is a
         # coverage-presence marker, and a null date keeps flat timestamps out
         # of every date/age/histogram path (which key on status == 'OK').
@@ -534,34 +553,52 @@ async def download_mapillary_metadata_async(
         flat_only_points.add(point)
 
     covered_points = pano_covered_points | flat_only_points
-    for (i, j), (grid_lat, grid_lon) in point_by_index.items():
-        if (i, j) not in covered_points:
-            rows.append(
-                {
-                    "query_lat": grid_lat,
-                    "query_lon": grid_lon,
-                    "query_timestamp": query_timestamp,
-                    "pano_lat": None,
-                    "pano_lon": None,
-                    "pano_id": None,
-                    "capture_date": None,
-                    "copyright_info": None,
-                    "status": "ZERO_RESULTS",
-                    # No image at this point → all Mapillary extras null.
-                    "creator_id": None,
-                    "organization_id": None,
-                    "sequence_id": None,
-                    "is_pano": None,
-                    "on_foot": None,
-                    "quality_score": None,
-                    "compass_angle": None,
-                }
-            )
+    columns = list(MAPILLARY_METADATA_DTYPES.keys())
+    covered_df = pd.DataFrame(rows, columns=columns)
+    del rows
 
-    df = pd.DataFrame(rows, columns=list(MAPILLARY_METADATA_DTYPES.keys()))
-    csv_bytes = df.to_csv(index=False).encode("utf-8")
-    with gzip.open(output_csv_gz_path, "wb") as f:
-        f.write(csv_bytes)
+    # The empty-grid-point fill, built COLUMN-WISE rather than as one dict per
+    # point. This is the single biggest allocation in the whole pipeline: a
+    # 16-key dict is 464 bytes, so Cairo's ~10.5M points cost ~4.9 GB of dicts
+    # plus another ~6 GB when pandas turns them into an N x 16 object matrix —
+    # on a cgroup capped at 8 GB (issue #157). As arrays the same fill is two
+    # float columns and a handful of all-null ones.
+    empty_ordinals = np.setdiff1d(
+        np.arange(num_grid_points, dtype=np.int64),
+        np.fromiter(
+            (_grid_ordinal(i, j) for i, j in covered_points),
+            dtype=np.int64,
+            count=len(covered_points),
+        ),
+        assume_unique=True,
+    )
+    empty_df = pd.DataFrame(
+        {
+            "query_lat": grid_lats[empty_ordinals],
+            "query_lon": grid_lons[empty_ordinals],
+            "query_timestamp": query_timestamp,
+            "status": "ZERO_RESULTS",
+            # No image at this point → all Mapillary extras null.
+            **{
+                c: None
+                for c in columns
+                if c not in ("query_lat", "query_lon", "query_timestamp", "status")
+            },
+        },
+        columns=columns,
+    )
+    num_empty_points = len(empty_ordinals)
+    del empty_ordinals
+
+    df = pd.concat([covered_df, empty_df], ignore_index=True) if num_empty_points else covered_df
+    del covered_df, empty_df
+    # Stream straight into the gzip handle. df.to_csv() with no path built the
+    # ENTIRE csv as one Python str and then a second full copy as bytes — about
+    # 1.7 GB of pure duplication at Cairo scale, for a file we are writing out
+    # anyway.
+    with gzip.open(output_csv_gz_path, "wt", encoding="utf-8", newline="") as f:
+        df.to_csv(f, index=False)
+    del df
 
     # Read back through the shared loader so dtypes match GSV runs exactly
     df = load_city_csv_file(output_csv_gz_path)
@@ -569,7 +606,7 @@ async def download_mapillary_metadata_async(
     logger.info(
         f"Wrote {len(df)} rows ({n_pano_rows} pano rows, "
         f"{len(flat_only_points)} flat-only points, {num_flat_images} flat images, "
-        f"{len(point_by_index) - len(covered_points)} empty grid points) "
+        f"{num_empty_points} empty grid points) "
         f"to {output_csv_gz_path}"
     )
 

--- a/tests/test_download_common.py
+++ b/tests/test_download_common.py
@@ -11,7 +11,9 @@ import pytest
 from streetscape_metadata_tracker.download_common import (
     AsyncRateLimiter,
     DownloadError,
+    generate_grid_arrays,
     generate_grid_points,
+    grid_index_ranges,
     standardize_capture_date,
 )
 
@@ -209,3 +211,74 @@ def test_rate_limiter_zero_or_negative_disables(monkeypatch):
 
     _run(scenario())
     assert sleeps == []
+
+
+# ── generate_grid_arrays (issue #157) ───────────────────────────────────────
+
+
+def _reference_grid(origin, width_steps, height_steps, step_length):
+    """The original nested-loop grid, kept verbatim as the frozen-geometry oracle.
+
+    Grid geometry is immutable by design: every future run of a city re-derives
+    these coordinates so its diffs align on an identical rectangle. Any drift
+    here silently misaligns a city against its own history, which no other test
+    would catch — so the fast paths are checked against the slow original rather
+    than against each other.
+    """
+    points = []
+    for i in range(-height_steps // 2, height_steps // 2 + 1):
+        for j in range(-width_steps // 2, width_steps // 2 + 1):
+            north = geopy.distance.distance(meters=i * step_length).destination(origin, 0)
+            point = geopy.distance.distance(meters=j * step_length).destination(north, 90)
+            points.append((point.latitude, point.longitude, i, j))
+    return points
+
+
+@pytest.mark.parametrize(
+    ("origin", "w", "h", "step"),
+    [
+        (SEATTLE, 11, 7, 20),  # odd/odd: exercises the // 2 fencepost asymmetry
+        (SEATTLE, 4, 6, 20),
+        (geopy.Point(-33.8688, 151.2093), 8, 8, 20),  # southern hemisphere
+        (geopy.Point(30.0444, 31.2357), 5, 5, 50),
+        (geopy.Point(64.1466, -21.9426), 3, 8, 15),  # high latitude
+        (SEATTLE, 0, 0, 20),  # degenerate single point
+    ],
+)
+def test_both_generators_match_the_original_loop_exactly(origin, w, h, step):
+    reference = _reference_grid(origin, w, h, step)
+
+    assert generate_grid_points(origin, w, h, step) == reference
+
+    lats, lons, i_idx, j_idx = generate_grid_arrays(origin, w, h, step)
+    as_tuples = [
+        (lat, lon, int(i), int(j))
+        for lat, lon, i, j in zip(
+            lats.tolist(), lons.tolist(), i_idx.tolist(), j_idx.tolist(), strict=True
+        )
+    ]
+    assert as_tuples == reference, "array grid must be bit-identical, not merely close"
+
+
+def test_grid_index_ranges_match_the_generated_order():
+    w, h = 11, 7
+    i_values, j_values = grid_index_ranges(w, h)
+    _, _, i_idx, j_idx = generate_grid_arrays(SEATTLE, w, h, 20)
+
+    # The ordinal formula the Mapillary downloader uses to replace its
+    # (i, j) -> (lat, lon) dict depends on this exact ordering.
+    expected = [(i, j) for i in i_values for j in j_values]
+    assert list(zip(i_idx.tolist(), j_idx.tolist(), strict=True)) == expected
+
+
+def test_grid_ordinal_arithmetic_locates_every_point():
+    """The downloader indexes grid points by arithmetic instead of a dict."""
+    w, h = 9, 5
+    i_values, j_values = grid_index_ranges(w, h)
+    lats, lons, i_idx, j_idx = generate_grid_arrays(SEATTLE, w, h, 20)
+    n_j = len(j_values)
+
+    for ordinal, (i, j) in enumerate(zip(i_idx.tolist(), j_idx.tolist(), strict=True)):
+        computed = (i - i_values[0]) * n_j + (j - j_values[0])
+        assert computed == ordinal
+        assert (lats[computed], lons[computed]) == (lats[ordinal], lons[ordinal])


### PR DESCRIPTION
Refs #157.

## What was actually wrong

A big Mapillary city looked like a hang: tile download and decode finish, the process prints nothing for hours, then it is SIGKILLed at the timeout.

It was never CPU-bound. With memory available the entire post-decode path is **2–4 minutes** at Cairo scale. It was holding **four full-grid-sized structures live at once — ~1.67 GB per 1M grid points** — against a cgroup capped at `MemoryHigh=4G` / `MemoryMax=8G`:

| | structure | @1M pts | Cairo (10.5M) |
|---|---|---|---|
| 1 | `grid_points`, list of N 4-tuples | 0.21 GB | 2.2 GB |
| 2 | `point_by_index` dict + 2N fresh tuples | 0.22 GB | 2.3 GB |
| 3 | `rows`, list of N 16-key dicts (464 B each) | 0.47 GB | 4.9 GB |
| 4 | pandas' N×16 object matrix + 12 object cols | 0.58 GB | 6.1 GB |
| 5 | full CSV as `str`, then a second copy as `bytes` | 0.02 GB | ~1.7 GB |
| | **peak** | **1.67 GB** | **17.6 GB** |

**This corrects the diagnosis on the issue**, which blamed GC and the aggregate step. GC is a *symptom* of the oversized heap, not the cost — benchmarked at 1.0–1.5× with it disabled, and most of the graph isn't even GC-tracked. And `generate_aggregate_v2` is already skipped under the scheduler by `--no-publish-json`, so it can only affect manual runs.

## The fix

- **Build the empty-grid-point fill column-wise** instead of one dict per point. Removes rows 3 and 4 — ~11 GB at Cairo.
- **Index grid points by arithmetic** rather than a list of tuples plus an `(i, j) -> (lat, lon)` dict. The grid is a regular lattice, so position is computable. Removes rows 1 and 2 — ~4.5 GB.
- **Write the CSV straight into the gzip handle.** `df.to_csv()` with no path built the whole file as one `str` then a second full copy as `bytes` — pure duplication for a file being written anyway.

Measured on a 1M-point all-empty grid: **0.73 GB peak, down from 1.67 GB.** Cairo projects to ~7.7 GB instead of 17.6 GB, and with #166's 40 km cap to **~2.9 GB**.

Also hoists the northward displacement out of `generate_grid_points`' inner loop, where it never depended on `j` — half the geodesic solves for identical output. That path cost 74.8 µs/point, i.e. **~13 minutes on Cairo before a single tile was fetched**.

## Frozen-geometry safety

Grid geometry is immutable by design: every future run of a city re-derives these coordinates so its diffs align on an identical rectangle. **The coordinate math is untouched** — the only change is which loop the north displacement lives in.

Both generators are tested against the original nested loop kept verbatim as an oracle, parametrized across odd/even step counts, both hemispheres, high latitude and the degenerate single-point grid, asserting **bit-identical** output rather than approximate agreement. Drift there would silently misalign a city against its own history and no other test would catch it.

Full suite: 502 passed. `ruff check`/`format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011eXNu3Aen8addoCPKKKFbG