### PR TITLE
Archive Google's published Street View driving plan and join it to the catalog (#176)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,7 @@ __pycache__/
 # findings that matter are written up in docs/experiments/; these are the raw
 # outputs, and they stay out of data/ so the publisher can't rsync them public.
 /experiments/
+# Driving-plan snapshots (issue #176): dated immutable archive of Google's
+# published feed. Outside data/ so the publish rsync never sees it; never
+# committed.
+/archive/

--- a/config/scheduler.makelab1.toml
+++ b/config/scheduler.makelab1.toml
@@ -117,3 +117,10 @@ enabled = true
 min_available_memory_gb = 8.0
 max_load_per_core = 0.9
 min_connection_limit = 5
+
+[driving_plan]
+# Nightly snapshot of Google's published driving-plan feed (issue #176).
+# Matches the manual snapshot dir already on prod; outside data/ so the
+# publish rsync never sees it. See config/scheduler.toml for field docs.
+enabled = true
+archive_dir = "/projects/makeabilitylab/streetscape-tracker/archive/gsv_driving_plan"

--- a/config/scheduler.toml
+++ b/config/scheduler.toml
@@ -191,3 +191,19 @@ min_available_memory_gb = 8.0
 max_load_per_core = 0.9
 # Never throttle concurrency below this floor.
 min_connection_limit = 5
+
+[driving_plan]
+# Nightly snapshot of Google's published Street View driving-plan feed
+# (issue #176): a single mutable URL Google overwrites in place, so revisions
+# are lost to anyone not archiving. One unauthenticated request per night —
+# no API key, no provider budget — run by run-due before the city loop (so it
+# happens even on zero-due nights and can't be eaten by the batch deadline).
+# A snapshot catalog row is written every fetch; the gzipped artifact and the
+# per-district DB entries only when the feed content actually changed.
+enabled = true
+# Artifacts live OUTSIDE data/ on purpose: data/ is rsynced to the public web
+# server and its whitelist publishes every *.json.gz — archiving there would
+# republish Google's content.
+#archive_dir = "archive/gsv_driving_plan"   # default: <repo>/archive/gsv_driving_plan
+#url = "https://www.google.com/streetview/static/feed/driving/data.json"
+#timeout_s = 60.0

--- a/streetscape_metadata_tracker/db.py
+++ b/streetscape_metadata_tracker/db.py
@@ -27,7 +27,7 @@ from .naming import sanitize_city_query_str
 
 logger = logging.getLogger(__name__)
 
-SCHEMA_VERSION = 9
+SCHEMA_VERSION = 10
 
 _SCHEMA = """
 CREATE TABLE IF NOT EXISTS cities (
@@ -201,6 +201,51 @@ CREATE TABLE IF NOT EXISTS street_walks (
     -- park paths, cycleways, steps), and both can be walked the same night.
     UNIQUE (city_id, provider, network_type, run_date)
 );
+
+-- Snapshots of Google's published Street View driving-plan feed (issue #176).
+-- The feed is a single mutable URL Google overwrites in place, so revisions
+-- are unobservable without our own dated archive. One row per fetch, even when
+-- the content is unchanged — the row IS the observation "we looked, it was X".
+-- The gzipped artifact and the exploded entries below exist only for fetches
+-- whose sha256 differs from the previous snapshot. First catalog family (bar
+-- api_usage) that is not city-keyed: the unit of observation is Google's whole
+-- worldwide plan. Artifacts live OUTSIDE data/ (archive/gsv_driving_plan/)
+-- because data/ is rsynced to the public web server and the whitelist would
+-- republish Google's content.
+CREATE TABLE IF NOT EXISTS driving_plan_snapshots (
+    snapshot_id       INTEGER PRIMARY KEY,
+    fetch_date        TEXT NOT NULL UNIQUE,
+    fetched_at        TEXT NOT NULL,
+    sha256            TEXT NOT NULL,
+    record_count      INTEGER NOT NULL,
+    changed           INTEGER NOT NULL,
+    artifact_filename TEXT,
+    source_url        TEXT
+);
+
+-- One row per (feed record, district): the feed's `districts` field is a
+-- comma-joined string (US districts are counties, which join onto catalog
+-- places). `publish` is stored verbatim and NEVER filtered at ingest — the
+-- Yes -> No transition across snapshots is the campaign-closed signal, data in
+-- its own right. Dirty datestart/dateend values (e.g. '13/1/19', 'Septemb…')
+-- keep the raw string beside a NULL parsed date; a row is never dropped
+-- because its date failed to parse. Rows exist only for changed snapshots.
+CREATE TABLE IF NOT EXISTS driving_plan_entries (
+    entry_id       INTEGER PRIMARY KEY,
+    snapshot_id    INTEGER NOT NULL REFERENCES driving_plan_snapshots(snapshot_id),
+    country        TEXT,
+    code           TEXT,
+    svspc          TEXT,
+    region         TEXT,
+    district       TEXT,
+    publish        TEXT,
+    date_start_raw TEXT,
+    date_start     TEXT,
+    date_end_raw   TEXT,
+    date_end       TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_dpe_snapshot ON driving_plan_entries(snapshot_id);
+CREATE INDEX IF NOT EXISTS idx_dpe_country_region ON driving_plan_entries(country, region);
 """
 
 # v1 → v2: add the provider dimension. Three tables need constraint changes
@@ -495,6 +540,13 @@ def init_schema(conn: sqlite3.Connection) -> None:
         user_version = 8
     if user_version == 8:
         _migrate_v8_to_v9(conn)
+        user_version = 9
+    # v9 -> v10 is purely additive (driving_plan_snapshots / driving_plan_entries,
+    # issue #176), so like v2 -> v3 it needs no rebuild migration: the CREATE
+    # TABLE IF NOT EXISTS in _SCHEMA creates the tables on any older catalog,
+    # and the version stamp below records the upgrade.
+    if user_version == 9:
+        user_version = 10
     conn.executescript(_SCHEMA)
     conn.execute(f"PRAGMA user_version = {SCHEMA_VERSION}")
     conn.commit()
@@ -1366,3 +1418,124 @@ def record_attempt(
             (city_id, provider, now, error, now, error),
         )
     conn.commit()
