### PR TITLE
Don't let one transient tile failure discard an entire Mapillary city

### DIFF
--- a/streetscape_metadata_tracker/download_mapillary.py
+++ b/streetscape_metadata_tracker/download_mapillary.py
@@ -50,7 +50,7 @@ import numpy as np
 import pandas as pd
 from tqdm import tqdm
 
-from .analysis import FLAT_ONLY
+from .analysis import FLAT_ONLY, REQUEST_FAILED
 from .config import MAPILLARY_METADATA_DTYPES
 from .download_common import (
     DownloadError,
@@ -299,11 +299,60 @@ def assign_to_grid(
     return i, j, in_grid
 
 
+def _points_in_tiles(
+    lats: np.ndarray, lons: np.ndarray, tiles: list[tuple[int, int]], zoom: int = TILE_ZOOM
+) -> np.ndarray:
+    """
+    Boolean mask of which (lat, lon) points fall inside any of ``tiles``.
+
+    Vectorized form of ``lonlat_to_tile_frac``; used to attribute undownloaded
+    tiles back to the grid points they cover (issue #168). Deliberately ignores
+    the tiles' render buffer: a point just outside a failed tile may in fact
+    have been covered by a neighbour, and calling it "unknown" errs toward
+    admitting we don't know rather than claiming empty.
+    """
+    if len(lats) == 0:
+        return np.zeros(0, dtype=bool)
+    n = 2**zoom
+    fx = (lons + 180.0) / 360.0 * n
+    fy = (1.0 - np.arcsinh(np.tan(np.radians(lats))) / np.pi) / 2.0 * n
+    # One packed int per tile so membership is a single sorted-array lookup
+    # instead of a Python loop over the (usually tiny) failed-tile list.
+    keys = fx.astype(np.int64) * n + fy.astype(np.int64)
+    failed_keys = np.array(sorted(x * n + y for x, y in tiles), dtype=np.int64)
+    return np.isin(keys, failed_keys)
+
+
 # ── Download ───────────────────────────────────────────────────────────────
 
 
+# A city whose permanently-failed tiles exceed this fraction of the tile set is
+# abandoned rather than finalized as an immutable snapshot. Mirrors
+# download_gsv.MAX_FAILED_POINT_FRACTION: tolerate a blip, refuse a hole.
+#
+# It is a FRACTION rather than an absolute count on purpose, and the
+# consequence is worth being explicit about: a big city (Chicago, 480 tiles)
+# absorbs a stray 404 at 0.2%, while a small city (16 tiles) gets no tolerance
+# at all, because there one tile is ~6% of its entire area. That asymmetry is
+# the right way round — the threshold is bounding the size of the unknown
+# region in a snapshot that is immutable once published, not counting requests.
+# A small city that loses a tile simply fails and is retried on its next
+# nightly slot, which costs a few tile requests.
+MAX_FAILED_TILE_FRACTION = 0.02
+
+# The tiles CDN can return a transient 404 for a tile that serves fine minutes
+# later (observed on Chicago, 2026-07-29: z14/4196/6084 404'd through every
+# retry, then returned 2.1M features the next day). Three tries inside a
+# 60-second window was too thin a budget for that.
+_TILE_MAX_TRIES = 5
+_TILE_MAX_TIME_S = 120
+
+
 @backoff.on_exception(
-    backoff.expo, (asyncio.TimeoutError, aiohttp.ClientError), max_tries=3, max_time=60
+    backoff.expo,
+    (asyncio.TimeoutError, aiohttp.ClientError),
+    max_tries=_TILE_MAX_TRIES,
+    max_time=_TILE_MAX_TIME_S,
 )
 async def _fetch_tile(
     session: aiohttp.ClientSession, url: str, timeout: aiohttp.ClientTimeout
@@ -375,8 +424,14 @@ async def fetch_city_images_async(
     try:
         # Token rides in each tile URL as ?access_token= — see TILE_URL_TEMPLATE
         # comment (the tiles CDN 403s the Authorization header).
+        #
+        # return_exceptions: one bad tile out of hundreds used to discard the
+        # whole city, for both the grid run and the road walk (issue #168). A
+        # transient 404 is worth one tile, not a city.
         async with aiohttp.ClientSession() as session:
-            results = await asyncio.gather(*(fetch_one(x, y) for x, y in tiles))
+            settled = await asyncio.gather(
+                *(fetch_one(x, y) for x, y in tiles), return_exceptions=True
+            )
     except DownloadError as e:
         # e.g. the rejected-token error from _fetch_tile; attach the spent
         # request count so the caller can still record it in the ledger.
@@ -388,6 +443,38 @@ async def fetch_city_images_async(
         raise error from e
     finally:
         progress_bar.close()
+
+    results = []
+    failed_tiles: list[tuple[int, int]] = []
+    first_error: BaseException | None = None
+    for (x, y), outcome in zip(tiles, settled, strict=True):
+        if isinstance(outcome, BaseException):
+            # A bad token is a whole-city condition, not a per-tile one: every
+            # remaining tile would fail the same way, so don't dress it up as
+            # partial coverage.
+            if isinstance(outcome, DownloadError):
+                outcome.api_requests = api_requests
+                raise outcome
+            failed_tiles.append((x, y))
+            first_error = first_error or outcome
+        else:
+            results.append(outcome)
+
+    if failed_tiles:
+        failed_fraction = len(failed_tiles) / len(tiles)
+        detail = f"{len(failed_tiles)}/{len(tiles)} tiles failed: {redact_credentials(first_error)}"
+        if failed_fraction > MAX_FAILED_TILE_FRACTION:
+            error = DownloadError(
+                f"Mapillary tile download failed: {detail} "
+                f"({failed_fraction:.1%} > {MAX_FAILED_TILE_FRACTION:.0%} tolerated); "
+                f"refusing to finalize an incomplete snapshot"
+            )
+            error.api_requests = api_requests
+            raise error from first_error
+        # Under the threshold the run continues, but the caller must mark the
+        # affected grid points REQUEST_FAILED rather than let them look like
+        # genuine no-imagery — see download_mapillary_metadata_async.
+        logger.warning(f"Continuing with {detail}; affected grid points marked REQUEST_FAILED")
 
     # Tiles are encoded with a buffer, so features near tile edges appear in
     # two tiles — dedup on image id (panos and flats share the id space).
@@ -401,6 +488,8 @@ async def fetch_city_images_async(
         "api_requests": api_requests,
         "tiles": len(tiles),
         "raw_feature_count": sum(len(r) for r in results),
+        # (x, y) of tiles that never came back. Empty on a clean run.
+        "failed_tiles": failed_tiles,
     }
 
 
@@ -468,6 +557,7 @@ async def download_mapillary_metadata_async(
     api_requests = fetched["api_requests"]
     tiles = fetched["tiles"]
     results = fetched["raw_feature_count"]
+    failed_tiles = fetched.get("failed_tiles") or []
     panos = [img for img in images if img["is_pano"]]
     flats = [img for img in images if not img["is_pano"]]
     logger.info(
@@ -587,6 +677,23 @@ async def download_mapillary_metadata_async(
         },
         columns=columns,
     )
+    # An uncovered point inside a tile that never downloaded is UNKNOWN, not
+    # empty. Left as ZERO_RESULTS it would be indistinguishable from genuine
+    # no-imagery and would quietly understate coverage and pollute the
+    # run-to-run diff, so it gets its own status — the same shape as the GSV
+    # downloader writing REQUEST_FAILED rows for its sub-threshold holes
+    # (issue #168). REQUEST_FAILED counts toward neither 360° nor any-imagery
+    # coverage, and is already one of analysis.SYSTEMIC_FAILURE_STATUSES.
+    if failed_tiles:
+        in_failed_tile = _points_in_tiles(
+            grid_lats[empty_ordinals], grid_lons[empty_ordinals], failed_tiles
+        )
+        empty_df.loc[in_failed_tile, "status"] = REQUEST_FAILED
+        num_failed_points = int(in_failed_tile.sum())
+        logger.warning(
+            f"{num_failed_points:,} grid points fall in {len(failed_tiles)} undownloaded "
+            f"tile(s); written as {REQUEST_FAILED} rather than empty"
+        )
     num_empty_points = len(empty_ordinals)
     del empty_ordinals
 

--- a/tests/test_mapillary.py
+++ b/tests/test_mapillary.py
@@ -10,15 +10,18 @@ import math
 import re
 from datetime import UTC, datetime
 
+import aiohttp
 import geopy
 import mapbox_vector_tile
 import numpy as np
 import pandas as pd
 import pytest
+import yarl
+from multidict import CIMultiDict, CIMultiDictProxy
 
 from streetscape_metadata_tracker import download_mapillary as dm
 from streetscape_metadata_tracker.config import MAPILLARY_METADATA_DTYPES
-from streetscape_metadata_tracker.download_common import generate_grid_points
+from streetscape_metadata_tracker.download_common import DownloadError, generate_grid_points
 from streetscape_metadata_tracker.json_summarizer import compute_mapillary_meta
 
 SEATTLE = (47.6062, -122.3321)
@@ -710,3 +713,123 @@ def test_compute_mapillary_meta_none_for_legacy_schema():
         columns=list(METADATA_DTYPES.keys()),
     )
     assert compute_mapillary_meta(df) is None
+
+
+# ── Tile fault tolerance (issue #168) ──────────────────────────────────────
+
+
+def _failing_fetch(fail_xy, tiles_by_xy=None, status=404):
+    """A _fetch_tile stand-in where one chosen tile always errors."""
+
+    async def fake_fetch(session, url, timeout):
+        m = re.search(r"/2/14/(\d+)/(\d+)\?", url)
+        xy = (int(m.group(1)), int(m.group(2)))
+        if xy in fail_xy:
+            # A real RequestInfo: aiohttp's __str__ dereferences it, and the
+            # error text goes through redact_credentials, so the URL (which
+            # carries the access token) must be present and scrubbable.
+            request_info = aiohttp.RequestInfo(
+                url=yarl.URL(url),
+                method="GET",
+                headers=CIMultiDictProxy(CIMultiDict()),
+                real_url=yarl.URL(url),
+            )
+            raise aiohttp.ClientResponseError(
+                request_info=request_info, history=(), status=status, message="Not Found"
+            )
+        return (tiles_by_xy or {}).get(xy, mapbox_vector_tile.encode([]))
+
+    return fake_fetch
+
+
+def _fetch_city(monkeypatch, fetch, lat, lon, width=30000, height=30000, step=2000):
+    monkeypatch.setattr(dm, "_fetch_tile", fetch)
+    return asyncio.run(
+        dm.fetch_city_images_async(
+            "Test City", dm.grid_bbox(lat, lon, width, height, step), "MLY|test|token"
+        )
+    )
+
+
+def test_one_bad_tile_no_longer_kills_the_whole_city(monkeypatch):
+    """The regression this exists for: Chicago 2026-07-29 lost both Mapillary
+    channels to a single transient 404 on z14/4196/6084, and the same tile
+    served 2.1M features the next day."""
+    lat, lon = 41.8, -87.7
+    all_tiles = dm.tiles_for_bbox(*dm.grid_bbox(lat, lon, 30000, 30000, 2000))
+    assert 1 / len(all_tiles) <= dm.MAX_FAILED_TILE_FRACTION, "one tile must be under threshold"
+
+    result = _fetch_city(monkeypatch, _failing_fetch({all_tiles[0]}), lat, lon)
+
+    assert result["failed_tiles"] == [all_tiles[0]]
+    assert result["tiles"] == len(all_tiles), "the tile set is still reported in full"
+
+
+def test_too_many_failed_tiles_still_refuses_to_finalize(monkeypatch):
+    """Tolerating a blip must not mean tolerating a hole."""
+    lat, lon = 41.8, -87.7
+    all_tiles = dm.tiles_for_bbox(*dm.grid_bbox(lat, lon, 30000, 30000, 2000))
+
+    with pytest.raises(DownloadError) as excinfo:
+        _fetch_city(monkeypatch, _failing_fetch(set(all_tiles)), lat, lon)
+
+    assert "refusing to finalize" in str(excinfo.value)
+    # The ledger still learns what the doomed attempt spent.
+    assert getattr(excinfo.value, "api_requests", 0) > 0
+
+
+def test_a_rejected_token_is_never_treated_as_a_partial_failure(monkeypatch):
+    """401/403 is a whole-city condition — every other tile would fail the same
+    way, so it must not be dressed up as one tolerable bad tile."""
+    lat, lon = 41.8, -87.7
+
+    async def bad_token(session, url, timeout):
+        raise DownloadError("Mapillary rejected the access token (HTTP 401).")
+
+    with pytest.raises(DownloadError) as excinfo:
+        _fetch_city(monkeypatch, bad_token, lat, lon)
+
+    assert "rejected the access token" in str(excinfo.value)
+    assert "refusing to finalize" not in str(excinfo.value)
+
+
+def test_points_under_a_failed_tile_are_request_failed_not_empty(monkeypatch, tmp_path):
+    """An uncovered point under an undownloaded tile is UNKNOWN. Left as
+    ZERO_RESULTS it is indistinguishable from genuine no-imagery and quietly
+    understates coverage."""
+    lat, lon = 41.8, -87.7
+    width = height = 30000
+    step = 500  # coarse: many tiles (so one failure is tolerated), few points
+    all_tiles = dm.tiles_for_bbox(*dm.grid_bbox(lat, lon, width, height, step))
+    failed = all_tiles[len(all_tiles) // 2]  # an interior tile, not a corner
+
+    monkeypatch.setattr(dm, "_fetch_tile", _failing_fetch({failed}))
+    out_path = str(tmp_path / "test_mapillary_2026-07-05.csv.gz")
+    result = asyncio.run(
+        dm.download_mapillary_metadata_async(
+            "Test City", lat, lon, width, height, step, "MLY|test|token", out_path
+        )
+    )
+
+    df = result["df"]
+    failed_rows = df[df["status"] == "REQUEST_FAILED"]
+    assert len(failed_rows) > 0, "the failed tile covers part of this grid"
+
+    # Every REQUEST_FAILED row really does sit inside the failed tile...
+    inside = dm._points_in_tiles(
+        failed_rows["query_lat"].to_numpy(), failed_rows["query_lon"].to_numpy(), [failed]
+    )
+    assert inside.all()
+    # ...and no point outside it was mislabelled.
+    empty_rows = df[df["status"] == "ZERO_RESULTS"]
+    outside = dm._points_in_tiles(
+        empty_rows["query_lat"].to_numpy(), empty_rows["query_lon"].to_numpy(), [failed]
+    )
+    assert not outside.any()
+
+
+def test_a_clean_run_reports_no_failed_tiles(monkeypatch, straddling_city):
+    """The tolerance path must be inert when nothing goes wrong."""
+    lat, lon = straddling_city
+    result = _fetch_city(monkeypatch, _failing_fetch(set()), lat, lon)
+    assert result["failed_tiles"] == []


### PR DESCRIPTION
Refs #168. **Stacked on #173** (uses its grid arrays for the tile-membership check); base will retarget to `main` once #173 merges.

## The bug

`fetch_city_images_async` gathered every z14 tile with no tolerance, so the first exception threw away the other 479 decoded tiles. And `_fetch_tile` sent 404 through `raise_for_status()`, making a status the tiles CDN returns *transiently* fatal after three tries in a 60-second window.

**Chicago, 2026-07-29:** tile `z14/4196/6084` 404'd through every retry and killed both `mapillary` (13:39) and `mapillary_streets` (13:40). The same 480 tiles served 2.1M features the next day. `mapillary_streets` currently stands at **4 successful cities against 16 failing**, while `gsv_streets` is 20/0.

## The fix

- `gather(return_exceptions=True)`, then partition. Above a failed fraction, raise as before (still carrying `api_requests` for the ledger); below it, continue and return `failed_tiles`.
- A **rejected token still fails the whole city immediately** rather than posing as one tolerable bad tile — every remaining tile would fail identically, and calling that "partial coverage" would be a lie.
- Backoff widened from 3 tries/60 s to 5/120 s.

### On the threshold

It's a **fraction, not a count**, and the asymmetry is deliberate: Chicago absorbs a stray 404 at 0.2%, while a 16-tile town gets *no* tolerance because there one tile is ~6% of its area. The quantity being bounded is the size of the unknown region in a snapshot that is **immutable once published** — a small city that loses a tile just fails and retries on its next nightly slot, costing a few tile requests. (Writing the tests is what surfaced this; my first comment claimed the opposite and was wrong.)

### The part that matters most

A tolerated tile's grid points are **not** left as `ZERO_RESULTS`. That is indistinguishable from genuine no-imagery, so it would quietly understate `coverage_rate_pct` and pollute the run-to-run diff — trading a loud failure for a silent data-quality bug. They're written as `REQUEST_FAILED`, the same shape as the GSV downloader recording its sub-threshold holes, and already excluded from both the 360° and any-imagery coverage numbers.

## Tests

Five new: one bad tile no longer kills the city; over-threshold still refuses to finalize (and still reports spend); a rejected token is never treated as partial; points under a failed tile are `REQUEST_FAILED` **and** no point outside it is mislabelled; a clean run reports no failed tiles.

Full suite: 507 passed. `ruff check`/`format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011eXNu3Aen8addoCPKKKFbG