### PR TITLE
Cap newly registered grids at 40 km/side, matching the retroactive cap (#166)

### DIFF
--- a/docs/worldwide_sampling.md
+++ b/docs/worldwide_sampling.md
@@ -135,8 +135,12 @@ An admin-1 name that merely restates the city (`Lima Province`, `Kyiv City`,
 the identity (`build_worldwide_frame.effective_admin`), so city-state-like
 slugs stay clean. `sanitize_city_query_str` itself is unchanged (it is a
 frozen contract); we simply feed it clean inputs. Megacities inherit the
-existing 80 km grid cap (Shanghai's ~437×308 km administrative boundary clamps
-to 80×80 km).
+registration-time grid cap of 40 km/side (`cli.MAX_GRID_DIM_M`), so Shanghai's
+~437×308 km administrative boundary clamps to 40×40 km. That ceiling was 80 km
+until issue #166, when production showed 80 km still admitted grids no night
+could collect — Cairo's ~10.5M points exceeded the entire daily gsv budget and
+were skipped every night. `scripts/cap_oversized_grids.py` applied the same
+40 km cap retroactively to already-registered cities.
 
 Some frame cities were **already registered** earlier under geocoder-derived
 slugs (e.g. `são-paulo--são-paulo--brazil`, `istanbul--marmara-region--turkey`).

--- a/scripts/cap_oversized_grids.py
+++ b/scripts/cap_oversized_grids.py
@@ -24,6 +24,13 @@ rectangle. So this refuses any city with a real (non-baseline) dated run unless
 only imported baseline runs, have no diff continuity to lose and are resized
 freely.
 
+SCOPE. Only *enabled* cities are swept by default — a disabled city costs the
+scheduler nothing tonight. But a disabled city registered under the old 80 km
+ceiling is a landmine: enabling it later re-creates exactly the #166 failure,
+and the registration-time cap can't help because it only runs at registration.
+``--include-disabled`` sweeps them too; the default run reports how many are
+sitting there.
+
 Nothing is ever deleted. This edits catalog rows only — existing run files stay
 on disk and their published URLs keep working. Makes ZERO provider API calls.
 
@@ -37,6 +44,9 @@ Usage:
     # Also re-grid cities that already have real dated runs (breaks their diff
     # continuity — the files remain, but new runs no longer diff against old):
     python scripts/cap_oversized_grids.py --include-collected --execute
+
+    # Also cap disabled cities, so enabling one later can't reintroduce #166:
+    python scripts/cap_oversized_grids.py --include-disabled --execute
 """
 
 import argparse
@@ -68,21 +78,28 @@ def grid_points(width_m: float, height_m: float, step_m: float) -> int:
     return (int(width_m / step_m) + 1) * (int(height_m / step_m) + 1)
 
 
-def find_oversized(conn, max_extent_m: float) -> list[dict]:
+def find_oversized(conn, max_extent_m: float, include_disabled: bool = False) -> list[dict]:
     """
-    Enabled cities with either dimension over the cap, largest first.
+    Cities with either dimension over the cap, largest first.
 
-    Each entry carries the proposed dimensions and the run history that decides
-    whether resizing is free: ``real_runs`` (dated, non-baseline) is what makes
-    a resize destructive to diff continuity.
+    Enabled cities only unless ``include_disabled`` — a disabled city burns no
+    collection time today, but it keeps its oversized geometry until someone
+    enables it (see SCOPE above). Entries carry ``enabled`` so callers can
+    report the two groups separately.
+
+    Each entry also carries the proposed dimensions and the run history that
+    decides whether resizing is free: ``real_runs`` (dated, non-baseline) is
+    what makes a resize destructive to diff continuity.
     """
     rows = conn.execute(
         "SELECT city_id, display_name, center_lat, center_lon, "
-        "grid_width_m, grid_height_m, step_m FROM cities WHERE enabled = 1"
+        "grid_width_m, grid_height_m, step_m, enabled FROM cities"
     ).fetchall()
 
     oversized = []
     for row in rows:
+        if not row["enabled"] and not include_disabled:
+            continue
         if row["grid_width_m"] <= max_extent_m and row["grid_height_m"] <= max_extent_m:
             continue
         runs = db.get_runs_for_city(conn, row["city_id"], provider=None)
@@ -94,6 +111,7 @@ def find_oversized(conn, max_extent_m: float) -> list[dict]:
                 "center_lat": row["center_lat"],
                 "center_lon": row["center_lon"],
                 "step_m": row["step_m"],
+                "enabled": bool(row["enabled"]),
                 "old_width_m": row["grid_width_m"],
                 "old_height_m": row["grid_height_m"],
                 "new_width_m": min(row["grid_width_m"], max_extent_m),
@@ -110,6 +128,30 @@ def find_oversized(conn, max_extent_m: float) -> list[dict]:
     return oversized
 
 
+def _report_untouched_disabled(disabled: list[dict], include_disabled: bool) -> None:
+    """Warn about oversized *disabled* cities a default run is leaving behind.
+
+    They cost nothing tonight, which is why they are skipped — but nothing else
+    in the system will ever cap them, so enabling one is a live #166 relapse.
+    """
+    if not disabled or include_disabled:
+        return
+    print(
+        f"\nNOTE: {len(disabled)} disabled cities are also over the cap and were not "
+        f"listed. Enabling one reintroduces the oversized grid this script exists to "
+        f"prevent (the registration-time cap only applies at registration). Re-run "
+        f"with --include-disabled to cap them too:"
+    )
+    for c in sorted(disabled, key=lambda c: c["old_points"], reverse=True)[:10]:
+        print(
+            f"  {c['city_id'][:52]:52s} "
+            f"{int(c['old_width_m']):>8,}x{int(c['old_height_m']):<9,} "
+            f"{c['old_points']:>12,} points"
+        )
+    if len(disabled) > 10:
+        print(f"  ... and {len(disabled) - 10} more")
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(
         description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
@@ -124,6 +166,11 @@ def main() -> int:
         "--include-collected",
         action="store_true",
         help="Also resize cities with real dated runs, breaking their diff continuity",
+    )
+    parser.add_argument(
+        "--include-disabled",
+        action="store_true",
+        help="Also resize disabled cities, so enabling one later can't reintroduce #166",
     )
     parser.add_argument("--data-dir", default=get_default_data_dir())
     parser.add_argument(
@@ -146,13 +193,22 @@ def main() -> int:
     db_path = args.db_path or db.get_default_db_path(args.data_dir)
     conn = db.connect(db_path)
 
-    oversized = find_oversized(conn, args.max_extent_m)
+    # Always look at the whole catalog so a default run can still *report* the
+    # disabled cities it is deliberately leaving alone.
+    all_oversized = find_oversized(conn, args.max_extent_m, include_disabled=True)
+    disabled = [c for c in all_oversized if not c["enabled"]]
+    oversized = (
+        all_oversized if args.include_disabled else [c for c in all_oversized if c["enabled"]]
+    )
+
     mode = "EXECUTE" if args.execute else "DRY RUN"
     print(f"=== Cap oversized grids to {int(args.max_extent_m):,} m/side ({mode}) ===")
     print(f"Catalog: {db_path}")
 
     if not oversized:
-        print("\nNo enabled city exceeds the cap. Nothing to do.")
+        scope = "city" if args.include_disabled else "enabled city"
+        print(f"\nNo {scope} exceeds the cap. Nothing to do.")
+        _report_untouched_disabled(disabled, args.include_disabled)
         conn.close()
         return 0
 
@@ -167,9 +223,9 @@ def main() -> int:
     print("-" * len(header))
     for c in oversized:
         runs = f"{c['baseline_runs']}b/{c['real_runs']}r"
-        flag = (
-            "" if c["real_runs"] == 0 else ("  [FORCED]" if args.include_collected else "  [SKIP]")
-        )
+        flag = "" if c["enabled"] else "  [DISABLED]"
+        if c["real_runs"]:
+            flag += "  [FORCED]" if args.include_collected else "  [SKIP]"
         print(
             f"{c['city_id'][:52]:52s} "
             f"{int(c['old_width_m']):>8,}x{int(c['old_height_m']):<9,} "
@@ -190,6 +246,7 @@ def main() -> int:
             f"Re-run with --include-collected to resize them too "
             f"(no files are deleted; only diff continuity is lost)."
         )
+    _report_untouched_disabled(disabled, args.include_disabled)
 
     if not args.execute:
         print("\nDRY RUN — no catalog changes. Re-run with --execute to apply.")

--- a/scripts/cap_oversized_grids.py
+++ b/scripts/cap_oversized_grids.py
@@ -46,17 +46,19 @@ import sys
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from streetscape_metadata_tracker import db  # noqa: E402
+from streetscape_metadata_tracker import cli, db  # noqa: E402
 from streetscape_metadata_tracker.paths import get_default_data_dir  # noqa: E402
 
 logger = logging.getLogger("cap_oversized_grids")
 
-# Default cap per side. At the standard 20 m step this is ~4M grid points, which
-# fits inside the production gsv daily budget (10M) with room for other cities,
-# and is still roughly twice Seattle's grid — comfortably more than an urban
-# core. Deliberately a *dimension* cap rather than a point cap so the resulting
-# rectangle stays square-ish and legible on the map.
-DEFAULT_MAX_EXTENT_M = 40_000
+# Default cap per side — the same ceiling cli.py applies to newly registered
+# cities, so a city registered today can't need capping tomorrow. At the
+# standard 20 m step this is ~4M grid points, which fits inside the production
+# gsv daily budget (10M) with room for other cities, and is still roughly twice
+# Seattle's grid — comfortably more than an urban core. Deliberately a
+# *dimension* cap rather than a point cap so the resulting rectangle stays
+# square-ish and legible on the map.
+DEFAULT_MAX_EXTENT_M = cli.MAX_GRID_DIM_M
 
 CAP_NOTE = "grid capped to {extent} m/side (scripts/cap_oversized_grids.py, issue #166)"
 

--- a/scripts/reregister_boundaries.py
+++ b/scripts/reregister_boundaries.py
@@ -61,11 +61,13 @@ logger = logging.getLogger("reregister")
 # conservative — smaller than the recommendation ceiling below.
 REVIEW_THRESHOLD_M = 30000
 
-# Ceiling for the "best size" RECOMMENDATION written to the manual-review file
-# (and the going-forward cli.MAX_GRID_DIM_M). We bias BIGGER — recommend the
-# full OSM bbox so an analysis can later clip to the always-smaller polygon —
-# capping only the enormous administrative units (Đà Nẵng's 194×153 km) whose
-# collection time is impractical.
+# Ceiling for the "best size" RECOMMENDATION written to the manual-review file.
+# We bias BIGGER — recommend the full OSM bbox so an analysis can later clip to
+# the always-smaller polygon — capping only the enormous administrative units
+# (Đà Nẵng's 194×153 km) whose collection time is impractical. Kept at the
+# historical 80 km this one-time #91 tool actually ran with; the going-forward
+# registration ceiling (cli.MAX_GRID_DIM_M) has since dropped to 40 km
+# (issue #166), enforced retroactively by scripts/cap_oversized_grids.py.
 REC_CEILING_M = 80000
 
 # Default locations, relative to the repo root.

--- a/streetscape_metadata_tracker/cli.py
+++ b/streetscape_metadata_tracker/cli.py
@@ -67,8 +67,10 @@ logger = logging.getLogger(__name__)
 # night can absorb (Cairo ~10.5M points was skipped as over-budget every night,
 # and its ZERO_RESULTS fill alone OOMed the Mapillary tail — see #157/#166).
 # scripts/cap_oversized_grids.py applies this same cap retroactively; keep the
-# two in sync by importing this constant. Override with --width/--height for a
-# genuinely larger area.
+# two in sync by importing this constant. NB the budget math above assumes the
+# standard 20 m step — this is a *dimension* cap, so a finer --step re-inflates
+# the point count (40 km/side at step 10 is ~16M points, over budget again).
+# Override with --width/--height for a genuinely larger area.
 MAX_GRID_DIM_M = 40_000
 
 

--- a/streetscape_metadata_tracker/cli.py
+++ b/streetscape_metadata_tracker/cli.py
@@ -59,15 +59,17 @@ from .paths import get_default_data_dir, get_default_vis_dir
 
 logger = logging.getLogger(__name__)
 
-# Practical ceiling for auto-derived grid dimensions (issue #91). We bias grids
-# BIGGER not smaller — the full OSM bounding box, so a future analysis can clip
-# to the (always-smaller) polygon boundary; oversampling is free (GSV metadata
-# has no quota) and recoverable, undersampling loses coverage permanently. The
-# only real limit is collection time, so we clamp (with a warning) just the
-# handful of enormous administrative units — e.g. Đà Nẵng's 194×153 km
-# municipality — that would otherwise take ~hundreds of days. Override with
-# --width/--height for a genuinely larger area.
-MAX_GRID_DIM_M = 80000
+# Ceiling for auto-derived grid dimensions, per side (issue #166; supersedes
+# the 80 km value from #91). At the standard 20 m step, 40 km/side is ~4M grid
+# points — inside the production gsv daily budget (10M) with room for other
+# cities, and roughly twice Seattle's grid, comfortably more than an urban
+# core. Production data showed the old 80 km clamp still admitted grids no
+# night can absorb (Cairo ~10.5M points was skipped as over-budget every night,
+# and its ZERO_RESULTS fill alone OOMed the Mapillary tail — see #157/#166).
+# scripts/cap_oversized_grids.py applies this same cap retroactively; keep the
+# two in sync by importing this constant. Override with --width/--height for a
+# genuinely larger area.
+MAX_GRID_DIM_M = 40_000
 
 
 def _resolve_center(city_loc_data):

--- a/tests/test_cap_oversized_grids.py
+++ b/tests/test_cap_oversized_grids.py
@@ -182,9 +182,34 @@ def test_disabled_cities_are_left_alone(conn):
     assert find_oversized(conn, 40_000) == []
 
 
+def test_include_disabled_finds_the_landmine_cities(conn):
+    """A disabled city costs nothing tonight, but nothing else ever caps it —
+    the registration clamp runs only at registration — so enabling one later
+    reintroduces #166. --include-disabled is the way to reach them."""
+    disabled = _register(conn, "Dormant", width=100_000, height=100_000)
+    enabled = _register(conn, "Active", width=90_000, height=90_000)
+    conn.execute("UPDATE cities SET enabled = 0 WHERE city_id = ?", (disabled,))
+    conn.commit()
+
+    default_run = find_oversized(conn, 40_000)
+    assert [c["city_id"] for c in default_run] == [enabled]
+
+    swept = find_oversized(conn, 40_000, include_disabled=True)
+    assert sorted(c["city_id"] for c in swept) == sorted([disabled, enabled])
+    assert {c["city_id"]: c["enabled"] for c in swept} == {disabled: False, enabled: True}
+    assert all(c["new_width_m"] == 40_000 for c in swept)
+
+
 def test_default_cap_matches_registration_ceiling():
-    """The retroactive cap and cli.py's registration-time clamp must agree,
-    or a city registered today could need capping tomorrow."""
+    """The retroactive cap and cli.py's registration-time clamp must agree, or a
+    city registered today could need capping tomorrow.
+
+    The first equality holds by construction (``DEFAULT_MAX_EXTENT_M`` *is*
+    ``cli.MAX_GRID_DIM_M``) and only guards against someone re-hardcoding it.
+    The load-bearing half is ``== 40_000``: a deliberate change-detector on a
+    number the production budget depends on, so moving it is a decision rather
+    than an edit. If policy really changes, update this line with the reason.
+    """
     from scripts.cap_oversized_grids import DEFAULT_MAX_EXTENT_M
     from streetscape_metadata_tracker.cli import MAX_GRID_DIM_M
 

--- a/tests/test_cap_oversized_grids.py
+++ b/tests/test_cap_oversized_grids.py
@@ -180,3 +180,12 @@ def test_disabled_cities_are_left_alone(conn):
     conn.commit()
 
     assert find_oversized(conn, 40_000) == []
+
+
+def test_default_cap_matches_registration_ceiling():
+    """The retroactive cap and cli.py's registration-time clamp must agree,
+    or a city registered today could need capping tomorrow."""
+    from scripts.cap_oversized_grids import DEFAULT_MAX_EXTENT_M
+    from streetscape_metadata_tracker.cli import MAX_GRID_DIM_M
+
+    assert DEFAULT_MAX_EXTENT_M == MAX_GRID_DIM_M == 40_000

--- a/tests/test_cli_policy.py
+++ b/tests/test_cli_policy.py
@@ -279,3 +279,22 @@ def test_refuses_to_overwrite_existing_uncataloged_snapshot(monkeypatch, catalog
     assert calls == [], "must refuse before issuing any request"
     with open(out_path, "rb") as f:
         assert f.read() == b"orphan or concurrent run in flight", "existing file untouched"
+
+
+# ── Registration-time grid cap (issue #166) ─────────────────────────────────
+
+
+def test_cap_dimensions_clamps_each_side_to_40km():
+    """Auto-derived grids are capped at 40 km/side at registration (issue
+    #166), so newly registered cities can't recreate the oversized grids that
+    scripts/cap_oversized_grids.py had to fix retroactively."""
+    # Cairo's real pre-cap OSM-derived geometry
+    w, h = cli._cap_dimensions(66_453, 63_475, "Cairo, Egypt")
+    assert (w, h) == (40_000, 40_000)
+
+    # One long side clamps independently; the sane side is untouched
+    w, h = cli._cap_dimensions(51_568, 25_146, "Caracas, Venezuela")
+    assert (w, h) == (40_000, 25_146)
+
+    # At or under the cap passes through unchanged
+    assert cli._cap_dimensions(40_000, 12_000, "Fine") == (40_000, 12_000)


### PR DESCRIPTION
Refs #166.

## Why

`cli.py` already clamps auto-derived grid dimensions at registration — but at the old **80 km** ceiling from #91, which is exactly how the 16M-point grids (Shanghai 80×80 km, Cairo 66×63 km) got registered in the first place. `scripts/cap_oversized_grids.py` fixed those retroactively at **40 km/side** (executed on makelab2 2026-07-30, 43 cities capped), leaving the two caps disagreeing: a city registered tomorrow could once again be born uncollectable (over the 10M gsv daily budget) and OOM the Mapillary post-decode tail (#157).

## What

- `cli.MAX_GRID_DIM_M`: 80,000 → **40,000** (~4M points at step 20), with the #166 production rationale in the comment. This covers both auto-registration paths (`streetscape_tracker.py` new cities and `scripts/register_frame.py`, which shares `_cap_dimensions`).
- `cap_oversized_grids.py` imports that constant as its default instead of duplicating the number.
- `reregister_boundaries.py` keeps its historical 80 km recommendation ceiling (the one-time #91 tool already ran with it) but its comment no longer claims to match the going-forward registration cap.
- `--width`/`--height` overrides remain uncapped — the clamp warning already points at them as the deliberate escape hatch, same posture as `resize_city.py --force`.

## Tests

- `_cap_dimensions` clamps Cairo's and Caracas's real pre-cap geometry to 40 km per side independently, and passes at-or-under grids through unchanged.
- A sync test pins `DEFAULT_MAX_EXTENT_M == cli.MAX_GRID_DIM_M == 40_000` so the retroactive and registration-time caps can't drift apart again.

Full suite: 718 passed, 18 deselected.

## Review follow-ups (commit 751607b)

- `--include-disabled`: `find_oversized()` filtered `enabled = 1`, so cities registered under the old 80 km ceiling and left **disabled** were never swept — enabling one later reintroduces #166, and the registration clamp can't help because it only runs at registration. Default runs now also *report* the disabled cities they leave behind.
- `docs/worldwide_sampling.md` no longer documents the old 80 km cap / Shanghai clamping to 80×80 km.
- `cli.MAX_GRID_DIM_M` comment notes the ~4M-point math assumes step 20 (a dimension cap, so `--step 10` at 40 km/side is ~16M points).
- Sync-test docstring says the first equality holds by construction and `== 40_000` is a deliberate change-detector.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011eXNu3Aen8addoCPKKKFbG