+
+
+# ── GSV driving-plan feed (issue #176) ─────────────────────────────────────
+
+
+def register_driving_plan_snapshot(
+    conn: sqlite3.Connection,
+    *,
+    fetch_date: date,
+    sha256: str,
+    record_count: int,
+    changed: bool,
+    artifact_filename: str | None,
+    source_url: str | None = None,
+) -> int:
+    """
+    Catalog one fetch of the driving-plan feed. Idempotent on fetch_date: a
+    forced same-day re-fetch replaces the prior row rather than erroring, since
+    a snapshot is a full re-census of the feed, not an incremental append.
+
+    Returns the snapshot_id.
+    """
+    conn.execute(
+        """INSERT INTO driving_plan_snapshots
+           (fetch_date, fetched_at, sha256, record_count, changed,
+            artifact_filename, source_url)
+           VALUES (?, ?, ?, ?, ?, ?, ?)
+           ON CONFLICT(fetch_date) DO UPDATE SET
+             fetched_at = excluded.fetched_at,
+             sha256 = excluded.sha256,
+             record_count = excluded.record_count,
+             changed = excluded.changed,
+             artifact_filename = excluded.artifact_filename,
+             source_url = excluded.source_url""",
+        (
+            fetch_date.isoformat(),
+            utc_now_iso(),
+            sha256,
+            record_count,
+            int(changed),
+            artifact_filename,
+            source_url,
+        ),
+    )
+    conn.commit()
+    row = conn.execute(
+        "SELECT snapshot_id FROM driving_plan_snapshots WHERE fetch_date = ?",
+        (fetch_date.isoformat(),),
+    ).fetchone()
+    return row["snapshot_id"]
+
+
+def replace_driving_plan_entries(
+    conn: sqlite3.Connection, snapshot_id: int, entries: list[tuple]
+) -> int:
+    """
+    Replace the exploded per-district entries of one snapshot. Delete-then-
+    insert so a forced same-day re-ingest is idempotent rather than
+    duplicating rows. Each entry tuple must match the column order below.
+
+    Returns the number of rows inserted.
+    """
+    conn.execute("DELETE FROM driving_plan_entries WHERE snapshot_id = ?", (snapshot_id,))
+    conn.executemany(
+        """INSERT INTO driving_plan_entries
+           (snapshot_id, country, code, svspc, region, district, publish,
+            date_start_raw, date_start, date_end_raw, date_end)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+        entries,
+    )
+    conn.commit()
+    return len(entries)
+
+
+def get_latest_driving_plan_snapshot(
+    conn: sqlite3.Connection, *, before_date: str | None = None
+) -> sqlite3.Row | None:
+    """
+    Most recent driving-plan snapshot, or None. `before_date` (exclusive,
+    'YYYY-MM-DD') lets ingest compare against the snapshot preceding today's
+    own row, so a forced re-fetch never compares against itself.
+    """
+    if before_date is not None:
+        return conn.execute(
+            """SELECT * FROM driving_plan_snapshots WHERE fetch_date < ?
+               ORDER BY fetch_date DESC LIMIT 1""",
+            (before_date,),
+        ).fetchone()
+    return conn.execute(
+        "SELECT * FROM driving_plan_snapshots ORDER BY fetch_date DESC LIMIT 1"
+    ).fetchone()
+
+
+def get_driving_plan_snapshot(conn: sqlite3.Connection, fetch_date: date) -> sqlite3.Row | None:
+    """The snapshot row for one fetch date, or None."""
+    return conn.execute(
+        "SELECT * FROM driving_plan_snapshots WHERE fetch_date = ?",
+        (fetch_date.isoformat(),),
+    ).fetchone()
+
+
+def get_active_driving_plans(
+    conn: sqlite3.Connection, *, country: str = "United States"
+) -> list[sqlite3.Row]:
+    """
+    Entries of the latest content-changed snapshot for one country — the
+    current picture of Google's published plan. Includes publish='No' rows
+    (retired windows); filter in the caller if only live campaigns matter.
+    """
+    latest = conn.execute(
+        """SELECT snapshot_id FROM driving_plan_snapshots WHERE changed = 1
+           ORDER BY fetch_date DESC LIMIT 1"""
+    ).fetchone()
+    if latest is None:
+        return []
+    return conn.execute(
+        """SELECT * FROM driving_plan_entries
+           WHERE snapshot_id = ? AND country = ?
+           ORDER BY region, district""",
+        (latest["snapshot_id"], country),
+    ).fetchall()

--- a/streetscape_metadata_tracker/driving_plan.py
+++ b/streetscape_metadata_tracker/driving_plan.py
@@ -1,0 +1,255 @@
+"""
+Snapshot Google's published Street View driving-plan feed (issue #176).
+
+Google publishes a forward-looking Street View collection plan behind a single
+mutable, unauthenticated URL that it overwrites in place. Plan revisions — a
+window shifting, a county added or dropped, a row retiring (`publish` flipping
+Yes -> No) — are invisible to anyone not snapshotting, and cannot be
+reconstructed after the fact. This module fetches the feed, archives dated
+immutable gzip snapshots with content-hash dedupe, and explodes the records
+into the catalog (one row per district) so planned re-drives can later be
+joined against the observed capture dates this project already measures.
+
+Like the GSV history harvester (issue #2), the source is an undocumented asset
+with no guarantee it keeps working; the archive is the hedge against its own
+fragility. Treat the plan as advisory, never a contract — Google's own note
+says listed cities "may include smaller cities and towns within driving
+distance", so absence is not a guarantee of no driving.
+
+Politeness: one unauthenticated request per day, enforced by the ingest gate
+(a snapshot row for today short-circuits before any network I/O). Fetching
+uses stdlib urllib — deliberately not the aiohttp/backoff machinery the
+collectors need, since this is one request to one static URL once a day.
+
+Storage: artifacts live OUTSIDE data/ (default: <repo>/archive/gsv_driving_plan/)
+because data/ is rsynced to the public web server and its whitelist publishes
+every *.json.gz — archiving there would republish Google's content.
+"""
+
+import gzip
+import hashlib
+import json
+import logging
+import os
+import time
+import urllib.request
+from dataclasses import dataclass
+from datetime import UTC, date, datetime
+
+from . import db
+from .download_gsv_history import _USER_AGENT
+
+logger = logging.getLogger(__name__)
+
+FEED_URL = "https://www.google.com/streetview/static/feed/driving/data.json"
+
+
+def default_archive_dir() -> str:
+    """Default snapshot archive: <repo root>/archive/gsv_driving_plan."""
+    repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    return os.path.join(repo_root, "archive", "gsv_driving_plan")
+
+
+def generate_snapshot_filename(fetch_date: date) -> str:
+    """
+    Dated immutable artifact name for one feed snapshot.
+
+    >>> from datetime import date
+    >>> generate_snapshot_filename(date(2026, 8, 1))
+    'gsv_driving_plan_2026-08-01.json.gz'
+    """
+    return f"gsv_driving_plan_{fetch_date.isoformat()}.json.gz"
+
+
+def fetch_feed(url: str = FEED_URL, *, timeout_s: float = 60.0, retries: int = 3) -> bytes:
+    """
+    Fetch the raw feed bytes with a browser User-Agent, retrying transient
+    failures with a short backoff. Raises the last error if all tries fail.
+    """
+    request = urllib.request.Request(url, headers={"User-Agent": _USER_AGENT})
+    last_error: Exception | None = None
+    for attempt in range(retries):
+        try:
+            with urllib.request.urlopen(request, timeout=timeout_s) as resp:
+                return resp.read()
+        except Exception as e:  # noqa: BLE001 — urllib raises a menagerie; all retryable here
+            last_error = e
+            if attempt < retries - 1:
+                delay = 5.0 * (attempt + 1)
+                logger.warning(
+                    "Driving-plan fetch attempt %d/%d failed (%s); retrying in %.0fs",
+                    attempt + 1, retries, e, delay,
+                )
+                time.sleep(delay)
+    raise last_error
+
+
+def parse_feed(raw: bytes) -> list[dict]:
+    """Decode the feed; it must be a JSON array of objects."""
+    data = json.loads(raw)
+    if not isinstance(data, list) or not all(isinstance(r, dict) for r in data):
+        raise ValueError("Driving-plan feed is not a JSON array of objects")
+    return data
+
+
+def parse_feed_date(value) -> str | None:
+    """
+    Defensively parse a feed timestamp to 'YYYY-MM-DD', or None.
+
+    The feed carries clean ISO timestamps but ~58 records have dirty values
+    ('13/1/19', truncated month names). Strict ISO only — no day/month-
+    ambiguous heuristics; callers keep the raw string beside the parsed date,
+    so a None loses nothing. Never raises.
+
+    >>> parse_feed_date("2026-02-02T08:00:00.000Z")
+    '2026-02-02'
+    >>> parse_feed_date("13/1/19") is None
+    True
+    >>> parse_feed_date(None) is None
+    True
+    >>> parse_feed_date("") is None
+    True
+    """
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00")).date().isoformat()
+    except ValueError:
+        return None
+
+
+def explode_records(records: list[dict], snapshot_id: int) -> list[tuple]:
+    """
+    Explode feed records into driving_plan_entries tuples, one per district.
+
+    `districts` is a comma-joined string; the split is uniform for all
+    countries (non-US districts are free-form, but the raw feed is fully
+    preserved in the artifact, so nothing is lost if a comma-split is wrong
+    there). An empty/missing `districts` yields a single row with a NULL
+    district. No record is ever dropped — dirty dates become NULL parsed
+    dates beside the intact raw string.
+    """
+    entries = []
+    for rec in records:
+        start_raw = rec.get("datestart")
+        end_raw = rec.get("dateend")
+        common = (
+            snapshot_id,
+            rec.get("country"),
+            rec.get("code"),
+            rec.get("svspc"),
+            rec.get("region"),
+        )
+        tail = (
+            rec.get("publish"),
+            start_raw,
+            parse_feed_date(start_raw),
+            end_raw,
+            parse_feed_date(end_raw),
+        )
+        districts = [d.strip() for d in (rec.get("districts") or "").split(",") if d.strip()]
+        if not districts:
+            entries.append(common + (None,) + tail)
+        else:
+            for district in districts:
+                entries.append(common + (district,) + tail)
+    return entries
+
+
+def write_snapshot_artifact(raw: bytes, archive_dir: str, fetch_date: date) -> str:
+    """
+    Gzip the raw feed bytes to the dated artifact, atomically (tmp + rename).
+    mtime=0 keeps the gzip bytes deterministic for a given input. Returns the
+    bare filename.
+    """
+    os.makedirs(archive_dir, exist_ok=True)
+    filename = generate_snapshot_filename(fetch_date)
+    path = os.path.join(archive_dir, filename)
+    tmp_path = path + ".tmp"
+    with open(tmp_path, "wb") as f:
+        f.write(gzip.compress(raw, mtime=0))
+    os.replace(tmp_path, path)
+    return filename
+
+
+@dataclass(frozen=True)
+class IngestResult:
+    """Outcome of one ingest pass, for logging and the CLI summary."""
+
+    snapshot_id: int | None
+    fetch_date: str
+    skipped: bool
+    changed: bool
+    record_count: int
+    entry_count: int
+
+
+def ingest(
+    conn,
+    *,
+    archive_dir: str,
+    fetch_date: date | None = None,
+    raw: bytes | None = None,
+    force: bool = False,
+    url: str = FEED_URL,
+    timeout_s: float = 60.0,
+) -> IngestResult:
+    """
+    Fetch (or accept injected bytes for backfill/tests), archive, and catalog
+    one snapshot of the driving-plan feed. The single code path behind both
+    the nightly scheduler hook and the manual fetch-driving-plan subcommand.
+
+    A snapshot row is written on EVERY ingest; the artifact and the exploded
+    entries only when the sha256 differs from the previous snapshot (the feed
+    moves rarely — this avoids ~365 near-identical files a year). `publish`
+    is never filtered: the Yes -> No transition is the campaign-closed signal.
+
+    Politeness gate: if a snapshot row already exists for fetch_date and not
+    `force`, returns skipped=True without touching the network.
+    """
+    fetch_date = fetch_date or datetime.now(UTC).date()
+    existing = db.get_driving_plan_snapshot(conn, fetch_date)
+    if existing is not None and not force:
+        return IngestResult(
+            snapshot_id=existing["snapshot_id"],
+            fetch_date=fetch_date.isoformat(),
+            skipped=True,
+            changed=bool(existing["changed"]),
+            record_count=existing["record_count"],
+            entry_count=0,
+        )
+
+    if raw is None:
+        raw = fetch_feed(url, timeout_s=timeout_s)
+    sha = hashlib.sha256(raw).hexdigest()
+    records = parse_feed(raw)
+
+    # Compare against the snapshot BEFORE this date (not any-hash-ever), so an
+    # A -> B -> A flip-flop is recorded as a change both times, and a forced
+    # same-day re-ingest never compares against its own prior row.
+    prev = db.get_latest_driving_plan_snapshot(conn, before_date=fetch_date.isoformat())
+    changed = prev is None or prev["sha256"] != sha
+
+    artifact_filename = write_snapshot_artifact(raw, archive_dir, fetch_date) if changed else None
+    snapshot_id = db.register_driving_plan_snapshot(
+        conn,
+        fetch_date=fetch_date,
+        sha256=sha,
+        record_count=len(records),
+        changed=changed,
+        artifact_filename=artifact_filename,
+        source_url=url,
+    )
+    # Always replace (with [] when unchanged): a forced same-day re-ingest that
+    # flips changed 1 -> 0 must not leave the earlier ingest's rows behind.
+    entries = explode_records(records, snapshot_id) if changed else []
+    entry_count = db.replace_driving_plan_entries(conn, snapshot_id, entries)
+
+    return IngestResult(
+        snapshot_id=snapshot_id,
+        fetch_date=fetch_date.isoformat(),
+        skipped=False,
+        changed=changed,
+        record_count=len(records),
+        entry_count=entry_count,
+    )

--- a/streetscape_metadata_tracker/driving_plan.py
+++ b/streetscape_metadata_tracker/driving_plan.py
@@ -78,7 +78,10 @@ def fetch_feed(url: str = FEED_URL, *, timeout_s: float = 60.0, retries: int = 3
                 delay = 5.0 * (attempt + 1)
                 logger.warning(
                     "Driving-plan fetch attempt %d/%d failed (%s); retrying in %.0fs",
-                    attempt + 1, retries, e, delay,
+                    attempt + 1,
+                    retries,
+                    e,
+                    delay,
                 )
                 time.sleep(delay)
     raise last_error

--- a/streetscape_metadata_tracker/scheduler.py
+++ b/streetscape_metadata_tracker/scheduler.py
@@ -14,6 +14,7 @@ Usage (--config accepted on either side of the subcommand):
     python -m streetscape_metadata_tracker.scheduler [--config PATH] run-due [--dry-run] [--limit N]
     python -m streetscape_metadata_tracker.scheduler [--config PATH] regenerate-aggregate [--publish]
     python -m streetscape_metadata_tracker.scheduler [--config PATH] reconcile-walks [--date D] [--dry-run]
+    python -m streetscape_metadata_tracker.scheduler [--config PATH] fetch-driving-plan [--force] [--from-file P --date D]
 
 Config: TOML (see config/scheduler.toml). Requires Python 3.11+ (tomllib).
 """
@@ -39,7 +40,7 @@ from pathlib import Path
 
 from tabulate import tabulate
 
-from . import db
+from . import db, driving_plan
 from .alerting import AlertConfig, send_alert, should_alert
 from .download_common import redact_credentials
 from .download_mapillary import estimate_tile_count
@@ -121,6 +122,23 @@ class ResourceGuardConfig:
 
 
 @dataclass
+class DrivingPlanConfig:
+    """[driving_plan] — nightly snapshot of Google's published Street View
+    driving-plan feed (issue #176).
+
+    NOT a [providers.*] channel on purpose: it has no API key, no request
+    budget, no per-city cadence — one unauthenticated request per night for
+    the whole worldwide feed. Artifacts live OUTSIDE data/ so the publish
+    rsync never sees them (its whitelist would republish Google's content).
+    """
+
+    enabled: bool = True
+    archive_dir: str = str(_PROJECT_ROOT / "archive" / "gsv_driving_plan")
+    url: str = driving_plan.FEED_URL
+    timeout_s: float = 60.0
+
+
+@dataclass
 class SchedulerConfig:
     # [schedule]
     cycle_days: int = 90
@@ -161,6 +179,8 @@ class SchedulerConfig:
     alerts: AlertConfig = field(default_factory=AlertConfig)
     # [resource_guard] — load/RAM-aware concurrency backoff on shared hosts
     resource_guard: ResourceGuardConfig = field(default_factory=ResourceGuardConfig)
+    # [driving_plan] — nightly driving-plan feed snapshot (issue #176)
+    driving_plan: DrivingPlanConfig = field(default_factory=DrivingPlanConfig)
 
     def __post_init__(self):
         if not self.db_path:
@@ -199,6 +219,7 @@ def load_scheduler_config(path: str | None = None) -> SchedulerConfig:
     pub = raw.get("publish", {})
     al = raw.get("alerts", {})
     rg = raw.get("resource_guard", {})
+    dp = raw.get("driving_plan", {})
 
     providers = None
     if "providers" in raw:
@@ -274,6 +295,12 @@ def load_scheduler_config(path: str | None = None) -> SchedulerConfig:
             min_available_memory_gb=rg.get("min_available_memory_gb", 8.0),
             max_load_per_core=rg.get("max_load_per_core", 0.9),
             min_connection_limit=rg.get("min_connection_limit", 5),
+        ),
+        driving_plan=DrivingPlanConfig(
+            enabled=dp.get("enabled", True),
+            archive_dir=dp.get("archive_dir", str(_PROJECT_ROOT / "archive" / "gsv_driving_plan")),
+            url=dp.get("url", driving_plan.FEED_URL),
+            timeout_s=dp.get("timeout_s", 60.0),
         ),
     )
 
@@ -750,6 +777,22 @@ def cmd_status(cfg: SchedulerConfig) -> int:
         used = db.get_api_usage(conn, today, provider)
         budget = cfg.providers[provider].daily_request_budget
         print(f"{provider} budget today: {used:,} / {budget:,} requests used.")
+
+    if cfg.driving_plan.enabled:
+        latest = db.get_latest_driving_plan_snapshot(conn)
+        if latest is None:
+            print("driving plan: never fetched.")
+        else:
+            last_changed = conn.execute(
+                """SELECT fetch_date FROM driving_plan_snapshots WHERE changed = 1
+                   ORDER BY fetch_date DESC LIMIT 1"""
+            ).fetchone()
+            state = "changed" if latest["changed"] else "unchanged"
+            print(
+                f"driving plan: last fetch {latest['fetch_date']} ({state}, "
+                f"{latest['record_count']:,} records; last change "
+                f"{last_changed['fetch_date'] if last_changed else '—'})."
+            )
     return 0
 
 
@@ -788,6 +831,60 @@ def cmd_regenerate(cfg: SchedulerConfig, publish: bool = False) -> int:
         if _publish(cfg, "regenerate-aggregate (manual)") != 0:
             return 1
         print("Published to the web server.")
+    return 0
+
+
+def cmd_fetch_driving_plan(
+    cfg: SchedulerConfig,
+    *,
+    force: bool = False,
+    from_file: str | None = None,
+    target_date: date | None = None,
+) -> int:
+    """
+    Snapshot the GSV driving-plan feed once, outside the nightly cycle
+    (issue #176). Same driving_plan.ingest() code path as run-due's hook.
+
+    ``--from-file`` ingests already-saved raw feed JSON instead of fetching —
+    the backfill handle for snapshots saved by hand before this existed (pair
+    it with ``--date`` for the date the bytes were actually fetched).
+    """
+    conn = db.connect(cfg.db_path)
+    raw = None
+    if from_file is not None:
+        opener = gzip.open if from_file.endswith(".gz") else open
+        with opener(from_file, "rb") as f:
+            raw = f.read()
+    try:
+        result = driving_plan.ingest(
+            conn,
+            archive_dir=cfg.driving_plan.archive_dir,
+            fetch_date=target_date,
+            raw=raw,
+            force=force,
+            url=cfg.driving_plan.url,
+            timeout_s=cfg.driving_plan.timeout_s,
+        )
+    except Exception as e:
+        logger.exception("Driving-plan fetch failed")
+        print(f"Driving-plan fetch failed: {e}")
+        return 1
+    if result.skipped:
+        print(
+            f"Snapshot for {result.fetch_date} already exists "
+            f"({result.record_count:,} records); use --force to re-fetch."
+        )
+    elif result.changed:
+        print(
+            f"Snapshot {result.fetch_date}: feed CHANGED — archived "
+            f"{driving_plan.generate_snapshot_filename(date.fromisoformat(result.fetch_date))} "
+            f"({result.record_count:,} records, {result.entry_count:,} entries)."
+        )
+    else:
+        print(
+            f"Snapshot {result.fetch_date}: feed unchanged since the previous "
+            f"snapshot ({result.record_count:,} records); no artifact written."
+        )
     return 0
 
 
@@ -1305,6 +1402,37 @@ def _collect_due(conn, cfg: SchedulerConfig, today: date):
     return ordered, providers_for_city
 
 
+def _fetch_driving_plan_nightly(cfg: SchedulerConfig, conn, today: date) -> str | None:
+    """
+    Snapshot the driving-plan feed (issue #176). Returns an error string for
+    the batch summary, or None. Never raises: a broken Google feed must not
+    cost a night of collection (the issue #167 lesson), and a failure here is
+    advisory — the feed is an undocumented asset with no uptime contract.
+    """
+    if not cfg.driving_plan.enabled:
+        return None
+    try:
+        result = driving_plan.ingest(
+            conn,
+            archive_dir=cfg.driving_plan.archive_dir,
+            fetch_date=today,
+            url=cfg.driving_plan.url,
+            timeout_s=cfg.driving_plan.timeout_s,
+        )
+    except Exception as e:
+        logger.exception("Driving-plan snapshot failed")
+        return f"driving-plan fetch failed: {e}"
+    if result.skipped:
+        outcome = "already snapshotted today"
+    elif result.changed:
+        outcome = f"CHANGED — archived, {result.entry_count:,} entries"
+    else:
+        outcome = "unchanged"
+    logger.info(f"Driving-plan snapshot {result.fetch_date}: {outcome} "
+                f"({result.record_count:,} records)")
+    return None
+
+
 def cmd_run_due(
     cfg: SchedulerConfig,
     dry_run: bool = False,
@@ -1357,7 +1485,14 @@ def cmd_run_due(
                 fits = "ok" if est <= budget_left[provider] else "OVER BUDGET (deferred)"
                 print(f"  {city.city_id:60s} {provider:16s} ~{est:>9,} req  {fits}")
                 budget_left[provider] -= est if est <= budget_left[provider] else 0
+        if cfg.driving_plan.enabled:
+            print("Would also snapshot the GSV driving-plan feed (issue #176).")
         return 0
+
+    # Snapshot the driving-plan feed BEFORE the city loop: upstream of the
+    # batch deadline and any mid-loop kill, and on zero-due nights too. Cheap
+    # (one request), and a failure never fails the night.
+    plan_error = _fetch_driving_plan_nightly(cfg, conn, today)
 
     # The tail below (aggregate, manifest, backup, publish) is what makes a
     # night visible, and it only runs if the loop returns. Everything that can
@@ -1376,6 +1511,7 @@ def cmd_run_due(
         f"{processed} cities"
         + (f"; {skipped_budget} deferred for budget" if skipped_budget else "")
         + (f"; stopped early ({stop_reason})" if stop_reason else "")
+        + (f"; {plan_error}" if plan_error else "")
     )
     logger.info("Done: " + summary)
     return _finish_batch(
@@ -1620,6 +1756,24 @@ def build_parser() -> argparse.ArgumentParser:
     p_rec.add_argument(
         "--dry-run", action="store_true", help="List what would be reconciled; no catalog writes"
     )
+    p_plan = sub.add_parser(
+        "fetch-driving-plan",
+        help="Snapshot Google's published Street View driving-plan feed",
+    )
+    _add_global_flags(p_plan)
+    p_plan.add_argument(
+        "--force", action="store_true", help="Re-fetch even if today's snapshot exists"
+    )
+    p_plan.add_argument(
+        "--from-file",
+        default=None,
+        help="Ingest saved raw feed JSON (.json or .json.gz) instead of fetching (backfill)",
+    )
+    p_plan.add_argument(
+        "--date",
+        default=None,
+        help="Snapshot date YYYY-MM-DD (default: today, UTC); use with --from-file for backfill",
+    )
     p_run = sub.add_parser("run-due", help="Collect today's due cities")
     _add_global_flags(p_run)
     p_run.add_argument("--dry-run", action="store_true", help="Print what would run; no downloads")
@@ -1649,6 +1803,11 @@ def main() -> int:
     if args.command == "reconcile-walks":
         target = date.fromisoformat(args.date) if args.date else None
         return cmd_reconcile_walks(cfg, target_date=target, dry_run=args.dry_run)
+    if args.command == "fetch-driving-plan":
+        target = date.fromisoformat(args.date) if args.date else None
+        return cmd_fetch_driving_plan(
+            cfg, force=args.force, from_file=args.from_file, target_date=target
+        )
     if args.command == "run-due":
         try:
             return cmd_run_due(cfg, dry_run=args.dry_run, limit=args.limit)

--- a/streetscape_metadata_tracker/scheduler.py
+++ b/streetscape_metadata_tracker/scheduler.py
@@ -1428,8 +1428,9 @@ def _fetch_driving_plan_nightly(cfg: SchedulerConfig, conn, today: date) -> str 
         outcome = f"CHANGED — archived, {result.entry_count:,} entries"
     else:
         outcome = "unchanged"
-    logger.info(f"Driving-plan snapshot {result.fetch_date}: {outcome} "
-                f"({result.record_count:,} records)")
+    logger.info(
+        f"Driving-plan snapshot {result.fetch_date}: {outcome} ({result.record_count:,} records)"
+    )
     return None
 
 

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -757,6 +757,42 @@ def test_migrate_v8_to_v9_clears_a_stale_scratch_table(tmp_path):
     conn.close()
 
 
+def test_migrate_v9_to_v10(tmp_path):
+    """A v9 catalog gains the driving-plan tables on connect (issue #176).
+
+    A v9 catalog is exactly the current schema minus the two driving_plan
+    tables, so the fixture is built from db._SCHEMA with them dropped (keeping
+    the fixture in sync with the code) and stamped user_version = 9.
+    """
+    db_path = str(tmp_path / "v9.db")
+    raw = sqlite3.connect(db_path)
+    raw.executescript(db._SCHEMA)
+    raw.execute("DROP TABLE driving_plan_entries")
+    raw.execute("DROP TABLE driving_plan_snapshots")
+    raw.execute(
+        """INSERT INTO cities (city_id, display_name, city_name, center_lat,
+           center_lon, grid_width_m, grid_height_m, step_m, created_at)
+           VALUES ('bend--or', 'Bend, OR', 'Bend', 44.05, -121.31,
+                   5000, 5000, 20, '2026-01-01T00:00:00+00:00')"""
+    )
+    raw.execute("PRAGMA user_version = 9")
+    raw.commit()
+    raw.close()
+
+    conn = db.connect(db_path)
+    assert conn.execute("PRAGMA user_version").fetchone()[0] == db.SCHEMA_VERSION
+    assert conn.execute("SELECT COUNT(*) FROM driving_plan_snapshots").fetchone()[0] == 0
+    assert conn.execute("SELECT COUNT(*) FROM driving_plan_entries").fetchone()[0] == 0
+    # Existing data is untouched by the additive migration.
+    assert db.resolve_city(conn, "bend--or").city_id == "bend--or"
+
+    # Idempotent: reopening must not error or re-migrate.
+    conn.close()
+    conn2 = db.connect(db_path)
+    assert conn2.execute("PRAGMA user_version").fetchone()[0] == db.SCHEMA_VERSION
+    conn2.close()
+
+
 def test_two_network_types_coexist_on_one_date(tmp_path):
     """The widened key is what lets both walks of a city survive the same night."""
     conn = db.connect(str(tmp_path / "c.db"))

--- a/tests/test_driving_plan.py
+++ b/tests/test_driving_plan.py
@@ -1,0 +1,258 @@
+"""Driving-plan feed snapshot tests (issue #176) — no network.
+
+The fetch primitive is either bypassed (raw= injection, the same seam the
+--from-file backfill uses) or monkeypatched; ingest is exercised for real
+against the conn fixture's catalog and a tmp_path archive dir.
+"""
+
+import gzip
+import json
+import urllib.request
+from datetime import date
+
+import pytest
+
+from streetscape_metadata_tracker import db, driving_plan
+
+
+def _record(**overrides):
+    base = {
+        "country": "United States",
+        "code": "US",
+        "svspc": "SV",
+        "region": "Kentucky",
+        "districts": "Jefferson, Bullitt, Nelson",
+        "publish": "Yes",
+        "datestart": "2026-02-02T08:00:00.000Z",
+        "dateend": "2026-12-31T08:00:00.000Z",
+    }
+    base.update(overrides)
+    return base
+
+
+def _raw(records):
+    return json.dumps(records).encode("utf-8")
+
+
+# ── Parsing ────────────────────────────────────────────────────────────────
+
+
+def test_parse_feed_date_handles_clean_and_dirty_values():
+    assert driving_plan.parse_feed_date("2026-02-02T08:00:00.000Z") == "2026-02-02"
+    # The ~58 known-dirty shapes must map to None, never raise.
+    assert driving_plan.parse_feed_date("13/1/19") is None
+    assert driving_plan.parse_feed_date("Septemb") is None
+    assert driving_plan.parse_feed_date("") is None
+    assert driving_plan.parse_feed_date(None) is None
+    assert driving_plan.parse_feed_date(12345) is None
+
+
+def test_parse_feed_rejects_non_array_payloads():
+    with pytest.raises(ValueError):
+        driving_plan.parse_feed(b'{"oops": "an object"}')
+    with pytest.raises(ValueError):
+        driving_plan.parse_feed(b'["just", "strings"]')
+
+
+def test_explode_records_splits_districts_and_drops_nothing():
+    records = [
+        _record(),
+        # Free-form non-US districts split the same way; the raw feed is
+        # preserved in the artifact, so a wrong split there loses nothing.
+        _record(country="Andorra", code="AD", region=None, districts="No Driving, All Areas"),
+        # Empty districts -> one presence row with a NULL district.
+        _record(country="Iceland", code="IS", districts=""),
+        _record(country="Norway", code="NO", districts=None),
+    ]
+    entries = driving_plan.explode_records(records, snapshot_id=7)
+
+    districts = [(e[1], e[5]) for e in entries]  # (country, district)
+    assert ("United States", "Jefferson") in districts
+    assert ("United States", "Bullitt") in districts
+    assert ("United States", "Nelson") in districts
+    assert ("Andorra", "No Driving") in districts
+    assert ("Andorra", "All Areas") in districts
+    assert ("Iceland", None) in districts
+    assert ("Norway", None) in districts
+    assert len(entries) == 3 + 2 + 1 + 1
+    assert all(e[0] == 7 for e in entries)
+
+
+def test_dirty_date_row_survives_with_raw_string_and_null_parse(conn, tmp_path):
+    raw = _raw([_record(datestart="13/1/19")])
+    driving_plan.ingest(conn, archive_dir=str(tmp_path), fetch_date=date(2026, 8, 1), raw=raw)
+
+    rows = conn.execute("SELECT * FROM driving_plan_entries").fetchall()
+    assert len(rows) == 3, "a dirty date must never drop the record"
+    assert all(r["date_start"] is None for r in rows)
+    assert all(r["date_start_raw"] == "13/1/19" for r in rows)
+    assert all(r["date_end"] == "2026-12-31" for r in rows)
+
+
+# ── Ingest: archive + catalog ──────────────────────────────────────────────
+
+
+def test_first_ingest_archives_and_explodes(conn, tmp_path):
+    raw = _raw([_record()])
+    result = driving_plan.ingest(
+        conn, archive_dir=str(tmp_path), fetch_date=date(2026, 8, 1), raw=raw
+    )
+
+    assert not result.skipped and result.changed
+    assert result.record_count == 1 and result.entry_count == 3
+
+    row = conn.execute("SELECT * FROM driving_plan_snapshots").fetchone()
+    assert row["fetch_date"] == "2026-08-01" and row["changed"] == 1
+    assert row["artifact_filename"] == "gsv_driving_plan_2026-08-01.json.gz"
+    assert row["sha256"] and row["record_count"] == 1
+
+    artifact = tmp_path / "gsv_driving_plan_2026-08-01.json.gz"
+    assert artifact.exists()
+    assert gzip.decompress(artifact.read_bytes()) == raw, "the archive is the raw feed, verbatim"
+    assert not (tmp_path / "gsv_driving_plan_2026-08-01.json.gz.tmp").exists()
+
+
+def test_unchanged_feed_gets_a_snapshot_row_but_no_artifact_or_entries(conn, tmp_path):
+    raw = _raw([_record()])
+    driving_plan.ingest(conn, archive_dir=str(tmp_path), fetch_date=date(2026, 8, 1), raw=raw)
+    result = driving_plan.ingest(
+        conn, archive_dir=str(tmp_path), fetch_date=date(2026, 8, 2), raw=raw
+    )
+
+    assert not result.changed and result.entry_count == 0
+    day2 = conn.execute(
+        "SELECT * FROM driving_plan_snapshots WHERE fetch_date = '2026-08-02'"
+    ).fetchone()
+    assert day2["changed"] == 0, "the row IS the observation 'we looked, it was unchanged'"
+    assert day2["artifact_filename"] is None
+    assert not (tmp_path / "gsv_driving_plan_2026-08-02.json.gz").exists()
+    n_entries = conn.execute(
+        "SELECT COUNT(*) FROM driving_plan_entries WHERE snapshot_id = ?",
+        (day2["snapshot_id"],),
+    ).fetchone()[0]
+    assert n_entries == 0
+
+
+def test_publish_yes_to_no_transition_is_queryable_across_changed_snapshots(conn, tmp_path):
+    """The Yes -> No flip is the campaign-closed signal — the reason ingest
+    never filters on publish."""
+    driving_plan.ingest(
+        conn,
+        archive_dir=str(tmp_path),
+        fetch_date=date(2026, 8, 1),
+        raw=_raw([_record(publish="Yes")]),
+    )
+    result = driving_plan.ingest(
+        conn,
+        archive_dir=str(tmp_path),
+        fetch_date=date(2026, 9, 1),
+        raw=_raw([_record(publish="No")]),
+    )
+    assert result.changed
+    assert (tmp_path / "gsv_driving_plan_2026-09-01.json.gz").exists()
+
+    flips = conn.execute(
+        """SELECT s.fetch_date, e.publish FROM driving_plan_entries e
+           JOIN driving_plan_snapshots s ON s.snapshot_id = e.snapshot_id
+           WHERE e.region = 'Kentucky' AND e.district = 'Jefferson'
+           ORDER BY s.fetch_date"""
+    ).fetchall()
+    assert [(r["fetch_date"], r["publish"]) for r in flips] == [
+        ("2026-08-01", "Yes"),
+        ("2026-09-01", "No"),
+    ]
+    # And the read helper reflects the newest picture.
+    active = db.get_active_driving_plans(conn)
+    assert {r["publish"] for r in active} == {"No"}
+
+
+def test_same_day_reingest_skips_without_touching_the_network(conn, tmp_path, monkeypatch):
+    raw = _raw([_record()])
+    driving_plan.ingest(conn, archive_dir=str(tmp_path), fetch_date=date(2026, 8, 1), raw=raw)
+
+    def no_network(*a, **k):
+        raise AssertionError("politeness gate must short-circuit before any fetch")
+
+    monkeypatch.setattr(driving_plan, "fetch_feed", no_network)
+    result = driving_plan.ingest(conn, archive_dir=str(tmp_path), fetch_date=date(2026, 8, 1))
+
+    assert result.skipped and result.record_count == 1
+
+
+def test_forced_same_day_reingest_replaces_without_duplicating(conn, tmp_path):
+    driving_plan.ingest(
+        conn, archive_dir=str(tmp_path), fetch_date=date(2026, 8, 1), raw=_raw([_record()])
+    )
+    two = [_record(), _record(region="Ohio", districts="Hamilton")]
+    result = driving_plan.ingest(
+        conn, archive_dir=str(tmp_path), fetch_date=date(2026, 8, 1), raw=_raw(two), force=True
+    )
+
+    assert not result.skipped and result.changed
+    assert conn.execute("SELECT COUNT(*) FROM driving_plan_snapshots").fetchone()[0] == 1
+    assert conn.execute("SELECT COUNT(*) FROM driving_plan_entries").fetchone()[0] == 4
+    assert conn.execute("SELECT record_count FROM driving_plan_snapshots").fetchone()[0] == 2
+
+
+def test_forced_reingest_that_becomes_unchanged_clears_stale_entries(conn, tmp_path):
+    """Day 1 archives feed A; day 2's first ingest sees feed B (changed, entries
+    written); a forced day-2 re-fetch sees A again — changed must flip to 0 and
+    the earlier ingest's entries must not linger."""
+    feed_a, feed_b = _raw([_record()]), _raw([_record(region="Ohio")])
+    driving_plan.ingest(conn, archive_dir=str(tmp_path), fetch_date=date(2026, 8, 1), raw=feed_a)
+    driving_plan.ingest(conn, archive_dir=str(tmp_path), fetch_date=date(2026, 8, 2), raw=feed_b)
+    result = driving_plan.ingest(
+        conn, archive_dir=str(tmp_path), fetch_date=date(2026, 8, 2), raw=feed_a, force=True
+    )
+
+    assert not result.changed
+    day2 = conn.execute(
+        "SELECT * FROM driving_plan_snapshots WHERE fetch_date = '2026-08-02'"
+    ).fetchone()
+    assert day2["changed"] == 0 and day2["artifact_filename"] is None
+    n = conn.execute(
+        "SELECT COUNT(*) FROM driving_plan_entries WHERE snapshot_id = ?",
+        (day2["snapshot_id"],),
+    ).fetchone()[0]
+    assert n == 0
+
+
+# ── fetch_feed ─────────────────────────────────────────────────────────────
+
+
+def test_fetch_feed_retries_then_succeeds_with_browser_ua(monkeypatch):
+    calls = []
+
+    class FakeResponse:
+        def read(self):
+            return b"[]"
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+    def fake_urlopen(request, timeout=None):
+        calls.append(request)
+        if len(calls) < 3:
+            raise OSError("transient")
+        return FakeResponse()
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+    monkeypatch.setattr(driving_plan.time, "sleep", lambda s: None)
+
+    assert driving_plan.fetch_feed("https://example.com/feed.json", retries=3) == b"[]"
+    assert len(calls) == 3
+    assert calls[0].get_header("User-agent", "").startswith("Mozilla/5.0")
+
+
+def test_fetch_feed_raises_after_exhausting_retries(monkeypatch):
+    def always_down(request, timeout=None):
+        raise OSError("down")
+
+    monkeypatch.setattr(urllib.request, "urlopen", always_down)
+    monkeypatch.setattr(driving_plan.time, "sleep", lambda s: None)
+
+    with pytest.raises(OSError):
+        driving_plan.fetch_feed("https://example.com/feed.json", retries=2)

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1713,8 +1713,8 @@ _PLAN_RECORD = {
 def test_config_parses_driving_plan_section(tmp_path):
     p = tmp_path / "s.toml"
     p.write_text(
-        "[driving_plan]\nenabled = false\narchive_dir = \"/somewhere/plans\"\n"
-        "url = \"https://example.com/feed.json\"\ntimeout_s = 10.0\n"
+        '[driving_plan]\nenabled = false\narchive_dir = "/somewhere/plans"\n'
+        'url = "https://example.com/feed.json"\ntimeout_s = 10.0\n'
     )
     cfg = load_scheduler_config(str(p))
     assert not cfg.driving_plan.enabled
@@ -1833,16 +1833,12 @@ def test_cmd_fetch_driving_plan_backfills_from_file(conn, monkeypatch, tmp_path,
     cfg = SchedulerConfig()
     cfg.driving_plan.archive_dir = str(archive)
 
-    rc = cmd_fetch_driving_plan(
-        cfg, from_file=str(saved), target_date=date(2026, 7, 31)
-    )
+    rc = cmd_fetch_driving_plan(cfg, from_file=str(saved), target_date=date(2026, 7, 31))
 
     assert rc == 0
     assert "CHANGED" in capsys.readouterr().out
     row = conn.execute("SELECT * FROM driving_plan_snapshots").fetchone()
     assert row["fetch_date"] == "2026-07-31" and row["changed"] == 1
     assert (archive / "gsv_driving_plan_2026-07-31.json.gz").exists()
-    districts = {
-        r["district"] for r in conn.execute("SELECT district FROM driving_plan_entries")
-    }
+    districts = {r["district"] for r in conn.execute("SELECT district FROM driving_plan_entries")}
     assert districts == {"Jefferson", "Bullitt"}

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -8,7 +8,10 @@ import signal
 from datetime import date
 from pathlib import Path
 
+import pytest
+
 from streetscape_metadata_tracker import db
+from streetscape_metadata_tracker import scheduler as _sched
 from streetscape_metadata_tracker.naming import (
     generate_streetwalk_filename,
     streetwalk_coverage_filename,
@@ -20,6 +23,7 @@ from streetscape_metadata_tracker.scheduler import (
     _reconcile_orphaned_run,
     _reconcile_orphaned_walk,
     build_parser,
+    cmd_fetch_driving_plan,
     cmd_reconcile_walks,
     estimate_requests,
     load_scheduler_config,
@@ -28,6 +32,19 @@ from streetscape_metadata_tracker.scheduler import (
 from tests.conftest import make_city_df, write_city_csv_gz
 
 _PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+# The real nightly hook, saved before the autouse stub below replaces it so the
+# dedicated driving-plan tests can exercise it.
+_REAL_DRIVING_PLAN_HOOK = _sched._fetch_driving_plan_nightly
+
+
+@pytest.fixture(autouse=True)
+def _no_driving_plan_fetch(monkeypatch):
+    """run-due snapshots the driving-plan feed before the city loop (issue
+    #176). Stub the hook for every test so the suite stays hermetic — no
+    network, no writes to the real archive/ dir; the driving-plan tests
+    restore _REAL_DRIVING_PLAN_HOOK explicitly."""
+    monkeypatch.setattr(_sched, "_fetch_driving_plan_nightly", lambda cfg, conn, today: None)
 
 
 def _register(conn, name, width=5000, height=5000, step=20):
@@ -395,6 +412,11 @@ def test_makelab1_production_config_is_wired():
     assert "/cse/web/" not in cfg.db_path and "/cse/web/" not in cfg.data_dir
     # Shared-host resource guard is active in production.
     assert cfg.resource_guard.enabled
+    # Nightly driving-plan snapshot (issue #176): on, and archived on lab
+    # storage OUTSIDE data/ so the publish rsync never sees it.
+    assert cfg.driving_plan.enabled
+    assert "/archive/gsv_driving_plan" in cfg.driving_plan.archive_dir
+    assert not cfg.driving_plan.archive_dir.startswith(cfg.data_dir)
     # The batch deadline must stay strictly below the unit's TimeoutStartSec, or
     # systemd kills the loop first and the night publishes nothing (#167). These
     # two live in different files and only mean something together.
@@ -1671,3 +1693,156 @@ def test_a_plain_bool_from_run_one_city_still_works(conn, tmp_path, monkeypatch)
     ).fetchone()
     assert row["consecutive_failures"] == 1
     assert "subprocess failed on 2026-07-02" in row["last_error"]  # the fallback
+
+
+# ── Driving-plan feed snapshots (issue #176) ───────────────────────────────
+
+
+_PLAN_RECORD = {
+    "country": "United States",
+    "code": "US",
+    "svspc": "SV",
+    "region": "Kentucky",
+    "districts": "Jefferson, Bullitt",
+    "publish": "Yes",
+    "datestart": "2026-02-02T08:00:00.000Z",
+    "dateend": "2026-12-31T08:00:00.000Z",
+}
+
+
+def test_config_parses_driving_plan_section(tmp_path):
+    p = tmp_path / "s.toml"
+    p.write_text(
+        "[driving_plan]\nenabled = false\narchive_dir = \"/somewhere/plans\"\n"
+        "url = \"https://example.com/feed.json\"\ntimeout_s = 10.0\n"
+    )
+    cfg = load_scheduler_config(str(p))
+    assert not cfg.driving_plan.enabled
+    assert cfg.driving_plan.archive_dir == "/somewhere/plans"
+    assert cfg.driving_plan.url == "https://example.com/feed.json"
+    assert cfg.driving_plan.timeout_s == 10.0
+
+
+def test_config_driving_plan_defaults_when_section_missing(tmp_path):
+    """No [driving_plan] section means ON with the repo-local archive dir, so
+    prod picks the feature up on deploy without a config edit."""
+    p = tmp_path / "s.toml"
+    p.write_text("[schedule]\ncycle_days = 90\n")
+    cfg = load_scheduler_config(str(p))
+    assert cfg.driving_plan.enabled
+    assert cfg.driving_plan.archive_dir.endswith(os.path.join("archive", "gsv_driving_plan"))
+
+
+def test_run_due_snapshots_driving_plan_even_on_a_zero_due_night(conn, monkeypatch):
+    """The hook sits BEFORE the city loop, so a night with nothing due still
+    archives the feed — the whole point of a daily observation series."""
+    from streetscape_metadata_tracker import scheduler as sched
+
+    monkeypatch.setattr(sched, "_fetch_driving_plan_nightly", _REAL_DRIVING_PLAN_HOOK)
+    ingested = []
+    monkeypatch.setattr(
+        sched.driving_plan,
+        "ingest",
+        lambda c, **kw: ingested.append(kw["fetch_date"]) or _ingest_result(),
+    )
+    monkeypatch.setattr(sched.db, "connect", lambda path: conn)
+
+    rc = sched.cmd_run_due(SchedulerConfig(publish_enabled=False), today=date(2026, 7, 2))
+
+    assert ingested == [date(2026, 7, 2)]
+    assert rc == 0
+
+
+def _ingest_result(**overrides):
+    from streetscape_metadata_tracker.driving_plan import IngestResult
+
+    base = dict(
+        snapshot_id=1,
+        fetch_date="2026-07-02",
+        skipped=False,
+        changed=False,
+        record_count=1,
+        entry_count=0,
+    )
+    base.update(overrides)
+    return IngestResult(**base)
+
+
+def test_driving_plan_failure_never_fails_the_night(conn, monkeypatch):
+    """The feed is an undocumented asset with no uptime contract; it breaking
+    must not cost a night of collection (the issue #167 posture)."""
+    from streetscape_metadata_tracker import scheduler as sched
+
+    _register(conn, "Alpha", width=1000, height=1000, step=20)
+    db.assign_schedule(conn, 90)
+    conn.execute("UPDATE schedule_state SET last_success_at = NULL")
+    conn.commit()
+
+    monkeypatch.setattr(sched, "_fetch_driving_plan_nightly", _REAL_DRIVING_PLAN_HOOK)
+
+    def boom(c, **kw):
+        raise RuntimeError("feed gone")
+
+    monkeypatch.setattr(sched.driving_plan, "ingest", boom)
+    ran, published = [], []
+    monkeypatch.setattr(
+        sched,
+        "_run_one_city",
+        lambda cfg, city, today, provider="gsv", **kw: ran.append(city.city_id) or True,
+    )
+    _stub_tail(monkeypatch, sched, conn, published)
+
+    rc = sched.cmd_run_due(_publishing_cfg(), today=date(2026, 7, 2))
+
+    assert len(ran) == 1, "the city loop must still run"
+    assert published == ["aggregate", "manifest", "publish"]
+    assert rc == 0, "a plan-fetch failure alone is not an unhealthy night"
+
+
+def test_driving_plan_hook_respects_dry_run_and_enabled_flag(conn, monkeypatch, capsys):
+    from streetscape_metadata_tracker import scheduler as sched
+
+    monkeypatch.setattr(sched, "_fetch_driving_plan_nightly", _REAL_DRIVING_PLAN_HOOK)
+    ingested = []
+    monkeypatch.setattr(
+        sched.driving_plan, "ingest", lambda c, **kw: ingested.append(1) or _ingest_result()
+    )
+    monkeypatch.setattr(sched.db, "connect", lambda path: conn)
+
+    # Dry run: announced but not fetched.
+    rc = sched.cmd_run_due(SchedulerConfig(), dry_run=True, today=date(2026, 7, 2))
+    assert rc == 0 and not ingested
+    assert "driving-plan" in capsys.readouterr().out
+
+    # Disabled: not fetched, not announced.
+    cfg = SchedulerConfig()
+    cfg.driving_plan.enabled = False
+    rc = sched.cmd_run_due(cfg, today=date(2026, 7, 2))
+    assert rc == 0 and not ingested
+
+
+def test_cmd_fetch_driving_plan_backfills_from_file(conn, monkeypatch, tmp_path, capsys):
+    """--from-file + --date ingests an already-saved raw feed — the handle for
+    cataloging the manual snapshot kept on prod before this existed."""
+    from streetscape_metadata_tracker import scheduler as sched
+
+    saved = tmp_path / "data.json"
+    saved.write_text(json.dumps([_PLAN_RECORD]))
+    archive = tmp_path / "archive"
+    monkeypatch.setattr(sched.db, "connect", lambda path: conn)
+    cfg = SchedulerConfig()
+    cfg.driving_plan.archive_dir = str(archive)
+
+    rc = cmd_fetch_driving_plan(
+        cfg, from_file=str(saved), target_date=date(2026, 7, 31)
+    )
+
+    assert rc == 0
+    assert "CHANGED" in capsys.readouterr().out
+    row = conn.execute("SELECT * FROM driving_plan_snapshots").fetchone()
+    assert row["fetch_date"] == "2026-07-31" and row["changed"] == 1
+    assert (archive / "gsv_driving_plan_2026-07-31.json.gz").exists()
+    districts = {
+        r["district"] for r in conn.execute("SELECT district FROM driving_plan_entries")
+    }
+    assert districts == {"Jefferson", "Bullitt"}


### PR DESCRIPTION
Closes #176.

Google publishes its forward-looking Street View collection plan behind a single mutable, unauthenticated URL (`.../streetview/static/feed/driving/data.json`) that it overwrites in place — plan revisions are permanently unobservable without our own dated archive. This adds that archive, per the design in the issue.

## What's here

- **`driving_plan.py`** — fetch (stdlib urllib, browser UA, 3 retries; deliberately not the aiohttp machinery — one request to one static URL once a day), defensive parsing, and a single `ingest()` code path behind both the nightly hook and the manual CLI. A politeness gate short-circuits before any network I/O when today's snapshot already exists, hard-capping at one request/day.
- **Catalog schema v10** (purely additive, auto-migrates on connect): `driving_plan_snapshots` — one row on *every* fetch ("we looked, it was X"), with sha256, record count, and a `changed` flag; `driving_plan_entries` — one row per (record, district), exploded from the comma-joined `districts` field. The artifact and entries are written only when the hash differs from the previous snapshot, so an unchanged feed costs one row, not one file.
- **`publish` is stored verbatim and never filtered** — the Yes→No transition is the campaign-closed signal, queryable by joining consecutive changed snapshots. Dirty dates (`13/1/19`, truncated month names — ~58 records) keep the raw string beside a NULL parsed date; no row is ever dropped.
- **Scheduler**: a `[driving_plan]` config section (default-on; explicit blocks added to both TOMLs, prod pointing at the existing manual `archive/gsv_driving_plan/` dir), a nightly hook in `run-due` placed **before** the city loop — so zero-due nights and deadline/SIGTERM kills can't skip it — that never fails the night (the #167 posture), a `fetch-driving-plan` subcommand with `--force` and `--from-file`/`--date` backfill, and a `driving plan:` line in `status`.
- **Storage is outside `data/`** (`archive/`, gitignored): the publish rsync whitelist ships every `*.json.gz`, and archiving there would republish Google's content.

## Verified

- 669 tests pass, including: v9→v10 migration, hash dedupe, Yes→No transition query, dirty-date survival, same-day politeness gate, forced re-ingest idempotency, the zero-due-night hook, hook-failure-never-fails-the-night, and `--from-file` backfill. Suite stays hermetic via an autouse stub of the hook.
- Live smoke test: first real fetch archived 3,715 records → 11,784 district entries (89 KB gzipped), matching the issue's numbers; a same-day re-run skipped without touching the network.

## Post-merge (prod, one time)

Backfill the hand-saved 2026-07-31 snapshot, then the timer takes over:
```
python -m streetscape_metadata_tracker.scheduler --config config/scheduler.makelab1.toml \
  fetch-driving-plan --from-file archive/gsv_driving_plan/<saved file> --date 2026-07-31
```

Note: the working tree's issue #101 walk-diff work (schema v11) is stacked on this and stays local; it will rebase onto this once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)