### PR TITLE
Make grid.html and streets.html explorable, not just sortable (issue #188)

### DIFF
--- a/tests/e2e/test_smoke.py
+++ b/tests/e2e/test_smoke.py
@@ -874,6 +874,42 @@ def test_column_picker_adds_and_drops_columns(page: Page, base_url):
     assert errors == []
 
 
+def test_unchecking_every_optional_column_actually_empties_the_table(page: Page, base_url):
+    """Regression: resolveVisibleColumns used to treat an explicit "every box
+    unchecked" selection the same as "no picker override" and silently kept
+    rendering the preset's columns while the checkboxes read unchecked. Only
+    the always-on columns (City, the link) should survive unchecking
+    everything, and a reload of the resulting link must reproduce that."""
+    errors = _capture_errors(page)
+    page.goto(f"{base_url}/grid.html")
+
+    page.locator(".col-picker summary").click()
+    boxes = page.locator("input[data-column]")
+    count = boxes.count()
+    for i in range(count):
+        boxes.nth(i).uncheck()
+
+    # Only the two always-on columns remain: City and the trailing link.
+    expect(page.locator("#grid-thead th")).to_have_count(2)
+    expect(page.locator('th[data-key="providerLabel"]')).to_have_count(0)
+    for i in range(count):
+        expect(boxes.nth(i)).not_to_be_checked()
+
+    # The URL carries the explicit empty selection...
+    assert "cols=" in page.url
+    reload_url = page.url
+
+    # ...and reloading it cold reproduces the same empty-but-not-default view,
+    # rather than snapping back to the preset's columns.
+    page.goto(reload_url)
+    expect(page.locator("#grid-thead th")).to_have_count(2)
+    page.locator(".col-picker summary").click()
+    for i in range(page.locator("input[data-column]").count()):
+        expect(page.locator("input[data-column]").nth(i)).not_to_be_checked()
+
+    assert errors == []
+
+
 def test_distribution_strip_describes_the_sorted_column(page: Page, base_url):
     """The strip is a histogram of the ACTIVE SORT COLUMN over the CURRENTLY
     FILTERED rows. Its bars are decorative; the summary sentence beside them is

--- a/tests/e2e/test_smoke.py
+++ b/tests/e2e/test_smoke.py
@@ -731,3 +731,194 @@ def test_city_page_change_overlay_draws_the_published_diff(page: Page, base_url)
     _expect_pane_ink(page, "diffOverlay", drawn=True)
 
     assert errors == []
+
+
+# ── Exploration chassis (issue #188) ──────────────────────────────────────────
+# The pure logic (filter predicates, URL round-trip, bucketing, preset
+# resolution) is unit-tested offline in www/js/__tests__/table-controls.test.js.
+# What can only be checked in a real browser is the wiring: that a control
+# actually narrows the rendered table, that reloading the URL the page wrote
+# reproduces the view, and that the default column set fits without pushing the
+# page sideways.
+
+
+def test_table_search_and_filters_narrow_the_rendered_rows(page: Page, base_url):
+    """Typing in the search box and setting a filter must change what is in the
+    tbody — and the caption must say "N of M" rather than continuing to report
+    the full dataset."""
+    errors = _capture_errors(page)
+    page.goto(f"{base_url}/streets.html")
+    rows = page.locator("#streets-tbody tr")
+    expect(rows).to_have_count(2)
+
+    # Free-text search is debounced, so assert on the settled state.
+    page.locator("#table-search").fill("map ville")
+    expect(rows).to_have_count(1)
+    expect(rows.first).to_contain_text("Map Ville")
+    expect(page.locator("#streets-caption")).to_contain_text("1 of 2")
+
+    # Clearing restores every row and the unqualified caption.
+    page.locator(".controls-clear").click()
+    expect(rows).to_have_count(2)
+    expect(page.locator("#streets-caption")).to_contain_text("2 published road-walk collections")
+
+    # A structured filter narrows the same way.
+    page.locator('select[data-filter="provider"]').select_option("mapillary")
+    expect(rows).to_have_count(1)
+    expect(rows.first).to_contain_text("Mapillary")
+
+    assert errors == []
+
+
+def test_range_filter_excludes_rows_with_no_measured_value(page: Page, base_url):
+    """A numeric window is a question about a measured quantity: the Mapillary
+    fixture walk is 0.0% by 360° pano, so a 50–100 window must drop it rather
+    than treating "no imagery" as somewhere in range."""
+    errors = _capture_errors(page)
+    page.goto(f"{base_url}/streets.html")
+    rows = page.locator("#streets-tbody tr")
+
+    page.locator('input[data-filter="cov"][data-bound="min"]').fill("50")
+    expect(rows).to_have_count(1)
+    expect(rows.first).to_contain_text("Alpha City")
+
+    assert errors == []
+
+
+def test_the_view_round_trips_through_the_url(page: Page, base_url):
+    """The address bar carries the whole view, so a finding can be linked. The
+    page writes it with replaceState; reloading that exact URL must reproduce
+    the filtered, sorted, preset-selected table."""
+    errors = _capture_errors(page)
+    page.goto(f"{base_url}/streets.html")
+    rows = page.locator("#streets-tbody tr")
+
+    page.locator('select[data-filter="provider"]').select_option("gsv")
+    page.locator("#table-preset").select_option("kilometres")
+    page.locator('th[data-key="label"] button').click()
+    expect(rows).to_have_count(1)
+
+    shared_url = page.url
+    assert "provider=gsv" in shared_url
+    assert "preset=kilometres" in shared_url
+    assert "sort=label" in shared_url
+
+    # Reload the link cold: the controls, the column set and the sort all come
+    # back, not just the row filter.
+    page.goto(shared_url)
+    expect(page.locator("#streets-tbody tr")).to_have_count(1)
+    expect(page.locator('select[data-filter="provider"]')).to_have_value("gsv")
+    expect(page.locator("#table-preset")).to_have_value("kilometres")
+    expect(page.locator('th[data-key="label"]')).to_have_attribute("aria-sort", "ascending")
+    # The Kilometres preset shows street length and hides the Walked date.
+    expect(page.locator('th[data-key="lengthKm"]')).to_have_count(1)
+    expect(page.locator('th[data-key="runDate"]')).to_have_count(0)
+
+    assert errors == []
+
+
+def test_sorting_survives_a_column_preset_change(page: Page, base_url):
+    """The regression the delegated header listener exists for: switching
+    presets re-renders the <thead>, which would destroy click handlers bound to
+    each button at construction — leaving headers that look sortable and are
+    not."""
+    errors = _capture_errors(page)
+    page.goto(f"{base_url}/streets.html")
+
+    # Kilometres keeps the sorted column (pct), so the sort carries across the
+    # re-render rather than being reset by the drop-the-sorted-column fallback.
+    page.locator("#table-preset").select_option("kilometres")
+    expect(page.locator('th[data-key="pct"]')).to_have_attribute("aria-sort", "descending")
+
+    page.locator('th[data-key="label"] button').click()
+    expect(page.locator('th[data-key="label"]')).to_have_attribute("aria-sort", "ascending")
+    expect(page.locator("#streets-tbody tr").first).to_contain_text("Alpha City")
+
+    page.locator('th[data-key="label"] button').click()
+    expect(page.locator('th[data-key="label"]')).to_have_attribute("aria-sort", "descending")
+    expect(page.locator("#streets-tbody tr").first).to_contain_text("Map Ville")
+
+    assert errors == []
+
+
+def test_dropping_the_sorted_column_falls_back_to_a_visible_one(page: Page, base_url):
+    """A preset that omits the active sort column must not leave the table
+    ordered by something the reader can no longer see."""
+    errors = _capture_errors(page)
+    page.goto(f"{base_url}/streets.html")
+    expect(page.locator('th[data-key="pct"]')).to_have_attribute("aria-sort", "descending")
+
+    # Network drops the coverage column entirely.
+    page.locator("#table-preset").select_option("network")
+    expect(page.locator('th[data-key="pct"]')).to_have_count(0)
+    expect(page.locator('th[data-key="label"]')).to_have_attribute("aria-sort", "ascending")
+
+    assert errors == []
+
+
+def test_column_picker_adds_and_drops_columns(page: Page, base_url):
+    errors = _capture_errors(page)
+    page.goto(f"{base_url}/grid.html")
+
+    # "Grid points" is not in the default Overview preset.
+    expect(page.locator('th[data-key="searchPoints"]')).to_have_count(0)
+    page.locator(".col-picker summary").click()
+    page.locator('input[data-column="searchPoints"]').check()
+    expect(page.locator('th[data-key="searchPoints"]')).to_have_count(1)
+    # The fixture publishes total_search_points = 4 for Alpha City.
+    expect(page.locator("#grid-tbody tr", has_text="Alpha City")).to_contain_text("4")
+
+    page.locator(".col-reset").click()
+    expect(page.locator('th[data-key="searchPoints"]')).to_have_count(0)
+
+    assert errors == []
+
+
+def test_distribution_strip_describes_the_sorted_column(page: Page, base_url):
+    """The strip is a histogram of the ACTIVE SORT COLUMN over the CURRENTLY
+    FILTERED rows. Its bars are decorative; the summary sentence beside them is
+    the accessible equivalent and must track both."""
+    errors = _capture_errors(page)
+    page.goto(f"{base_url}/streets.html")
+
+    summary = page.locator("#distribution-strip .strip-summary")
+    expect(summary).to_contain_text("360° street-km across 2 rows")
+
+    # Re-sorting repoints the strip at the newly sorted column.
+    page.locator('th[data-key="medianAge"] button').click()
+    expect(summary).to_contain_text("Median age")
+
+    # Filtering repoints it at the narrowed set.
+    page.locator('select[data-filter="provider"]').select_option("gsv")
+    expect(summary).to_contain_text("across 1 rows")
+
+    assert errors == []
+
+
+@pytest.mark.parametrize("path", ["grid.html", "streets.html"])
+def test_default_columns_fit_without_scrolling_the_page_sideways(page: Page, base_url, path):
+    """Both tables scrolled horizontally before #188, which is treated as a bug
+    rather than a layout choice. The default preset exists to fit the page's
+    1200px measure at desktop width."""
+    errors = _capture_errors(page)
+    page.set_viewport_size({"width": 1440, "height": 900})
+    page.goto(f"{base_url}/{path}")
+    expect(page.locator("tbody tr").first).to_be_visible()
+
+    # The document itself must not scroll sideways...
+    overflow = page.evaluate(
+        "() => document.documentElement.scrollWidth - document.documentElement.clientWidth"
+    )
+    assert overflow <= 0, f"{path} scrolls sideways by {overflow}px at 1440px wide"
+
+    # ...nor may the table overflow its own scroll container, which is the
+    # narrow-viewport safety net rather than the desktop layout.
+    table_overflow = page.evaluate(
+        """() => {
+             const wrap = document.querySelector('.streets-table-wrap');
+             return wrap.scrollWidth - wrap.clientWidth;
+           }"""
+    )
+    assert table_overflow <= 0, f"{path} table overflows its container by {table_overflow}px"
+
+    assert errors == []

--- a/www/css/data-table.css
+++ b/www/css/data-table.css
@@ -138,9 +138,12 @@
 
 /* Coverage cell: a proportional bar behind the number. The bar is
    aria-hidden — the percentage text is the accessible content. */
+/* Wide enough for the bar to read as a proportion, narrow enough that the two
+   coverage columns in a default preset still fit the 1200px measure without
+   the table overflowing its container (issue #188). */
 .coverage-cell {
   position: relative;
-  min-width: 140px;
+  min-width: 128px;
 }
 
 /* The coverage scale runs light-at-high (see coverageColor), so the bar needs
@@ -171,4 +174,202 @@
 
 .streets-no-link {
   color: #999;
+}
+
+/* ── Exploration controls (issue #188) ─────────────────────────────────────
+   Search, filters, the column preset/picker and the distribution strip. The
+   whole region is rendered by table-controls.js; nothing here is authored in
+   the HTML. */
+
+.controls-region {
+  margin-bottom: 16px;
+}
+
+.table-controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  gap: 10px 16px;
+  padding: 12px 14px;
+  background: #fff;
+  border-radius: 6px;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.15);
+}
+
+.control {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  font-size: 13px;
+}
+
+.control label,
+.control-legend {
+  color: #555;
+  font-size: 12px;
+}
+
+.control input,
+.control select {
+  font: inherit;
+  font-size: 13px;
+  padding: 4px 6px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  background: #fff;
+  color: #222;
+}
+
+.control-search input {
+  min-width: 220px;
+}
+
+/* Two bounds on one line; each input stays wide enough for a 4-digit figure
+   plus the spinner the browser adds to number inputs. */
+.control-range {
+  flex-direction: row;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+
+.control-range .control-legend {
+  flex-basis: 100%;
+}
+
+.control-range input {
+  width: 78px;
+}
+
+.control-dash {
+  color: #999;
+}
+
+/* A checkbox reads as a control + label on one line, not stacked. */
+.control-check {
+  flex-direction: row;
+  align-items: center;
+  gap: 6px;
+  align-self: flex-end;
+  padding-bottom: 5px;
+}
+
+.control-check label {
+  font-size: 13px;
+  color: #222;
+}
+
+.col-picker {
+  position: relative; /* the open panel positions against this, not the page */
+  font-size: 13px;
+  align-self: flex-end;
+  padding-bottom: 4px;
+}
+
+.col-picker summary {
+  cursor: pointer;
+  color: #1a6b1d;
+  font-weight: bold;
+}
+
+/* Floated over the table rather than pushing it down, so opening the picker
+   does not reflow the rows you are reading. */
+.col-picker .col-panel {
+  position: absolute;
+  z-index: 5;
+  left: 0;
+  margin-top: 6px;
+  padding: 10px 12px;
+  border: 1px solid #ddd;
+  border-radius: 6px;
+  background: #fff;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+}
+
+.col-picker .col-panel fieldset {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(140px, 1fr));
+  gap: 2px 14px;
+  margin: 0 0 8px;
+  padding: 0;
+  border: 0;
+}
+
+.col-toggle {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  white-space: nowrap;
+}
+
+.col-picker .col-reset,
+.controls-clear {
+  font: inherit;
+  font-size: 12px;
+  padding: 4px 8px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  background: #f7f7f7;
+  color: #333;
+  cursor: pointer;
+}
+
+.controls-clear {
+  align-self: flex-end;
+}
+
+.controls-clear:hover,
+.col-picker .col-reset:hover {
+  background: #ececec;
+}
+
+.control input:focus-visible,
+.control select:focus-visible,
+.col-picker summary:focus-visible,
+.controls-clear:focus-visible,
+.col-reset:focus-visible,
+.col-toggle input:focus-visible {
+  outline: 2px solid #1a73e8;
+  outline-offset: 1px;
+}
+
+/* ── Distribution strip ────────────────────────────────────────────────────
+   A histogram of the ACTIVE SORT COLUMN over the CURRENTLY FILTERED rows, so
+   it describes what you have selected rather than the whole table. Single
+   series, so: one flat hue, no legend, no axis furniture. Deliberately not
+   painted with coverageColor — these bars encode row counts, and reusing the
+   coverage ramp would imply the height meant coverage. */
+
+.distribution-strip {
+  margin-top: 10px;
+  padding: 10px 14px;
+  background: #fff;
+  border-radius: 6px;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.15);
+}
+
+.strip-bars {
+  display: flex;
+  align-items: flex-end;
+  gap: 2px; /* the surface gap that keeps adjacent bars readable as separate */
+  height: 40px;
+}
+
+.strip-bar {
+  flex: 1;
+  min-width: 2px;
+  background: #6c8ba0; /* 3.6:1 on the white surface — above the 3:1 floor */
+  border-radius: 2px 2px 0 0; /* rounded data-end, anchored to the baseline */
+}
+
+.strip-summary {
+  margin: 6px 0 0;
+  color: #555;
+  font-size: 12px;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .strip-bar {
+    transition: height 120ms ease-out;
+  }
 }

--- a/www/eslint.config.js
+++ b/www/eslint.config.js
@@ -76,7 +76,28 @@ const tableGlobals = {
   sortRowsBy: "readonly",
   formatCellNumber: "readonly",
   coverageCellHtml: "readonly",
+  headerCellHtml: "readonly",
+  rowHtmlFromColumns: "readonly",
   createSortableTable: "readonly",
+};
+
+// Symbols table-controls.js DEFINES and the two table pages CONSUME (issue
+// #188). Loaded after table-utils.js, whose formatCellNumber it consumes.
+const tableControlGlobals = {
+  foldForSearch: "readonly",
+  matchesSearch: "readonly",
+  isFilterUnset: "readonly",
+  rowPassesFilter: "readonly",
+  applyFilters: "readonly",
+  resolveVisibleColumns: "readonly",
+  parseTableState: "readonly",
+  serializeTableState: "readonly",
+  histogramBuckets: "readonly",
+  medianOf: "readonly",
+  formatStripSummary: "readonly",
+  renderDistributionStrip: "readonly",
+  controlsHtml: "readonly",
+  createTableControls: "readonly",
 };
 
 const browserRules = {
@@ -136,10 +157,28 @@ module.exports = [
     rules: browserRules,
   },
   {
+    // The exploration chassis (issue #188): consumes table-utils.js's
+    // formatCellNumber and defines the tableControlGlobals. Node export shim
+    // (`module`) for the unit tests.
+    files: ["js/table-controls.js"],
+    languageOptions: {
+      ecmaVersion: 2022,
+      sourceType: "script",
+      globals: {
+        ...globals.browser,
+        ...vendorGlobals,
+        ...sharedGlobals,
+        ...tableGlobals,
+        module: "readonly",
+      },
+    },
+    rules: browserRules,
+  },
+  {
     // The two table pages (issues #99/#155 and the grid table): consume the
-    // streetscape-utils.js and table-utils.js globals and, like the files
-    // above, carry a Node export shim (`module`) so their pure helpers can be
-    // unit-tested.
+    // streetscape-utils.js, table-utils.js and table-controls.js globals and,
+    // like the files above, carry a Node export shim (`module`) so their pure
+    // helpers can be unit-tested.
     files: ["js/streets.js", "js/grid.js"],
     languageOptions: {
       ecmaVersion: 2022,
@@ -149,6 +188,7 @@ module.exports = [
         ...vendorGlobals,
         ...sharedGlobals,
         ...tableGlobals,
+        ...tableControlGlobals,
         module: "readonly",
       },
     },

--- a/www/grid.html
+++ b/www/grid.html
@@ -56,7 +56,10 @@
         once per provider. Coverage percentages are cross-provider
         comparable; raw panorama counts are not — GSV samples the nearest
         pano per grid point while Mapillary is a census of every 360° pano.
-        Sort any column by clicking its header.
+        Search, filter and re-sort to narrow the table; the strip below the
+        controls shows how the sorted column is distributed across the rows
+        currently in view, and the address bar always carries the view you are
+        looking at so it can be shared.
       </p>
     </div>
 
@@ -64,49 +67,20 @@
       Loading city collections…
     </div>
 
+    <!-- Search, filters, column preset/picker and the distribution strip are
+         rendered into this container by table-controls.js once the data has
+         loaded (issue #188). -->
+    <div id="grid-controls" class="controls-region"></div>
+
     <div id="grid-table-wrap" class="streets-table-wrap" hidden>
       <table class="streets-table">
         <caption id="grid-caption"></caption>
-        <!-- Sortable headers: the <button> is what carries the click and the
-             keyboard focus (a bare click handler on <th> is unreachable by
-             keyboard); table-utils.js keeps aria-sort in step with the active
-             column. The ▲/▼ glyph is decorative, hence aria-hidden. -->
-        <thead>
-          <tr>
-            <th scope="col" data-key="label" aria-sort="none">
-              <button type="button">City <span class="sort-arrow" aria-hidden="true"></span></button>
-            </th>
-            <th scope="col" data-key="providerLabel" aria-sort="none">
-              <button type="button" title="Imagery provider. Each provider is an independent run series on the same frozen grid.">
-                Provider <span class="sort-arrow" aria-hidden="true"></span></button>
-            </th>
-            <th scope="col" data-key="pct" aria-sort="none">
-              <button type="button" title="Share of the city's grid sample points with a 360° panorama">
-                Grid coverage <span class="sort-arrow" aria-hidden="true"></span></button>
-            </th>
-            <th scope="col" data-key="pctAny" aria-sort="none">
-              <button type="button" title="Including flat/perspective imagery (Mapillary); equals Grid coverage for Google Street View">
-                Any imagery <span class="sort-arrow" aria-hidden="true"></span></button>
-            </th>
-            <th scope="col" data-key="medianAge" aria-sort="none">
-              <button type="button" title="Median age of the city's panoramas at its latest snapshot">
-                Median age <span class="sort-arrow" aria-hidden="true"></span></button>
-            </th>
-            <th scope="col" data-key="panos" aria-sort="none">
-              <button type="button" title="Unique panoramas in the latest snapshot: official © Google panos for GSV, all 360° panos for Mapillary. Not comparable across providers (sample vs census).">
-                Panoramas <span class="sort-arrow" aria-hidden="true"></span></button>
-            </th>
-            <th scope="col" data-key="collected" aria-sort="none">
-              <button type="button" title="Date of the latest collection run — how fresh this row's data is">
-                Last collected <span class="sort-arrow" aria-hidden="true"></span></button>
-            </th>
-            <th scope="col" data-key="snapshots" aria-sort="none">
-              <button type="button" title="Number of dated collection runs; repeat runs enable change tracking over time">
-                Snapshots <span class="sort-arrow" aria-hidden="true"></span></button>
-            </th>
-            <th scope="col"><span class="visually-hidden">Link to city map</span></th>
-          </tr>
-        </thead>
+        <!-- Header cells are rendered by table-utils.js from the page's column
+             descriptors (GRID_COLUMNS), not authored here: column presets
+             change the visible set at runtime, so the header and the body have
+             to come from one list or they drift. Sorting is delegated from this
+             element, which is why it survives a re-render. -->
+        <thead id="grid-thead"></thead>
         <tbody id="grid-tbody"></tbody>
       </table>
     </div>
@@ -118,6 +92,7 @@
           crossorigin="anonymous"></script>
   <script src="js/streetscape-utils.js"></script>
   <script src="js/table-utils.js"></script>
+  <script src="js/table-controls.js"></script>
   <script src="js/grid.js"></script>
 </body>
 </html>

--- a/www/js/__tests__/grid.test.js
+++ b/www/js/__tests__/grid.test.js
@@ -67,21 +67,34 @@ test("gridRowModel: missing stats become nulls, never NaN or 'undefined'", () =>
 });
 
 test("every sortable column key exists on a row model", () => {
-  // Guards the html/js seam: a th[data-key] with no matching model field
-  // would silently sort every row as null.
+  // Guards the column/model seam: a sortable column with no matching model
+  // field would silently sort every row as null.
   const row = gridRowModel(SEATTLE);
-  for (const col of GRID_COLUMNS) {
+  for (const col of GRID_COLUMNS.filter((c) => c.sortable !== false)) {
     assert.ok(col.key in row, `row model is missing ${col.key}`);
   }
   assert.ok(GRID_COLUMNS.some((c) => c.key === GRID_DEFAULT_SORT.key));
 });
 
+test("every column can render a cell, including from a fully null row model", () => {
+  // The header and the body are both generated from GRID_COLUMNS now, so a
+  // column that throws on a sparse record takes the whole table down rather
+  // than rendering one bad cell.
+  const sparse = gridRowModel({ provider: "gsv", city_id: "x--y", city: "X" });
+  for (const col of GRID_COLUMNS) {
+    assert.equal(typeof col.cell, "function", `${col.key} has no cell renderer`);
+    assert.match(col.cell(sparse), /^<t[hd][\s>]/, `${col.key} did not render a cell`);
+  }
+});
+
 // --- gridRowHtml ------------------------------------------------------------
 
-test("gridRowHtml: one cell per column plus the link cell, linking to city.html", () => {
+test("gridRowHtml: one cell per column, linking to city.html", () => {
+  // The link column is now a GRID_COLUMNS entry like any other (it renders its
+  // own cell), so the count is exact rather than "columns plus one".
   const html = gridRowHtml(gridRowModel(SEATTLE));
   const cells = (html.match(/<t[hd][\s>]/g) || []).length;
-  assert.equal(cells, GRID_COLUMNS.length + 1);
+  assert.equal(cells, GRID_COLUMNS.length);
   assert.match(
     html,
     /href="city\.html\?file=seattle--wa_width_5000_height_5000_step_20_2026-07-05\.csv\.gz"/

--- a/www/js/__tests__/streets.test.js
+++ b/www/js/__tests__/streets.test.js
@@ -201,22 +201,32 @@ test("sortRows: does not mutate its input", () => {
 });
 
 test("every sortable column key exists on a row model", () => {
-  // Guards the html/js seam: a th[data-key] with no matching model field
-  // would silently sort every row as null.
+  // Guards the column/model seam: a sortable column with no matching model
+  // field would silently sort every row as null.
   const row = toRowModel(
     { city_id: "x", provider: "gsv", run_date: "2026-01-01", spacing_m: 15 },
     { city: "X" }
   );
-  for (const col of STREET_COLUMNS) {
+  for (const col of STREET_COLUMNS.filter((c) => c.sortable !== false)) {
     assert.ok(col.key in row, `row model is missing ${col.key}`);
   }
   assert.ok(STREET_COLUMNS.some((c) => c.key === DEFAULT_SORT.key));
 });
 
-test("a row renders one cell per column, plus the link cell", () => {
-  // The <thead> lives in streets.html and the <tr> is built here, so adding a
-  // column to one and not the other misaligns every row — invisible until the
-  // page is opened in a browser, which no test does.
+test("every column can render a cell, including from a fully null row model", () => {
+  // The header and the body are both generated from STREET_COLUMNS now, so a
+  // column that throws on a sparse walk takes the whole table down rather than
+  // rendering one bad cell.
+  const sparse = toRowModel({ city_id: "x", provider: "gsv" }, null);
+  for (const col of STREET_COLUMNS) {
+    assert.equal(typeof col.cell, "function", `${col.key} has no cell renderer`);
+    assert.match(col.cell(sparse), /^<t[hd][\s>]/, `${col.key} did not render a cell`);
+  }
+});
+
+test("a row renders one cell per column", () => {
+  // The link column is now a STREET_COLUMNS entry like any other (it renders
+  // its own cell), so the count is exact rather than "columns plus one".
   const html = walkRowHtml(
     toRowModel(
       { city_id: "x", provider: "gsv", network_type: "all_public", run_date: "2026-01-01" },
@@ -224,7 +234,7 @@ test("a row renders one cell per column, plus the link cell", () => {
     )
   );
   const cells = (html.match(/<t[hd][\s>]/g) || []).length;
-  assert.equal(cells, STREET_COLUMNS.length + 1);
+  assert.equal(cells, STREET_COLUMNS.length);
 });
 
 test("toRowModel: labels the network, defaulting a tokenless walk to roads", () => {
@@ -386,10 +396,10 @@ test("walkChangeCellHtml: a zero delta still renders (imagery churned, net flat)
   assert.match(html, />\+0\.0 pp</);
 });
 
-test("walkRowHtml: cell count matches STREET_COLUMNS plus the link column", () => {
+test("walkRowHtml: cell count matches STREET_COLUMNS, change block included", () => {
   const html = walkRowHtml(toRowModel({ ...SEATTLE_WALK, change: CHANGE_BLOCK }, null));
   const cells = (html.match(/<t[dh][ >]/g) || []).length;
-  assert.equal(cells, STREET_COLUMNS.length + 1);
+  assert.equal(cells, STREET_COLUMNS.length);
 });
 
 test("sortRows: changeDelta sorts numerically with first walks (null) last", () => {

--- a/www/js/__tests__/table-controls.test.js
+++ b/www/js/__tests__/table-controls.test.js
@@ -169,6 +169,15 @@ test("resolveVisibleColumns: unknown preset or column degrades instead of throwi
   );
 });
 
+test("resolveVisibleColumns: an explicit empty selection shows only the always-on columns", () => {
+  // `[]` is the picker having every optional box unchecked — a real, distinct
+  // selection, not "no override, fall back to the preset". Confusing this
+  // with `null` would silently re-show the preset's columns while the
+  // checkboxes still read unchecked.
+  const keys = resolveVisibleColumns(COLUMNS, PRESETS, "overview", []).map((c) => c.key);
+  assert.deepEqual(keys, ["label", "actions"]);
+});
+
 // --- URL round-trip ---------------------------------------------------------
 
 test("parseTableState/serializeTableState: a full view round-trips", () => {
@@ -195,6 +204,21 @@ test("serializeTableState: an untouched view writes nothing but the sort", () =>
     { filters: FILTERS, defaultPreset: "overview" }
   );
   assert.equal(qs, "");
+});
+
+test("parseTableState/serializeTableState: an explicit empty column selection round-trips as [], not null", () => {
+  // The picker zeroed out to no optional columns is a real selection, distinct
+  // from "no picker override" (cols: null) — a shared link for that view must
+  // reopen with zero optional columns, not silently regain the preset's.
+  const qs = serializeTableState(
+    { query: "", preset: "overview", cols: [], sort: null, values: {} },
+    { filters: FILTERS, defaultPreset: "overview" }
+  );
+  assert.equal(qs, "cols=");
+  assert.deepEqual(parseTableState(qs, { filters: FILTERS }).cols, []);
+
+  // A URL with no `cols` param at all is still "no override".
+  assert.equal(parseTableState("", { filters: FILTERS }).cols, null);
 });
 
 test("parseTableState: one-sided and malformed ranges degrade rather than throw", () => {

--- a/www/js/__tests__/table-controls.test.js
+++ b/www/js/__tests__/table-controls.test.js
@@ -1,0 +1,309 @@
+// Offline unit tests for the exploration chassis in table-controls.js
+// (issue #188): search, structured filters, column presets, URL round-trip,
+// and the distribution strip's bucketing.
+//
+// Run with `npm test` (Node's built-in test runner) — no network, no jsdom.
+// In the browser this module reads formatCellNumber from table-utils.js; here
+// we stub it. The DOM wiring in createTableControls is covered by the browser
+// e2e smoke test instead (tests/e2e/test_smoke.py).
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+global.formatCellNumber = (v, digits = 0) =>
+  v == null ? "—" : v.toFixed(digits);
+
+const {
+  foldForSearch,
+  matchesSearch,
+  isFilterUnset,
+  rowPassesFilter,
+  applyFilters,
+  resolveVisibleColumns,
+  parseTableState,
+  serializeTableState,
+  bucketCountFor,
+  histogramBuckets,
+  medianOf,
+  formatStripSummary,
+  controlsHtml,
+} = require("../table-controls.js");
+
+// --- search -----------------------------------------------------------------
+
+test("foldForSearch: strips accents and case so the worldwide frame is searchable", () => {
+  // Issue #115 put non-ASCII city names in the table; "avila" must find "Ávila".
+  assert.equal(foldForSearch("Ávila"), "avila");
+  assert.equal(foldForSearch("Córdoba"), "cordoba");
+  assert.equal(foldForSearch(null), "");
+  assert.equal(foldForSearch(42), "42");
+});
+
+const SEARCH_FIELDS = ["label", "providerLabel"];
+
+test("matchesSearch: every term must match, but any field may supply it", () => {
+  const row = { label: "Seattle, Washington", providerLabel: "Mapillary" };
+  assert.ok(matchesSearch(row, SEARCH_FIELDS, "seattle mapillary"));
+  assert.ok(matchesSearch(row, SEARCH_FIELDS, "SEATTLE"));
+  assert.ok(!matchesSearch(row, SEARCH_FIELDS, "seattle google"));
+});
+
+test("matchesSearch: a blank or whitespace query matches everything", () => {
+  const row = { label: "Seattle", providerLabel: "Mapillary" };
+  assert.ok(matchesSearch(row, SEARCH_FIELDS, ""));
+  assert.ok(matchesSearch(row, SEARCH_FIELDS, "   "));
+});
+
+// --- filters ----------------------------------------------------------------
+
+const FILTERS = [
+  {
+    key: "provider",
+    label: "Provider",
+    type: "select",
+    options: [
+      { value: "gsv", label: "GSV" },
+      { value: "mapillary", label: "Mapillary" },
+    ],
+    test: (row, value) => row.provider === value,
+  },
+  { key: "cov", label: "Coverage", type: "range", field: "pct", min: 0, max: 100 },
+  { key: "changed", label: "Has Δ", type: "boolean", test: (row) => row.delta != null },
+];
+
+const ROWS = [
+  { cityId: "a", provider: "gsv", pct: 90, delta: 1.2 },
+  { cityId: "b", provider: "mapillary", pct: 10, delta: null },
+  { cityId: "c", provider: "gsv", pct: null, delta: null },
+];
+
+test("isFilterUnset: blanks, unchecked boxes and empty ranges narrow nothing", () => {
+  assert.ok(isFilterUnset(FILTERS[0], ""));
+  assert.ok(isFilterUnset(FILTERS[0], null));
+  assert.ok(isFilterUnset(FILTERS[2], false));
+  assert.ok(isFilterUnset(FILTERS[1], { min: null, max: null }));
+  assert.ok(!isFilterUnset(FILTERS[1], { min: 10, max: null }));
+});
+
+test("rowPassesFilter: a range EXCLUDES rows with no measured value", () => {
+  // Same posture as sortRowsBy sinking nulls in both directions: an unmeasured
+  // city is absent, not zero. "Coverage 0–50" must not sweep in the row whose
+  // coverage was never recorded.
+  const range = FILTERS[1];
+  assert.ok(!rowPassesFilter(range, ROWS[2], { min: 0, max: 50 }));
+  assert.ok(rowPassesFilter(range, ROWS[1], { min: 0, max: 50 }));
+  // ...but an UNSET range leaves it alone.
+  assert.ok(rowPassesFilter(range, ROWS[2], { min: null, max: null }));
+});
+
+test("rowPassesFilter: range bounds are inclusive and one-sided bounds work", () => {
+  const range = FILTERS[1];
+  assert.ok(rowPassesFilter(range, { pct: 10 }, { min: 10, max: 90 }));
+  assert.ok(rowPassesFilter(range, { pct: 90 }, { min: 10, max: 90 }));
+  assert.ok(rowPassesFilter(range, { pct: 95 }, { min: 90, max: null }));
+  assert.ok(!rowPassesFilter(range, { pct: 95 }, { min: null, max: 90 }));
+});
+
+test("applyFilters: search and filters compose, and the input is untouched", () => {
+  const before = ROWS.map((r) => r.cityId);
+  const out = applyFilters(ROWS, {
+    filters: FILTERS,
+    values: { provider: "gsv" },
+    query: "",
+    searchFields: [],
+  });
+  assert.deepEqual(out.map((r) => r.cityId), ["a", "c"]);
+  assert.deepEqual(ROWS.map((r) => r.cityId), before);
+});
+
+test("applyFilters: a boolean filter keeps only rows its test accepts", () => {
+  const out = applyFilters(ROWS, {
+    filters: FILTERS,
+    values: { changed: true },
+    query: "",
+    searchFields: [],
+  });
+  assert.deepEqual(out.map((r) => r.cityId), ["a"]);
+});
+
+// --- column presets ---------------------------------------------------------
+
+const COLUMNS = [
+  { key: "label", label: "City", always: true },
+  { key: "provider", label: "Provider" },
+  { key: "pct", label: "Coverage" },
+  { key: "km", label: "Street km" },
+  { key: "actions", label: "", sortable: false, always: true },
+];
+
+const PRESETS = [
+  { id: "overview", label: "Overview", columns: ["provider", "pct"] },
+  { id: "km", label: "Kilometres", columns: ["pct", "km"] },
+];
+
+test("resolveVisibleColumns: a preset yields its columns plus the always-on ones", () => {
+  const keys = resolveVisibleColumns(COLUMNS, PRESETS, "overview", null).map((c) => c.key);
+  assert.deepEqual(keys, ["label", "provider", "pct", "actions"]);
+});
+
+test("resolveVisibleColumns: explicit picker keys win over the preset", () => {
+  const keys = resolveVisibleColumns(COLUMNS, PRESETS, "overview", ["km"]).map((c) => c.key);
+  assert.deepEqual(keys, ["label", "km", "actions"]);
+});
+
+test("resolveVisibleColumns: order follows the canonical list, not the URL", () => {
+  // ?cols=km,provider must still render Provider before Street km.
+  const keys = resolveVisibleColumns(COLUMNS, PRESETS, null, ["km", "provider"]).map((c) => c.key);
+  assert.deepEqual(keys, ["label", "provider", "km", "actions"]);
+});
+
+test("resolveVisibleColumns: unknown preset or column degrades instead of throwing", () => {
+  // A stale link from before a column was renamed should still open a page.
+  assert.deepEqual(
+    resolveVisibleColumns(COLUMNS, PRESETS, "nope", null).map((c) => c.key),
+    ["label", "provider", "pct", "actions"]
+  );
+  assert.deepEqual(
+    resolveVisibleColumns(COLUMNS, PRESETS, null, ["gone"]).map((c) => c.key),
+    ["label", "actions"]
+  );
+});
+
+// --- URL round-trip ---------------------------------------------------------
+
+test("parseTableState/serializeTableState: a full view round-trips", () => {
+  const state = {
+    query: "seattle",
+    preset: "km",
+    cols: ["pct", "km"],
+    sort: { key: "pct", dir: "asc" },
+    values: { provider: "gsv", cov: { min: 10, max: 90 }, changed: true },
+  };
+  const qs = serializeTableState(state, { filters: FILTERS, defaultPreset: "overview" });
+  const parsed = parseTableState(qs, { filters: FILTERS });
+  assert.equal(parsed.query, "seattle");
+  assert.equal(parsed.preset, "km");
+  assert.deepEqual(parsed.cols, ["pct", "km"]);
+  assert.deepEqual(parsed.sort, { key: "pct", dir: "asc" });
+  assert.deepEqual(parsed.values, state.values);
+});
+
+test("serializeTableState: an untouched view writes nothing but the sort", () => {
+  // Default state must not litter the address bar with redundant parameters.
+  const qs = serializeTableState(
+    { query: "", preset: "overview", cols: null, sort: null, values: {} },
+    { filters: FILTERS, defaultPreset: "overview" }
+  );
+  assert.equal(qs, "");
+});
+
+test("parseTableState: one-sided and malformed ranges degrade rather than throw", () => {
+  const parsed = parseTableState("cov=10~", { filters: FILTERS });
+  assert.deepEqual(parsed.values.cov, { min: 10, max: null });
+
+  const openMin = parseTableState("cov=~90", { filters: FILTERS });
+  assert.deepEqual(openMin.values.cov, { min: null, max: 90 });
+
+  // Fully unparseable: the filter is simply not set.
+  assert.deepEqual(parseTableState("cov=abc~xyz", { filters: FILTERS }).values, {});
+});
+
+test("parseTableState: a select value outside the option list is ignored", () => {
+  // A hand-edited URL should not filter the table down to nothing on a value
+  // no control could ever produce.
+  assert.deepEqual(parseTableState("provider=bogus", { filters: FILTERS }).values, {});
+  assert.deepEqual(parseTableState("provider=gsv", { filters: FILTERS }).values, {
+    provider: "gsv",
+  });
+});
+
+test("parseTableState: an empty query string yields defaults, not undefined", () => {
+  const parsed = parseTableState("", { filters: FILTERS });
+  assert.deepEqual(parsed, { query: "", preset: null, cols: null, sort: null, values: {} });
+});
+
+// --- distribution strip -----------------------------------------------------
+
+test("bucketCountFor: scales with N and clamps at both ends", () => {
+  // A heavily filtered view must not render two lone bars across 24 empty
+  // buckets, and a full table must not render bars thinner than their gaps.
+  assert.equal(bucketCountFor(1), 1);
+  assert.equal(bucketCountFor(2), 2);
+  assert.equal(bucketCountFor(283), 17); // production's walk count
+  assert.equal(bucketCountFor(1501), 24); // production's grid-series count, capped
+});
+
+test("histogramBuckets: bucket count adapts to N when not given one", () => {
+  assert.equal(histogramBuckets([1, 2]).buckets.length, 2);
+  assert.equal(histogramBuckets(Array.from({ length: 100 }, (_, i) => i)).buckets.length, 10);
+});
+
+test("histogramBuckets: drops nulls and puts the maximum in the last bucket", () => {
+  const stats = histogramBuckets([0, 50, 100, null, undefined], 4);
+  assert.equal(stats.count, 3);
+  assert.equal(stats.min, 0);
+  assert.equal(stats.max, 100);
+  assert.equal(stats.buckets.length, 4);
+  // 100 belongs in the final bucket, not one past the end.
+  assert.equal(stats.buckets[3].count, 1);
+  assert.equal(stats.buckets.reduce((n, b) => n + b.count, 0), 3);
+});
+
+test("histogramBuckets: a single distinct value yields one bucket, not a zero-width range", () => {
+  const stats = histogramBuckets([7, 7, 7], 10);
+  assert.equal(stats.buckets.length, 1);
+  assert.deepEqual(stats.buckets[0], { from: 7, to: 7, count: 3 });
+});
+
+test("histogramBuckets: nothing measurable yields null, not an empty chart", () => {
+  assert.equal(histogramBuckets([]), null);
+  assert.equal(histogramBuckets([null, undefined]), null);
+  // NaN/Infinity are not measurements either.
+  assert.equal(histogramBuckets([NaN, Infinity]), null);
+});
+
+test("medianOf: averages the middle pair on an even count, ignores nulls", () => {
+  assert.equal(medianOf([1, 2, 3]), 2);
+  assert.equal(medianOf([1, 2, 3, 4]), 2.5);
+  assert.equal(medianOf([3, null, 1]), 2);
+  assert.equal(medianOf([]), null);
+});
+
+test("formatStripSummary: carries min/median/max as text for screen readers", () => {
+  const column = { key: "pct", label: "Grid coverage", type: "number", unit: "%", digits: 1 };
+  const summary = formatStripSummary(column, [10, 20, 90]);
+  assert.match(summary, /Grid coverage across 3 rows/);
+  assert.match(summary, /min 10\.0%/);
+  assert.match(summary, /median 20\.0%/);
+  assert.match(summary, /max 90\.0%/);
+});
+
+test("formatStripSummary: says so plainly when the filtered view has no values", () => {
+  const column = { key: "pct", label: "Grid coverage", type: "number" };
+  assert.match(formatStripSummary(column, [null, null]), /No grid coverage values/);
+});
+
+// --- controls markup --------------------------------------------------------
+
+test("controlsHtml: every filter becomes a labeled control", () => {
+  const html = controlsHtml({ filters: FILTERS, presets: PRESETS, columns: COLUMNS });
+  // Select: a real <select> tied to its <label> by id.
+  assert.match(html, /<label for="f-provider">Provider<\/label>/);
+  assert.match(html, /<select id="f-provider" data-filter="provider">/);
+  // Range: two number inputs, each individually labeled for a screen reader
+  // (a shared visible legend cannot distinguish min from max).
+  assert.match(html, /aria-label="Minimum Coverage"/);
+  assert.match(html, /aria-label="Maximum Coverage"/);
+  // Boolean: a checkbox, not a select.
+  assert.match(html, /type="checkbox" id="f-changed"/);
+});
+
+test("controlsHtml: the picker offers every column except the always-on ones", () => {
+  const html = controlsHtml({ filters: FILTERS, presets: PRESETS, columns: COLUMNS });
+  for (const key of ["provider", "pct", "km"]) {
+    assert.match(html, new RegExp(`data-column="${key}"`));
+  }
+  // City and the link column are structural — they are never toggleable.
+  assert.doesNotMatch(html, /data-column="label"/);
+  assert.doesNotMatch(html, /data-column="actions"/);
+});

--- a/www/js/__tests__/table-utils.test.js
+++ b/www/js/__tests__/table-utils.test.js
@@ -15,6 +15,8 @@ const {
   sortRowsBy,
   formatCellNumber,
   coverageCellHtml,
+  headerCellHtml,
+  rowHtmlFromColumns,
   createSortableTable,
 } = require("../table-utils.js");
 
@@ -42,8 +44,21 @@ test("cityDisplayLabel: city-states don't repeat, empty records fall to Unknown"
 // --- sortRowsBy -------------------------------------------------------------
 
 const COLUMNS = [
-  { key: "label", label: "City", type: "text", initial: "asc" },
-  { key: "pct", label: "Coverage", type: "number", initial: "desc" },
+  {
+    key: "label",
+    label: "City",
+    type: "text",
+    initial: "asc",
+    always: true,
+    cell: (r) => `<th scope="row">${r.label}</th>`,
+  },
+  {
+    key: "pct",
+    label: "Coverage",
+    type: "number",
+    initial: "desc",
+    cell: (r) => `<td>${r.pct}</td>`,
+  },
 ];
 
 const ROWS = [
@@ -93,82 +108,152 @@ test("coverageCellHtml: bar clamped to 0–100%, dash cell for null", () => {
   assert.equal(coverageCellHtml(null), `<td class="coverage-cell">—</td>`);
 });
 
+// --- headerCellHtml / rowHtmlFromColumns ------------------------------------
+
+test("headerCellHtml: marks the active column and reserves the arrow", () => {
+  const active = headerCellHtml(COLUMNS[1], { key: "pct", dir: "desc" });
+  assert.match(active, /data-key="pct"/);
+  assert.match(active, /aria-sort="descending"/);
+  assert.match(active, /▼/);
+
+  const idle = headerCellHtml(COLUMNS[0], { key: "pct", dir: "desc" });
+  assert.match(idle, /aria-sort="none"/);
+  assert.doesNotMatch(idle, /[▲▼]/);
+});
+
+test("headerCellHtml: a non-sortable column gets a label-less header, no data-key", () => {
+  // The trailing link column: no sort affordance, but it still needs a <th> or
+  // every body row would have one more cell than the header.
+  const html = headerCellHtml(
+    { key: "actions", sortable: false, srLabel: "Link to city map" },
+    { key: "pct", dir: "desc" }
+  );
+  assert.doesNotMatch(html, /data-key/);
+  assert.doesNotMatch(html, /<button/);
+  assert.match(html, /Link to city map/);
+});
+
+test("rowHtmlFromColumns: renders exactly the columns it is given", () => {
+  const html = rowHtmlFromColumns(COLUMNS, ROWS[0]);
+  assert.equal(html, "<tr><th scope=\"row\">Cee</th><td>50</td></tr>");
+  // One column in, one cell out — this is the invariant that replaced the old
+  // hand-maintained thead/tbody pairing.
+  assert.equal(rowHtmlFromColumns([COLUMNS[1]], ROWS[0]), "<tr><td>50</td></tr>");
+});
+
 // --- createSortableTable (stub-DOM, same approach as streets.test.js) --------
 
-/** A minimal Element stand-in for the pieces createSortableTable touches. */
-function stubTh(key) {
+/**
+ * A minimal <thead> stand-in. The controller replaces the element's innerHTML
+ * and delegates clicks to it, so the stub records the markup and can replay a
+ * click for a given column key — asserting along the way that the key is
+ * actually present in the rendered header.
+ */
+function stubThead() {
   const listeners = [];
-  const arrow = { textContent: "" };
-  const th = {
-    dataset: { key },
-    attrs: {},
-    setAttribute(name, value) { this.attrs[name] = value; },
-    querySelector(sel) {
-      if (sel === "button") {
-        return { addEventListener: (_type, fn) => listeners.push(fn) };
-      }
-      if (sel === ".sort-arrow") return arrow;
-      return null;
+  return {
+    innerHTML: "",
+    addEventListener(type, fn) {
+      if (type === "click") listeners.push(fn);
     },
-    click: () => listeners.forEach((fn) => fn()),
-    arrow,
+    clickKey(key) {
+      assert.ok(
+        this.innerHTML.includes(`data-key="${key}"`),
+        `header has no sortable column ${key}`
+      );
+      const target = {
+        closest: (sel) => (sel === "th[data-key]" ? { dataset: { key } } : null),
+      };
+      for (const fn of listeners) fn({ target });
+    },
   };
-  return th;
 }
 
-function stubTable(columns) {
-  const ths = columns.map((c) => stubTh(c.key));
-  const wrapEl = { querySelectorAll: () => ths };
-  const tbodyEl = { innerHTML: "" };
-  return { ths, wrapEl, tbodyEl };
+function stubTable() {
+  return { theadEl: stubThead(), tbodyEl: { innerHTML: "" } };
+}
+
+function makeTable(overrides = {}) {
+  const { theadEl, tbodyEl } = stubTable();
+  const table = createSortableTable({
+    columns: COLUMNS,
+    defaultSort: { key: "pct", dir: "desc" },
+    theadEl,
+    tbodyEl,
+    ...overrides,
+  });
+  return { table, theadEl, tbodyEl };
 }
 
 test("createSortableTable: renders sorted rows and keeps aria-sort in step", () => {
-  const { ths, wrapEl, tbodyEl } = stubTable(COLUMNS);
-  const table = createSortableTable({
-    columns: COLUMNS,
-    defaultSort: { key: "pct", dir: "desc" },
-    wrapEl,
-    tbodyEl,
-    rowHtml: (r) => `<tr><td>${r.cityId}</td></tr>`,
-  });
+  const { table, theadEl, tbodyEl } = makeTable();
   table.setRows(ROWS);
-  assert.match(tbodyEl.innerHTML, /^<tr><td>b<\/td><\/tr>/);
-  assert.equal(ths[1].attrs["aria-sort"], "descending");
-  assert.equal(ths[0].attrs["aria-sort"], "none");
-  assert.equal(ths[1].arrow.textContent, "▼");
+  assert.match(tbodyEl.innerHTML, /^<tr><th scope="row">Bee<\/th>/);
+  assert.match(theadEl.innerHTML, /data-key="pct" aria-sort="descending"/);
+  assert.match(theadEl.innerHTML, /data-key="label" aria-sort="none"/);
 });
 
 test("createSortableTable: header click sorts a new column at its natural direction, re-click reverses", () => {
-  const { ths, tbodyEl, wrapEl } = stubTable(COLUMNS);
-  const table = createSortableTable({
-    columns: COLUMNS,
-    defaultSort: { key: "pct", dir: "desc" },
-    wrapEl,
-    tbodyEl,
-    rowHtml: (r) => `[${r.cityId}]`,
-  });
+  const { table, theadEl, tbodyEl } = makeTable();
   table.setRows(ROWS);
 
-  ths[0].click(); // label column: initial asc
-  assert.equal(tbodyEl.innerHTML, "[a][b][c][d]");
-  assert.equal(ths[0].attrs["aria-sort"], "ascending");
-  assert.equal(ths[0].arrow.textContent, "▲");
+  theadEl.clickKey("label"); // label column: initial asc
+  assert.match(tbodyEl.innerHTML, /^<tr><th scope="row">Aye<\/th>/);
+  assert.match(theadEl.innerHTML, /data-key="label" aria-sort="ascending"/);
 
-  ths[0].click(); // same column: reverses
-  assert.equal(tbodyEl.innerHTML, "[d][c][b][a]");
-  assert.equal(ths[0].attrs["aria-sort"], "descending");
+  theadEl.clickKey("label"); // same column: reverses
+  assert.match(tbodyEl.innerHTML, /^<tr><th scope="row">Dee<\/th>/);
+  assert.match(theadEl.innerHTML, /data-key="label" aria-sort="descending"/);
+});
+
+test("createSortableTable: sorting still works after a column change re-renders the header", () => {
+  // The regression the delegated listener exists for. Listeners bound to each
+  // <th>'s button at construction die the first time setColumns replaces the
+  // thead's innerHTML, leaving a table whose headers look clickable and are not.
+  const { table, theadEl, tbodyEl } = makeTable();
+  table.setRows(ROWS);
+  table.setColumns(COLUMNS); // re-render, same columns
+  theadEl.clickKey("label");
+  assert.match(tbodyEl.innerHTML, /^<tr><th scope="row">Aye<\/th>/);
+  assert.equal(table.getSort().key, "label");
+});
+
+test("createSortableTable: dropping the sorted column falls back to a visible one", () => {
+  // Otherwise the table stays ordered by a column the reader can no longer see.
+  const { table, tbodyEl } = makeTable();
+  table.setRows(ROWS);
+  assert.equal(table.getSort().key, "pct");
+  table.setColumns([COLUMNS[0]]);
+  assert.equal(table.getSort().key, "label");
+  assert.match(tbodyEl.innerHTML, /^<tr><th scope="row">Aye<\/th>/);
+});
+
+test("createSortableTable: setSortTo restores a direction instead of toggling it", () => {
+  // A "?sort=pct&dir=desc" link must land descending even though the page
+  // already opens on that column — click semantics would reverse it.
+  const { table } = makeTable();
+  table.setRows(ROWS);
+  table.setSortTo("pct", "desc");
+  assert.deepEqual(table.getSort(), { key: "pct", dir: "desc" });
+  table.setSortTo("label", "asc");
+  assert.deepEqual(table.getSort(), { key: "label", dir: "asc" });
+});
+
+test("createSortableTable: onSortChange fires for header clicks, not for setSortTo", () => {
+  // table-controls.js listens here to repaint the strip and rewrite the URL;
+  // echoing a restore straight back into the URL would be circular.
+  const { table, theadEl } = makeTable();
+  const seen = [];
+  table.onSortChange((sort) => seen.push(sort.key));
+  table.setRows(ROWS);
+  theadEl.clickKey("label");
+  assert.deepEqual(seen, ["label"]);
+  table.setSortTo("pct", "desc");
+  assert.deepEqual(seen, ["label"]);
 });
 
 test("createSortableTable: setSort with an unknown key is a no-op", () => {
-  const { tbodyEl, wrapEl } = stubTable(COLUMNS);
-  const table = createSortableTable({
-    columns: COLUMNS,
-    defaultSort: { key: "pct", dir: "desc" },
-    wrapEl,
-    tbodyEl,
-    rowHtml: (r) => `[${r.cityId}]`,
-  });
+  const { table, tbodyEl } = makeTable();
   table.setRows(ROWS);
   const before = tbodyEl.innerHTML;
   table.setSort("nope");

--- a/www/js/grid.js
+++ b/www/js/grid.js
@@ -10,25 +10,231 @@
  *
  * Depends on globals from streetscape-utils.js (loaded first): PROVIDERS,
  * STREETSCAPE_DATA_BASE_URL, fetchGzippedJson, adaptCitiesPayload,
- * escapeHtml — and from table-utils.js: cityDisplayLabel, sortRowsBy,
- * formatCellNumber, coverageCellHtml, createSortableTable.
+ * escapeHtml — from table-utils.js: cityDisplayLabel, sortRowsBy,
+ * formatCellNumber, coverageCellHtml, rowHtmlFromColumns,
+ * createSortableTable — and from table-controls.js: createTableControls.
  */
 
 /**
- * The sortable columns, in table order. `key` is the row-model field, `type`
- * picks the comparator, and `initial` is the direction a first click applies
- * (numbers read best-first, text reads A–Z).
+ * Cell for the "View on map" link.
+ *
+ * @param {Object} row - From gridRowModel.
+ * @returns {string} HTML for one <td>.
+ */
+function gridLinkCellHtml(row) {
+  const link = row.filename
+    ? `<a class="streets-view-link"
+          href="city.html?file=${encodeURIComponent(row.filename)}">View on map</a>`
+    : `<span class="streets-no-link" title="This city has no published run to link to">—</span>`;
+  return `<td>${link}</td>`;
+}
+
+/**
+ * The columns, in table order.
+ *
+ * `key` is the row-model field, `type` picks the comparator, `initial` is the
+ * direction a first click applies (numbers read best-first, text reads A–Z),
+ * and `cell(row)` renders that column's own cell — the header and the body are
+ * both generated from this list so they cannot drift (see table-utils.js).
+ *
+ * `unit`/`digits` are read by the distribution strip; `title` becomes the
+ * header tooltip (these lived in grid.html before the header became
+ * JS-rendered).
+ *
+ * City/state/country names come from OSM/Nominatim (publicly editable
+ * third-party data) — escape everything data-derived entering innerHTML.
  */
 const GRID_COLUMNS = [
-  { key: "label", label: "City", type: "text", initial: "asc" },
-  { key: "providerLabel", label: "Provider", type: "text", initial: "asc" },
-  { key: "pct", label: "Grid coverage", type: "number", initial: "desc" },
-  { key: "pctAny", label: "Any imagery", type: "number", initial: "desc" },
-  { key: "medianAge", label: "Median age", type: "number", initial: "asc" },
-  { key: "panos", label: "Panoramas", type: "number", initial: "desc" },
-  { key: "collected", label: "Last collected", type: "text", initial: "desc" },
-  { key: "snapshots", label: "Snapshots", type: "number", initial: "desc" },
+  {
+    key: "label",
+    label: "City",
+    type: "text",
+    initial: "asc",
+    always: true,
+    cell: (r) => `<th scope="row">${escapeHtml(r.label)}</th>`,
+  },
+  {
+    key: "providerLabel",
+    label: "Provider",
+    type: "text",
+    initial: "asc",
+    title:
+      "Imagery provider. Each provider is an independent run series on the same frozen grid.",
+    cell: (r) => `<td>${escapeHtml(r.providerLabel)}</td>`,
+  },
+  {
+    key: "pct",
+    label: "Grid coverage",
+    type: "number",
+    initial: "desc",
+    unit: "%",
+    title: "Share of the city's grid sample points with a 360° panorama",
+    cell: (r) => coverageCellHtml(r.pct),
+  },
+  {
+    key: "pctAny",
+    label: "Any imagery",
+    type: "number",
+    initial: "desc",
+    unit: "%",
+    title:
+      "Including flat/perspective imagery (Mapillary); equals Grid coverage for Google Street View",
+    cell: (r) => coverageCellHtml(r.pctAny),
+  },
+  {
+    key: "medianAge",
+    label: "Median age",
+    type: "number",
+    initial: "asc",
+    unit: " yrs",
+    digits: 1,
+    title: "Median age of the city's panoramas at its latest snapshot",
+    cell: (r) => `<td>${r.medianAge == null ? "—" : `${formatCellNumber(r.medianAge, 1)} yrs`}</td>`,
+  },
+  {
+    key: "panos",
+    label: "Panoramas",
+    type: "number",
+    initial: "desc",
+    title:
+      "Unique panoramas in the latest snapshot: official © Google panos for GSV, all 360° " +
+      "panos for Mapillary. Not comparable across providers (sample vs census).",
+    cell: (r) => `<td>${formatCellNumber(r.panos)}</td>`,
+  },
+  // The denominator of Grid coverage (aggregate schema v3 additive, issue
+  // #189). Without it a reader cannot tell a 40% built from 1,681 points from
+  // a 40% built from two million — the difference between a village and a
+  // metro.
+  {
+    key: "searchPoints",
+    label: "Grid points",
+    type: "number",
+    initial: "desc",
+    title: "Sample points in the frozen grid — the denominator Grid coverage is a share of",
+    cell: (r) => `<td>${formatCellNumber(r.searchPoints)}</td>`,
+  },
+  {
+    key: "gridWidthM",
+    label: "Grid size",
+    type: "number",
+    initial: "desc",
+    unit: " m",
+    title:
+      "Extent of the frozen sampling grid, width × height. Sorts by width. Oversized city " +
+      "grids are capped at 40 km per side (issue #166).",
+    cell: (r) => `<td>${r.gridSpanLabel ?? "—"}</td>`,
+  },
+  {
+    key: "gridStepM",
+    label: "Grid step",
+    type: "number",
+    initial: "asc",
+    unit: " m",
+    title: "Spacing between grid sample points",
+    cell: (r) => `<td>${r.gridStepM == null ? "—" : `${formatCellNumber(r.gridStepM)} m`}</td>`,
+  },
+  {
+    key: "areaKm2",
+    label: "Grid area",
+    type: "number",
+    initial: "desc",
+    unit: " km²",
+    digits: 1,
+    title: "Area covered by the frozen sampling grid",
+    cell: (r) => `<td>${r.areaKm2 == null ? "—" : `${formatCellNumber(r.areaKm2, 1)} km²`}</td>`,
+  },
+  {
+    key: "collected",
+    label: "Last collected",
+    type: "text",
+    initial: "desc",
+    title: "Date of the latest collection run — how fresh this row's data is",
+    cell: (r) => `<td>${escapeHtml(r.collected ?? "—")}</td>`,
+  },
+  {
+    key: "snapshots",
+    label: "Snapshots",
+    type: "number",
+    initial: "desc",
+    title: "Number of dated collection runs; repeat runs enable change tracking over time",
+    cell: (r) => `<td>${formatCellNumber(r.snapshots)}</td>`,
+  },
+  {
+    key: "actions",
+    label: "",
+    sortable: false,
+    always: true,
+    srLabel: "Link to city map",
+    cell: gridLinkCellHtml,
+  },
 ];
+
+/**
+ * Column presets. The first is the default and must fit the page's 1200px
+ * measure without horizontal scrolling — that is what these exist for.
+ */
+const GRID_PRESETS = [
+  {
+    id: "overview",
+    label: "Overview",
+    title: "The headline read: how much imagery a city has, and how fresh it is",
+    columns: ["providerLabel", "pct", "pctAny", "medianAge", "panos", "collected"],
+  },
+  {
+    id: "grid",
+    label: "Grid geometry",
+    title: "What the percentage is a percentage OF (aggregate schema v3, issue #189)",
+    columns: ["providerLabel", "pct", "searchPoints", "gridWidthM", "gridStepM", "areaKm2"],
+  },
+  {
+    id: "provenance",
+    label: "Provenance",
+    title: "When each series was collected and how many times",
+    columns: ["providerLabel", "collected", "snapshots", "medianAge", "panos"],
+  },
+];
+
+/** Filters offered above the table. */
+const GRID_FILTERS = [
+  {
+    key: "provider",
+    label: "Provider",
+    type: "select",
+    anyLabel: "All providers",
+    options: [
+      { value: "gsv", label: "Google Street View" },
+      { value: "mapillary", label: "Mapillary" },
+    ],
+    test: (row, value) => row.provider === value,
+  },
+  {
+    key: "cov",
+    label: "Grid coverage %",
+    type: "range",
+    field: "pct",
+    min: 0,
+    max: 100,
+  },
+  {
+    key: "age",
+    label: "Median age (yrs)",
+    type: "range",
+    field: "medianAge",
+    min: 0,
+  },
+  {
+    key: "both",
+    label: "Both providers",
+    type: "boolean",
+    title:
+      "Only cities collected by BOTH Google Street View and Mapillary, where the two series " +
+      "are directly comparable on the same frozen grid",
+    test: (row) => row.hasBothProviders === true,
+  },
+];
+
+/** Row fields the free-text search box looks at. */
+const GRID_SEARCH_FIELDS = ["label", "cityId", "providerLabel"];
 
 /** Default sort: alphabetical, so the page opens as a browsable index. */
 const GRID_DEFAULT_SORT = { key: "label", dir: "asc" };
@@ -41,6 +247,10 @@ const GRID_DEFAULT_SORT = { key: "label", dir: "asc" };
  * @returns {Object} Row model.
  */
 function gridRowModel(city) {
+  // Grid geometry, published from aggregate v3 onward and null on older
+  // records (and on v1/v2, which will never gain it).
+  const width = city.grid?.width_meters ?? null;
+  const height = city.grid?.height_meters ?? null;
   return {
     cityId: city.city_id ?? "",
     label: city.city_id ? cityDisplayLabel(city) : "Unknown",
@@ -52,9 +262,22 @@ function gridRowModel(city) {
     pctAny: city.any_imagery_coverage_rate_percent ?? null,
     medianAge: city.pano_age_stats?.median_pano_age_years ?? null,
     panos: city.pano_count ?? null,
+    searchPoints: city.total_search_points ?? null,
+    gridWidthM: width,
+    gridStepM: city.grid?.step_length_meters ?? null,
+    // Rendered form of the extent; the column sorts on gridWidthM because a
+    // "40 × 40 km" string sorts lexically, which is meaningless.
+    gridSpanLabel:
+      width == null || height == null
+        ? null
+        : `${formatCellNumber(width / 1000, 1)} × ${formatCellNumber(height / 1000, 1)} km`,
+    areaKm2: city.search_area_km2 ?? null,
     collected: city.latest_run_date ?? null,
     snapshots: (city.runs ?? []).length || null,
     filename: city.data_file?.filename ?? null,
+    // Filled in by renderGridRuns, which is the only place that can see every
+    // provider's rows at once.
+    hasBothProviders: false,
   };
 }
 
@@ -62,33 +285,39 @@ function gridRowModel(city) {
  * Build one table row from a row model.
  *
  * @param {Object} row - From gridRowModel.
+ * @param {Object[]} [columns] - Visible columns; defaults to all of them.
  * @returns {string} HTML for one <tr>.
  */
-function gridRowHtml(row) {
-  const link = row.filename
-    ? `<a class="streets-view-link"
-          href="city.html?file=${encodeURIComponent(row.filename)}">View on map</a>`
-    : `<span class="streets-no-link" title="This city has no published run to link to">—</span>`;
-
-  // City/state/country names come from OSM/Nominatim (publicly editable
-  // third-party data) — escape everything data-derived entering innerHTML.
-  return `
-    <tr>
-      <th scope="row">${escapeHtml(row.label)}</th>
-      <td>${escapeHtml(row.providerLabel)}</td>
-      ${coverageCellHtml(row.pct)}
-      ${coverageCellHtml(row.pctAny)}
-      <td>${row.medianAge == null ? "—" : `${formatCellNumber(row.medianAge, 1)} yrs`}</td>
-      <td>${formatCellNumber(row.panos)}</td>
-      <td>${escapeHtml(row.collected ?? "—")}</td>
-      <td>${formatCellNumber(row.snapshots)}</td>
-      <td>${link}</td>
-    </tr>`;
+function gridRowHtml(row, columns = GRID_COLUMNS) {
+  return rowHtmlFromColumns(columns, row);
 }
 
-// The table controller (created on first render so a header click can
-// re-sort without refetching or re-adapting).
+/**
+ * Mark the rows whose city was collected by more than one provider.
+ *
+ * The head-to-head question ("does Mapillary ever beat GSV?") is only askable
+ * on cities where both series exist, and that is a property of the row SET,
+ * not of any single row — so it is computed here rather than in gridRowModel.
+ *
+ * @param {Object[]} rows - All row models; mutated in place.
+ * @returns {Object[]} The same array, for chaining.
+ */
+function markBothProviders(rows) {
+  const providersByCity = new Map();
+  for (const row of rows) {
+    if (!providersByCity.has(row.cityId)) providersByCity.set(row.cityId, new Set());
+    providersByCity.get(row.cityId).add(row.provider);
+  }
+  for (const row of rows) {
+    row.hasBothProviders = providersByCity.get(row.cityId).size > 1;
+  }
+  return rows;
+}
+
+// The table + controls controllers (created on first render so a header click
+// or a filter change can repaint without refetching or re-adapting).
 let gridTable = null;
+let gridControls = null;
 
 /**
  * Render the table (or the empty state) from the aggregate payload.
@@ -108,6 +337,7 @@ function renderGridRuns(rawCities) {
     generatedAt ??= meta.generatedAt;
     rows.push(...cities.map(gridRowModel));
   }
+  markBothProviders(rows);
 
   if (rows.length === 0) {
     statusEl.textContent = "No city collections have been published yet.";
@@ -117,18 +347,38 @@ function renderGridRuns(rawCities) {
   gridTable ??= createSortableTable({
     columns: GRID_COLUMNS,
     defaultSort: GRID_DEFAULT_SORT,
-    wrapEl,
+    theadEl: document.getElementById("grid-thead"),
     tbodyEl: document.getElementById("grid-tbody"),
-    rowHtml: gridRowHtml,
   });
-  gridTable.setRows(rows);
-
-  document.getElementById("grid-caption").textContent =
-    `${rows.length} city grid-run series` +
-    (generatedAt ? ` · updated ${new Date(generatedAt).toLocaleString()}` : "");
+  gridControls ??= createTableControls({
+    rootEl: document.getElementById("grid-controls"),
+    table: gridTable,
+    columns: GRID_COLUMNS,
+    presets: GRID_PRESETS,
+    filters: GRID_FILTERS,
+    searchFields: GRID_SEARCH_FIELDS,
+    onChange: (shown, all) => updateGridCaption(shown, all, generatedAt),
+  });
+  gridControls.setRows(rows);
 
   statusEl.hidden = true;
   wrapEl.hidden = false;
+}
+
+/**
+ * Keep the caption reporting what is actually on screen.
+ *
+ * @param {Object[]} shown - Filtered rows.
+ * @param {Object[]} all - Every row.
+ * @param {?string} generatedAt - Aggregate timestamp.
+ */
+function updateGridCaption(shown, all, generatedAt) {
+  const counts =
+    shown.length === all.length
+      ? `${all.length} city grid-run series`
+      : `${shown.length} of ${all.length} city grid-run series`;
+  document.getElementById("grid-caption").textContent =
+    counts + (generatedAt ? ` · updated ${new Date(generatedAt).toLocaleString()}` : "");
 }
 
 /** Fetch the aggregate, then render. */
@@ -155,8 +405,13 @@ if (typeof module !== "undefined" && module.exports) {
   module.exports = {
     gridRowModel,
     gridRowHtml,
+    markBothProviders,
     renderGridRuns,
+    updateGridCaption,
     GRID_COLUMNS,
+    GRID_PRESETS,
+    GRID_FILTERS,
+    GRID_SEARCH_FIELDS,
     GRID_DEFAULT_SORT,
   };
 }

--- a/www/js/streets.js
+++ b/www/js/streets.js
@@ -19,8 +19,9 @@
  *
  * Depends on globals from streetscape-utils.js (loaded first): PROVIDERS,
  * STREETSCAPE_DATA_BASE_URL, fetchGzippedJson, fetchStreetwalkManifest,
- * adaptCitiesPayload, escapeHtml — and from table-utils.js: cityDisplayLabel,
- * sortRowsBy, formatCellNumber, coverageCellHtml, createSortableTable.
+ * adaptCitiesPayload, escapeHtml — from table-utils.js: cityDisplayLabel,
+ * sortRowsBy, formatCellNumber, coverageCellHtml, createSortableTable — and
+ * from table-controls.js: createTableControls.
  */
 
 // ── Display helpers ───────────────────────────────────────────
@@ -70,29 +71,307 @@ function indexCitiesByProvider(rawCities, providers) {
   return index;
 }
 
+/** Format a nullable number for a table cell (table-utils alias). */
+function num(value, digits = 0) {
+  return formatCellNumber(value, digits);
+}
+
 /**
- * The sortable columns, in table order. `key` is the row-model field, `type`
- * picks the comparator, and `initial` is the direction a first click applies
- * (numbers read best-first, text reads A–Z).
+ * Cell for the "since last walk" coverage delta: an em-dash for a first walk
+ * (no change block in the manifest), else a signed percentage-point figure
+ * whose title carries the comparison date and the edge churn behind it.
+ *
+ * @param {Object} row - From toRowModel.
+ * @returns {string} HTML for one <td>.
+ */
+function walkChangeCellHtml(row) {
+  if (row.changeDelta == null) return `<td>—</td>`;
+  const sign = row.changeDelta >= 0 ? "+" : "";
+  const title =
+    `Since ${row.change.from}: ${row.change.edges_gained_coverage ?? 0} streets gained ` +
+    `coverage, ${row.change.edges_lost_coverage ?? 0} lost it`;
+  return `<td title="${escapeHtml(title)}">${sign}${row.changeDelta.toFixed(1)} pp</td>`;
+}
+
+/**
+ * Cell for the "View on map" link.
+ *
+ * The link carries THIS row's network type: city.html selects the walk to draw
+ * by network type and defaults to 'drive', so without it a "Roads + paths" row
+ * would open the city's drive walk instead — or, for a city walked only
+ * broadly, fall all the way back to the grid-attribution artifact, a different
+ * metric entirely. Advertising a row the link cannot reach is worse than not
+ * listing it.
+ *
+ * @param {Object} row - From toRowModel.
+ * @returns {string} HTML for one <td>.
+ */
+function walkLinkCellHtml(row) {
+  const link = row.filename
+    ? `<a class="streets-view-link"
+          href="city.html?file=${encodeURIComponent(row.filename)}&network=${encodeURIComponent(
+        row.networkType
+      )}">View on map</a>`
+    : `<span class="streets-no-link" title="This city has no published run to link to">—</span>`;
+  return `<td>${link}</td>`;
+}
+
+/**
+ * The columns, in table order.
+ *
+ * `key` is the row-model field, `type` picks the comparator, `initial` is the
+ * direction a first click applies (numbers read best-first, text reads A–Z),
+ * and `cell(row)` renders that column's own cell — the header and the body are
+ * both generated from this list so they cannot drift (see table-utils.js).
+ *
+ * `unit`/`digits` are read by the distribution strip; `title` becomes the
+ * header tooltip (these lived in streets.html before the header became
+ * JS-rendered).
+ *
+ * City/state/country names come from OSM/Nominatim (publicly editable
+ * third-party data) — escape everything data-derived entering innerHTML.
  */
 const STREET_COLUMNS = [
-  { key: "label", label: "City", type: "text", initial: "asc" },
-  { key: "providerLabel", label: "Provider", type: "text", initial: "asc" },
+  {
+    key: "label",
+    label: "City",
+    type: "text",
+    initial: "asc",
+    always: true,
+    cell: (r) => `<th scope="row">${escapeHtml(r.label)}</th>`,
+  },
+  {
+    key: "providerLabel",
+    label: "Provider",
+    type: "text",
+    initial: "asc",
+    cell: (r) => `<td>${escapeHtml(r.providerLabel)}</td>`,
+  },
   // Which OSM network was walked. Without this column two rows for one city
   // would look like duplicates, when in fact their coverage percentages divide
   // by different street-km denominators and are not comparable.
-  { key: "networkLabel", label: "Network", type: "text", initial: "asc" },
-  { key: "runDate", label: "Walked", type: "text", initial: "desc" },
-  { key: "spacing", label: "Sample spacing", type: "number", initial: "asc" },
-  { key: "pct", label: "Street-km covered", type: "number", initial: "desc" },
-  { key: "pctAny", label: "Any imagery", type: "number", initial: "desc" },
+  {
+    key: "networkLabel",
+    label: "Network",
+    type: "text",
+    initial: "asc",
+    title:
+      "Which OSM network was walked. &quot;Roads&quot; is motorized public roads only; " +
+      "&quot;Roads + paths&quot; also covers alleys, footpaths, park trails, cycleways and " +
+      "steps. Coverage percentages are only comparable within the same network.",
+    cell: (r) => `<td>${escapeHtml(r.networkLabel)}</td>`,
+  },
+  {
+    key: "runDate",
+    label: "Walked",
+    type: "text",
+    initial: "desc",
+    cell: (r) => `<td>${escapeHtml(r.runDate ?? "—")}</td>`,
+  },
+  {
+    key: "spacing",
+    label: "Sample spacing",
+    type: "number",
+    initial: "asc",
+    unit: " m",
+    cell: (r) => `<td>${r.spacing == null ? "—" : `${num(r.spacing)} m`}</td>`,
+  },
+  {
+    key: "pct",
+    label: "360° street-km",
+    type: "number",
+    initial: "desc",
+    unit: "%",
+    title: "Share of street-km covered by 360° imagery",
+    cell: (r) => coverageCellHtml(r.pct),
+  },
+  {
+    key: "pctAny",
+    label: "Any imagery",
+    type: "number",
+    initial: "desc",
+    unit: "%",
+    title:
+      "Including flat/perspective imagery; equals the 360° number for Google Street View",
+    cell: (r) => coverageCellHtml(r.pctAny),
+  },
   // "Since last walk" coverage delta (issue #101), from the manifest's
   // optional change block. Null for first walks — most cities, until their
   // second walk lands — which the number comparator sorts to the end.
-  { key: "changeDelta", label: "Δ coverage", type: "number", initial: "desc" },
-  { key: "edges", label: "Streets", type: "number", initial: "desc" },
-  { key: "fullyCovered", label: "Fully covered", type: "number", initial: "desc" },
+  {
+    key: "changeDelta",
+    label: "Δ coverage",
+    type: "number",
+    initial: "desc",
+    unit: " pp",
+    title:
+      "Change in 360° street-km coverage since the previous walk of this city, in " +
+      "percentage points. Blank for first walks.",
+    cell: walkChangeCellHtml,
+  },
+  // Absolute street length (schema v12, issue #189). A share cannot be turned
+  // back into kilometres without its denominator — 74.5% of Corvallis is 873 km
+  // and the same 74.5% of a village is 5 km — and deployment estimates are
+  // quoted in km, not percent.
+  {
+    key: "lengthKm",
+    label: "Street km",
+    type: "number",
+    initial: "desc",
+    unit: " km",
+    digits: 1,
+    title: "Total length of the walked network, in kilometres",
+    cell: (r) => `<td>${r.lengthKm == null ? "—" : `${num(r.lengthKm, 1)} km`}</td>`,
+  },
+  {
+    key: "lengthKmCovered",
+    label: "Covered km",
+    type: "number",
+    initial: "desc",
+    unit: " km",
+    digits: 1,
+    title: "Kilometres of street covered by 360° imagery",
+    cell: (r) => `<td>${r.lengthKmCovered == null ? "—" : `${num(r.lengthKmCovered, 1)} km`}</td>`,
+  },
+  {
+    key: "lengthKmCoveredAny",
+    label: "Covered km (any)",
+    type: "number",
+    initial: "desc",
+    unit: " km",
+    digits: 1,
+    title: "Kilometres of street covered by any imagery, including flat/perspective",
+    cell: (r) =>
+      `<td>${r.lengthKmCoveredAny == null ? "—" : `${num(r.lengthKmCoveredAny, 1)} km`}</td>`,
+  },
+  {
+    key: "medianAge",
+    label: "Median age",
+    type: "number",
+    initial: "asc",
+    unit: " yrs",
+    digits: 1,
+    title:
+      "Median age of the imagery covering this walk's streets. Stored rather than " +
+      "derived — a median of the per-class medians is not the median.",
+    cell: (r) => `<td>${r.medianAge == null ? "—" : `${num(r.medianAge, 1)} yrs`}</td>`,
+  },
+  {
+    key: "edges",
+    label: "Streets",
+    type: "number",
+    initial: "desc",
+    cell: (r) => `<td>${num(r.edges)}</td>`,
+  },
+  {
+    key: "fullyCovered",
+    label: "Fully covered",
+    type: "number",
+    initial: "desc",
+    cell: (r) => `<td>${num(r.fullyCovered)}</td>`,
+  },
+  {
+    key: "actions",
+    label: "",
+    sortable: false,
+    always: true,
+    srLabel: "Link to city map",
+    cell: walkLinkCellHtml,
+  },
 ];
+
+/**
+ * Column presets. The first is the default and must fit the page's 1200px
+ * measure without horizontal scrolling — that is what these exist for.
+ */
+const STREET_PRESETS = [
+  {
+    id: "overview",
+    label: "Overview",
+    title: "The headline read: who walked what, how much of it, and how fresh",
+    // pctAny stays in the default view: the 360°-vs-any-imagery split (issue
+    // #116) is the page's headline distinction for Mapillary, not a detail to
+    // be discovered behind a preset.
+    columns: [
+      "providerLabel",
+      "networkLabel",
+      "runDate",
+      "pct",
+      "pctAny",
+      "lengthKm",
+      "medianAge",
+    ],
+  },
+  {
+    id: "kilometres",
+    label: "Kilometres",
+    title: "Absolute street length rather than shares (schema v12)",
+    columns: ["providerLabel", "pct", "pctAny", "lengthKm", "lengthKmCovered", "lengthKmCoveredAny"],
+  },
+  {
+    id: "change",
+    label: "Change",
+    title: "Walk-to-walk movement (issue #101); blank until a city's second walk lands",
+    columns: ["providerLabel", "networkLabel", "runDate", "pct", "changeDelta", "lengthKm"],
+  },
+  {
+    id: "network",
+    label: "Network",
+    title: "The shape of the walked network itself",
+    columns: ["providerLabel", "networkLabel", "spacing", "edges", "fullyCovered", "lengthKm"],
+  },
+];
+
+/** Filters offered above the table. */
+const STREET_FILTERS = [
+  {
+    key: "provider",
+    label: "Provider",
+    type: "select",
+    anyLabel: "All providers",
+    options: [
+      { value: "gsv", label: "Google Street View" },
+      { value: "mapillary", label: "Mapillary" },
+    ],
+    test: (row, value) => row.provider === value,
+  },
+  {
+    key: "network",
+    label: "Network",
+    type: "select",
+    anyLabel: "All networks",
+    options: [
+      { value: "drive", label: "Roads" },
+      { value: "all_public", label: "Roads + paths" },
+    ],
+    test: (row, value) => row.networkType === value,
+  },
+  {
+    key: "cov",
+    label: "360° street-km %",
+    type: "range",
+    field: "pct",
+    min: 0,
+    max: 100,
+  },
+  {
+    key: "km",
+    label: "Street km",
+    type: "range",
+    field: "lengthKm",
+    min: 0,
+  },
+  {
+    key: "changed",
+    label: "Has Δ coverage",
+    type: "boolean",
+    title: "Only cities walked at least twice, so a change could be computed (issue #101)",
+    test: (row) => row.changeDelta != null,
+  },
+];
+
+/** Row fields the free-text search box looks at. */
+const STREET_SEARCH_FIELDS = ["label", "cityId", "providerLabel", "networkLabel"];
 
 /** Default sort: best 360° coverage first (what the page opens on). */
 const DEFAULT_SORT = { key: "pct", dir: "desc" };
@@ -135,6 +414,16 @@ function toRowModel(walk, city, labelSource = null) {
     // for first walks, so both stay null and the cell renders an em-dash.
     change: walk.change ?? null,
     changeDelta: walk.change?.coverage_pct_by_length_delta ?? null,
+    // Absolute lengths and median covered age (schema v12). NULL on walks
+    // cataloged before v12 and not yet backfilled.
+    lengthKm: walk.length_km ?? null,
+    lengthKmCovered: walk.length_km_covered ?? null,
+    lengthKmCoveredAny: walk.length_km_covered_any ?? null,
+    medianAge: walk.median_covered_age_years ?? null,
+    // Per-highway-class breakdown, absent-not-null in the manifest. Carried on
+    // the row model for the class-level filter now and the row expansion in
+    // the follow-up PR.
+    coverageByHighway: walk.coverage_by_highway ?? null,
     edges: walk.edges ?? null,
     fullyCovered: walk.edges_fully_covered ?? null,
     filename: city?.data_file?.filename ?? null,
@@ -154,71 +443,23 @@ function sortRows(rows, key, dir = "desc") {
   return sortRowsBy(STREET_COLUMNS, rows, key, dir);
 }
 
-/** Format a nullable number for a table cell (table-utils alias). */
-function num(value, digits = 0) {
-  return formatCellNumber(value, digits);
-}
-
 // ── Rendering ─────────────────────────────────────────────────
-
-/**
- * Cell for the "since last walk" coverage delta: an em-dash for a first walk
- * (no change block in the manifest), else a signed percentage-point figure
- * whose title carries the comparison date and the edge churn behind it.
- *
- * @param {Object} row - From toRowModel.
- * @returns {string} HTML for one <td>.
- */
-function walkChangeCellHtml(row) {
-  if (row.changeDelta == null) return `<td>—</td>`;
-  const sign = row.changeDelta >= 0 ? "+" : "";
-  const title =
-    `Since ${row.change.from}: ${row.change.edges_gained_coverage ?? 0} streets gained ` +
-    `coverage, ${row.change.edges_lost_coverage ?? 0} lost it`;
-  return `<td title="${escapeHtml(title)}">${sign}${row.changeDelta.toFixed(1)} pp</td>`;
-}
 
 /**
  * Build one table row from a row model.
  *
  * @param {Object} row - From toRowModel.
+ * @param {Object[]} [columns] - Visible columns; defaults to all of them.
  * @returns {string} HTML for one <tr>.
  */
-function walkRowHtml(row) {
-  // The link carries THIS row's network type: city.html selects the walk to
-  // draw by network type and defaults to 'drive', so without it a "Roads +
-  // paths" row would open the city's drive walk instead — or, for a city walked
-  // only broadly, fall all the way back to the grid-attribution artifact, a
-  // different metric entirely. Advertising a row the link cannot reach is worse
-  // than not listing it.
-  const link = row.filename
-    ? `<a class="streets-view-link"
-          href="city.html?file=${encodeURIComponent(row.filename)}&network=${encodeURIComponent(
-        row.networkType
-      )}">View on map</a>`
-    : `<span class="streets-no-link" title="This city has no published run to link to">—</span>`;
-
-  // City/state/country names come from OSM/Nominatim (publicly editable
-  // third-party data) — escape everything data-derived entering innerHTML.
-  return `
-    <tr>
-      <th scope="row">${escapeHtml(row.label)}</th>
-      <td>${escapeHtml(row.providerLabel)}</td>
-      <td>${escapeHtml(row.networkLabel)}</td>
-      <td>${escapeHtml(row.runDate ?? "—")}</td>
-      <td>${row.spacing == null ? "—" : `${num(row.spacing)} m`}</td>
-      ${coverageCellHtml(row.pct)}
-      ${coverageCellHtml(row.pctAny)}
-      ${walkChangeCellHtml(row)}
-      <td>${num(row.edges)}</td>
-      <td>${num(row.fullyCovered)}</td>
-      <td>${link}</td>
-    </tr>`;
+function walkRowHtml(row, columns = STREET_COLUMNS) {
+  return rowHtmlFromColumns(columns, row);
 }
 
-// The table controller (created on first render so a header click can
-// re-sort without refetching or re-joining).
+// The table + controls controllers (created on first render so a header click
+// or a filter change can repaint without refetching or re-joining).
 let streetsTable = null;
+let streetsControls = null;
 
 /**
  * Render the table (or the empty state) from a manifest + aggregate.
@@ -253,20 +494,46 @@ function renderStreetWalks(manifest, rawCities) {
   streetsTable ??= createSortableTable({
     columns: STREET_COLUMNS,
     defaultSort: DEFAULT_SORT,
-    wrapEl,
+    theadEl: document.getElementById("streets-thead"),
     tbodyEl: document.getElementById("streets-tbody"),
-    rowHtml: walkRowHtml,
   });
-  streetsTable.setRows(rows);
-
-  document.getElementById("streets-caption").textContent =
-    `${walks.length} published road-walk collection${walks.length === 1 ? "" : "s"}` +
-    (manifest.generated_at
-      ? ` · manifest updated ${new Date(manifest.generated_at).toLocaleString()}`
-      : "");
+  streetsControls ??= createTableControls({
+    rootEl: document.getElementById("streets-controls"),
+    table: streetsTable,
+    columns: STREET_COLUMNS,
+    presets: STREET_PRESETS,
+    filters: STREET_FILTERS,
+    searchFields: STREET_SEARCH_FIELDS,
+    onChange: (shown, all) => updateStreetsCaption(shown, all, manifest),
+  });
+  streetsControls.setRows(rows);
 
   statusEl.hidden = true;
   wrapEl.hidden = false;
+}
+
+/**
+ * Keep the caption reporting what is actually on screen.
+ *
+ * The count is the live result count for the current filters, so it must say
+ * how many of how many — a bare "12 collections" after a filter reads as the
+ * whole dataset.
+ *
+ * @param {Object[]} shown - Filtered rows.
+ * @param {Object[]} all - Every row.
+ * @param {?Object} manifest - For the generated-at stamp.
+ */
+function updateStreetsCaption(shown, all, manifest) {
+  const noun = `road-walk collection${all.length === 1 ? "" : "s"}`;
+  const counts =
+    shown.length === all.length
+      ? `${all.length} published ${noun}`
+      : `${shown.length} of ${all.length} published ${noun}`;
+  document.getElementById("streets-caption").textContent =
+    counts +
+    (manifest?.generated_at
+      ? ` · manifest updated ${new Date(manifest.generated_at).toLocaleString()}`
+      : "");
 }
 
 // ── Data loading ──────────────────────────────────────────────
@@ -310,7 +577,11 @@ if (typeof module !== "undefined" && module.exports) {
     walkChangeCellHtml,
     walkRowHtml,
     renderStreetWalks,
+    updateStreetsCaption,
     STREET_COLUMNS,
+    STREET_PRESETS,
+    STREET_FILTERS,
+    STREET_SEARCH_FIELDS,
     DEFAULT_SORT,
   };
 }

--- a/www/js/table-controls.js
+++ b/www/js/table-controls.js
@@ -132,24 +132,31 @@ function applyFilters(rows, { filters, values, query, searchFields }) {
 /**
  * Resolve the visible column descriptors for a preset or an explicit key list.
  *
- * Explicit keys win when present (the column picker deviating from a preset).
+ * Explicit keys win whenever the picker has been touched at all — including
+ * down to zero optional columns. That is `explicitKeys` being a non-null
+ * array (possibly empty), which is distinct from `null` ("no picker
+ * deviation, use the preset"). Testing `.length > 0` instead would treat
+ * "every box unchecked" as "no override" and silently snap back to the
+ * preset's columns while the checkboxes still read unchecked.
  * Order always follows the canonical `columns` order rather than the order the
  * keys arrived in, so the table's column sequence is stable no matter how the
  * URL was assembled. Unknown keys are ignored rather than throwing: a stale
  * link from before a column was renamed should degrade, not break the page.
  *
  * Non-sortable trailing columns (the "View on map" link) are `always: true`
- * and appear in every preset.
+ * and appear in every preset — including when the picker has zeroed out
+ * every optional column.
  *
  * @param {Object[]} columns - All column descriptors.
  * @param {Object[]} presets - Preset descriptors ({id, label, columns}).
  * @param {?string} presetId
- * @param {?string[]} explicitKeys
+ * @param {?string[]} explicitKeys - `null` means "no picker override"; an
+ *   array (including `[]`) is an explicit selection.
  * @returns {Object[]} Visible descriptors, in canonical order.
  */
 function resolveVisibleColumns(columns, presets, presetId, explicitKeys) {
   let wanted;
-  if (explicitKeys && explicitKeys.length > 0) {
+  if (explicitKeys != null) {
     wanted = new Set(explicitKeys);
   } else {
     const preset = presets.find((p) => p.id === presetId) ?? presets[0];
@@ -179,7 +186,7 @@ function parseTableState(search, { filters }) {
     const raw = params.get(filter.key);
     if (raw == null || raw === "") continue;
     if (filter.type === "range") {
-      // "10-90", "10-" (min only), "-90" (max only). Bare "-" is unset.
+      // "10~90", "10~" (min only), "~90" (max only). Bare "~" is unset.
       const [minRaw, maxRaw] = raw.split("~");
       const min = Number.parseFloat(minRaw);
       const max = Number.parseFloat(maxRaw);
@@ -197,11 +204,15 @@ function parseTableState(search, { filters }) {
 
   const dir = params.get("dir");
   const sortKey = params.get("sort");
-  const colsRaw = params.get("cols");
+  // `?cols=` (present, empty) is an explicit "picker zeroed out every optional
+  // column" and must round-trip as `[]`, not fall back to `null` ("no picker
+  // override, use the preset") the way a plain falsy check on the raw string
+  // would. Presence of the param is what carries that distinction, not its
+  // content.
   return {
     query: params.get("q") ?? "",
     preset: params.get("preset"),
-    cols: colsRaw ? colsRaw.split(",").filter(Boolean) : null,
+    cols: params.has("cols") ? params.get("cols").split(",").filter(Boolean) : null,
     sort: sortKey ? { key: sortKey, dir: dir === "asc" ? "asc" : "desc" } : null,
     values,
   };
@@ -221,7 +232,11 @@ function serializeTableState(state, { filters, defaultPreset }) {
   const params = new URLSearchParams();
   if (state.query) params.set("q", state.query);
   if (state.preset && state.preset !== defaultPreset) params.set("preset", state.preset);
-  if (state.cols && state.cols.length > 0) params.set("cols", state.cols.join(","));
+  // `state.cols` is `null` for "no picker override" and an array (possibly
+  // `[]`, when every optional column has been unchecked) for an explicit
+  // selection — both must be distinguishable after a round trip, so an empty
+  // selection still writes `cols=` rather than being dropped like `null` is.
+  if (state.cols) params.set("cols", state.cols.join(","));
   if (state.sort) {
     params.set("sort", state.sort.key);
     params.set("dir", state.sort.dir);
@@ -494,12 +509,15 @@ function createTableControls({
   const defaultPreset = presets[0].id;
   let allRows = [];
   let filtered = [];
+  // No `sort` field here: the sort is owned entirely by `table` (the
+  // createSortableTable controller), read via `table.getSort()` wherever it's
+  // needed (updateUrl, repaintStrip). Duplicating it into this state object
+  // would just be a second, driftable copy of the same fact.
   const state = {
     query: "",
     preset: defaultPreset,
     cols: null,
     values: {},
-    sort: null,
   };
 
   rootEl.innerHTML = controlsHtml({ filters, presets, columns });
@@ -620,8 +638,16 @@ function createTableControls({
     if (event.target.dataset?.bound) return;
     handleControlChange(event.target);
   });
+  let rangeTimer = null;
   rootEl.addEventListener("input", (event) => {
-    if (event.target.dataset?.bound) handleControlChange(event.target);
+    if (!event.target.dataset?.bound) return;
+    // Debounced for the same reason the search box is: a range bound applies
+    // on every keystroke (see above), and on grid.html that is up to 1,501
+    // rows re-filtered and re-rendered per digit typed. handleControlChange
+    // re-reads the input's live value when the timer fires, so only the
+    // settled figure is ever applied.
+    clearTimeout(rangeTimer);
+    rangeTimer = setTimeout(() => handleControlChange(event.target), 150);
   });
 
   rootEl.querySelector(".col-reset").addEventListener("click", () => {

--- a/www/js/table-controls.js
+++ b/www/js/table-controls.js
@@ -1,0 +1,693 @@
+/**
+ * table-controls.js — the exploration chassis for the data-table pages
+ * (grid.html and streets.html), issue #188.
+ *
+ * The tables outgrew "sortable list": grid.html renders 1,501 rows and
+ * streets.html 283, and the questions being asked of them are comparative
+ * ("where does Mapillary beat GSV?", "which cities have imagery where people
+ * actually walk?") rather than lookup-by-name. This module adds the machinery
+ * that makes a large table explorable — text search, structured filters,
+ * column presets, and a distribution strip for the sorted column — and keeps
+ * the whole view in the URL so a finding can be linked to.
+ *
+ * Deliberately NOT an export tool. `cities.json.gz` and `streetwalks.json.gz`
+ * are already published as public gzipped JSON at fixed URLs, so a CSV of the
+ * on-screen view would be a lossier copy of a path that already exists; real
+ * analysis pulls from the catalog instead.
+ *
+ * Page-agnostic: everything specific to a page arrives as descriptors
+ * (`columns`, `presets`, `filters`) from grid.js / streets.js. The pure
+ * functions here are exported for the offline unit tests; only
+ * `createTableControls` touches the DOM.
+ *
+ * Depends on globals from table-utils.js (loaded first): formatCellNumber.
+ */
+
+// ── Text search ───────────────────────────────────────────────
+
+/**
+ * Fold a value for accent- and case-insensitive substring matching.
+ *
+ * `Intl.Collator` (which sortRowsBy uses for ordering) has no substring
+ * operation, so search normalizes instead: NFD splits an accented character
+ * into base + combining mark and the mark is dropped. That is what lets
+ * "avila" match "Ávila" — the worldwide frame (issue #115) means most city
+ * names in the table are not plain ASCII.
+ *
+ * @param {*} value
+ * @returns {string}
+ */
+function foldForSearch(value) {
+  if (value == null) return "";
+  return String(value)
+    .normalize("NFD")
+    .replace(/\p{Diacritic}/gu, "")
+    .toLowerCase();
+}
+
+/**
+ * Does a row match a free-text query?
+ *
+ * Every whitespace-separated term must appear in at least one of the row's
+ * search fields (AND across terms, OR across fields), so "seattle mapillary"
+ * narrows to one series rather than matching either word.
+ *
+ * @param {Object} row - A row model.
+ * @param {string[]} fields - Row fields to search.
+ * @param {string} query - Raw query text; blank matches everything.
+ * @returns {boolean}
+ */
+function matchesSearch(row, fields, query) {
+  const terms = foldForSearch(query).split(/\s+/).filter(Boolean);
+  if (terms.length === 0) return true;
+  const haystack = fields.map((f) => foldForSearch(row[f])).join(" ");
+  return terms.every((term) => haystack.includes(term));
+}
+
+// ── Structured filters ────────────────────────────────────────
+
+/**
+ * Is a filter's value "unset" (and therefore not narrowing anything)?
+ *
+ * @param {Object} filter - Filter descriptor.
+ * @param {*} value - Current value for that filter.
+ * @returns {boolean}
+ */
+function isFilterUnset(filter, value) {
+  if (value == null || value === "") return true;
+  if (filter.type === "boolean") return value !== true;
+  if (filter.type === "range") return value.min == null && value.max == null;
+  return false;
+}
+
+/**
+ * Apply one filter descriptor to a row.
+ *
+ * Range filters EXCLUDE rows whose value is null. A numeric window is a
+ * question about a measured quantity, and an unmeasured row is not a small
+ * one — the same posture sortRowsBy takes when it sinks nulls in both
+ * directions rather than treating them as zero. (A city with no median age
+ * recorded is not "0 years old".)
+ *
+ * @param {Object} filter - Filter descriptor.
+ * @param {Object} row - A row model.
+ * @param {*} value - Current value for that filter.
+ * @returns {boolean}
+ */
+function rowPassesFilter(filter, row, value) {
+  if (isFilterUnset(filter, value)) return true;
+  if (filter.type === "range") {
+    const v = row[filter.field];
+    if (v == null) return false;
+    if (value.min != null && v < value.min) return false;
+    if (value.max != null && v > value.max) return false;
+    return true;
+  }
+  if (filter.type === "boolean") return filter.test(row);
+  // select
+  return filter.test ? filter.test(row, value) : row[filter.field] === value;
+}
+
+/**
+ * Narrow rows by the free-text query and every set filter.
+ *
+ * @param {Object[]} rows - All row models.
+ * @param {Object} cfg
+ * @param {Object[]} cfg.filters - Filter descriptors.
+ * @param {Object} cfg.values - {filterKey: value}.
+ * @param {string} cfg.query - Free-text query.
+ * @param {string[]} cfg.searchFields - Row fields the query searches.
+ * @returns {Object[]} A new filtered array (input untouched).
+ */
+function applyFilters(rows, { filters, values, query, searchFields }) {
+  return rows.filter(
+    (row) =>
+      matchesSearch(row, searchFields, query ?? "") &&
+      filters.every((filter) => rowPassesFilter(filter, row, values[filter.key]))
+  );
+}
+
+// ── Column presets ────────────────────────────────────────────
+
+/**
+ * Resolve the visible column descriptors for a preset or an explicit key list.
+ *
+ * Explicit keys win when present (the column picker deviating from a preset).
+ * Order always follows the canonical `columns` order rather than the order the
+ * keys arrived in, so the table's column sequence is stable no matter how the
+ * URL was assembled. Unknown keys are ignored rather than throwing: a stale
+ * link from before a column was renamed should degrade, not break the page.
+ *
+ * Non-sortable trailing columns (the "View on map" link) are `always: true`
+ * and appear in every preset.
+ *
+ * @param {Object[]} columns - All column descriptors.
+ * @param {Object[]} presets - Preset descriptors ({id, label, columns}).
+ * @param {?string} presetId
+ * @param {?string[]} explicitKeys
+ * @returns {Object[]} Visible descriptors, in canonical order.
+ */
+function resolveVisibleColumns(columns, presets, presetId, explicitKeys) {
+  let wanted;
+  if (explicitKeys && explicitKeys.length > 0) {
+    wanted = new Set(explicitKeys);
+  } else {
+    const preset = presets.find((p) => p.id === presetId) ?? presets[0];
+    wanted = new Set(preset.columns);
+  }
+  return columns.filter((column) => column.always === true || wanted.has(column.key));
+}
+
+// ── URL round-trip ────────────────────────────────────────────
+
+/**
+ * Parse a query string into control state.
+ *
+ * Every unrecognized or malformed value falls back to the default rather than
+ * throwing — a URL is user-editable text, and a bad `?pct=` should not blank
+ * the page.
+ *
+ * @param {string} search - `location.search`.
+ * @param {{filters: Object[]}} cfg
+ * @returns {{query: string, preset: ?string, cols: ?string[],
+ *            sort: ?{key: string, dir: string}, values: Object}}
+ */
+function parseTableState(search, { filters }) {
+  const params = new URLSearchParams(search || "");
+  const values = {};
+  for (const filter of filters) {
+    const raw = params.get(filter.key);
+    if (raw == null || raw === "") continue;
+    if (filter.type === "range") {
+      // "10-90", "10-" (min only), "-90" (max only). Bare "-" is unset.
+      const [minRaw, maxRaw] = raw.split("~");
+      const min = Number.parseFloat(minRaw);
+      const max = Number.parseFloat(maxRaw);
+      const parsed = {
+        min: Number.isFinite(min) ? min : null,
+        max: Number.isFinite(max) ? max : null,
+      };
+      if (parsed.min != null || parsed.max != null) values[filter.key] = parsed;
+    } else if (filter.type === "boolean") {
+      if (raw === "1") values[filter.key] = true;
+    } else if (filter.options.some((o) => o.value === raw)) {
+      values[filter.key] = raw;
+    }
+  }
+
+  const dir = params.get("dir");
+  const sortKey = params.get("sort");
+  const colsRaw = params.get("cols");
+  return {
+    query: params.get("q") ?? "",
+    preset: params.get("preset"),
+    cols: colsRaw ? colsRaw.split(",").filter(Boolean) : null,
+    sort: sortKey ? { key: sortKey, dir: dir === "asc" ? "asc" : "desc" } : null,
+    values,
+  };
+}
+
+/**
+ * Serialize control state back into a query string.
+ *
+ * Only non-default state is written, so an untouched page keeps a clean URL
+ * and a shared link carries exactly the deviations that produced the view.
+ *
+ * @param {Object} state - {query, preset, cols, sort, values}.
+ * @param {{filters: Object[], defaultPreset: string}} cfg
+ * @returns {string} A query string WITHOUT the leading "?" (may be empty).
+ */
+function serializeTableState(state, { filters, defaultPreset }) {
+  const params = new URLSearchParams();
+  if (state.query) params.set("q", state.query);
+  if (state.preset && state.preset !== defaultPreset) params.set("preset", state.preset);
+  if (state.cols && state.cols.length > 0) params.set("cols", state.cols.join(","));
+  if (state.sort) {
+    params.set("sort", state.sort.key);
+    params.set("dir", state.sort.dir);
+  }
+  for (const filter of filters) {
+    const value = state.values[filter.key];
+    if (isFilterUnset(filter, value)) continue;
+    if (filter.type === "range") {
+      params.set(filter.key, `${value.min ?? ""}~${value.max ?? ""}`);
+    } else if (filter.type === "boolean") {
+      params.set(filter.key, "1");
+    } else {
+      params.set(filter.key, value);
+    }
+  }
+  return params.toString();
+}
+
+// ── Distribution strip ────────────────────────────────────────
+
+/**
+ * How many buckets to cut a set of N values into.
+ *
+ * The square-root rule, clamped. A fixed bucket count is wrong at both ends of
+ * this table's range: at N=2 (a heavily filtered view) 24 buckets strand two
+ * lone bars at opposite edges of an otherwise empty strip, and past ~600 the
+ * bars are thinner than the gaps between them. Production sits at 283 walks
+ * and 1,501 grid series, both of which land on the 24 cap.
+ *
+ * @param {number} n - Count of measurable values.
+ * @returns {number}
+ */
+function bucketCountFor(n) {
+  return Math.min(24, Math.max(1, Math.ceil(Math.sqrt(n))));
+}
+
+/**
+ * Bucket numeric values into a histogram.
+ *
+ * Nulls are dropped rather than bucketed as zero (see rowPassesFilter). A
+ * single distinct value yields one full-width bucket instead of a degenerate
+ * zero-width range.
+ *
+ * @param {Array<?number>} values
+ * @param {number} [bucketCount] - Defaults to bucketCountFor(N).
+ * @returns {{buckets: {from: number, to: number, count: number}[],
+ *            min: number, max: number, count: number}|null}
+ *   Null when nothing is measurable.
+ */
+function histogramBuckets(values, bucketCount) {
+  const nums = values.filter((v) => typeof v === "number" && Number.isFinite(v));
+  if (nums.length === 0) return null;
+  bucketCount = bucketCount ?? bucketCountFor(nums.length);
+  const min = Math.min(...nums);
+  const max = Math.max(...nums);
+  if (min === max) {
+    return { buckets: [{ from: min, to: max, count: nums.length }], min, max, count: nums.length };
+  }
+  const width = (max - min) / bucketCount;
+  const buckets = Array.from({ length: bucketCount }, (_, i) => ({
+    from: min + i * width,
+    to: min + (i + 1) * width,
+    count: 0,
+  }));
+  for (const value of nums) {
+    // The maximum lands in the last bucket rather than one past the end.
+    const index = Math.min(bucketCount - 1, Math.floor((value - min) / width));
+    buckets[index].count += 1;
+  }
+  return { buckets, min, max, count: nums.length };
+}
+
+/** Median of a numeric array (the strip's text summary). */
+function medianOf(values) {
+  const nums = values
+    .filter((v) => typeof v === "number" && Number.isFinite(v))
+    .sort((a, b) => a - b);
+  if (nums.length === 0) return null;
+  const mid = Math.floor(nums.length / 2);
+  return nums.length % 2 ? nums[mid] : (nums[mid - 1] + nums[mid]) / 2;
+}
+
+/**
+ * Text equivalent of the distribution strip.
+ *
+ * The bars are decorative (`aria-hidden`); this sentence carries the same
+ * information for a screen reader and doubles as the visible caption.
+ *
+ * @param {Object} column - The active sort column descriptor.
+ * @param {Array<?number>} values
+ * @returns {string}
+ */
+function formatStripSummary(column, values) {
+  const stats = histogramBuckets(values);
+  if (!stats) return `No ${column.label.toLowerCase()} values in the current view.`;
+  const unit = column.unit ?? "";
+  const fmt = (v) => `${formatCellNumber(v, column.digits ?? 1)}${unit}`;
+  return (
+    `${column.label} across ${formatCellNumber(stats.count)} rows: ` +
+    `min ${fmt(stats.min)}, median ${fmt(medianOf(values))}, max ${fmt(stats.max)}.`
+  );
+}
+
+// ── DOM wiring ────────────────────────────────────────────────
+
+/**
+ * Render the distribution strip into a container.
+ *
+ * A single-series magnitude chart, so: one flat hue for every bar (bar colour
+ * carries no second meaning), no legend, no axis furniture. The bars are
+ * deliberately NOT painted with `coverageColor` — these encode row counts, and
+ * reusing the coverage ramp here would imply the height meant coverage.
+ *
+ * @param {Element} el - Container.
+ * @param {Object} column - Active sort column descriptor.
+ * @param {Array<?number>} values
+ */
+function renderDistributionStrip(el, column, values) {
+  const stats = histogramBuckets(values);
+  const summary = formatStripSummary(column, values);
+  if (!stats || column.type !== "number") {
+    el.innerHTML = `<p class="strip-summary">${
+      column.type === "number" ? summary : "Sort by a numeric column to see its distribution."
+    }</p>`;
+    return;
+  }
+  const tallest = Math.max(...stats.buckets.map((b) => b.count));
+  const unit = column.unit ?? "";
+  const digits = column.digits ?? 1;
+  const bars = stats.buckets
+    .map((bucket) => {
+      const height = tallest === 0 ? 0 : Math.round((bucket.count / tallest) * 100);
+      const label =
+        `${formatCellNumber(bucket.from, digits)}${unit}–` +
+        `${formatCellNumber(bucket.to, digits)}${unit}: ` +
+        `${formatCellNumber(bucket.count)} row${bucket.count === 1 ? "" : "s"}`;
+      // min-height keeps a non-empty bucket visible instead of rounding it away.
+      return `<span class="strip-bar" title="${label}" style="height:${
+        bucket.count > 0 ? Math.max(height, 2) : 0
+      }%"></span>`;
+    })
+    .join("");
+  el.innerHTML =
+    `<div class="strip-bars" aria-hidden="true">${bars}</div>` +
+    `<p class="strip-summary">${summary}</p>`;
+}
+
+/**
+ * Build the controls markup for a page.
+ *
+ * Real labeled form controls throughout: the search box is a `<label>`ed
+ * `<input type="search">`, filters are `<select>`/number inputs/checkboxes,
+ * and the column picker is a `<details>` disclosure wrapping a checkbox
+ * `<fieldset>` — so the whole region is keyboard-reachable and announced
+ * without any ARIA of its own.
+ *
+ * @param {Object} cfg - {filters, presets, columns}.
+ * @returns {string} HTML.
+ */
+function controlsHtml({ filters, presets, columns }) {
+  const filterControls = filters
+    .map((filter) => {
+      if (filter.type === "select") {
+        const options = [`<option value="">${filter.anyLabel ?? "All"}</option>`]
+          .concat(filter.options.map((o) => `<option value="${o.value}">${o.label}</option>`))
+          .join("");
+        return `
+          <div class="control">
+            <label for="f-${filter.key}">${filter.label}</label>
+            <select id="f-${filter.key}" data-filter="${filter.key}">${options}</select>
+          </div>`;
+      }
+      if (filter.type === "range") {
+        return `
+          <div class="control control-range" role="group" aria-labelledby="f-${filter.key}-legend">
+            <span class="control-legend" id="f-${filter.key}-legend">${filter.label}</span>
+            <input type="number" data-filter="${filter.key}" data-bound="min"
+                   aria-label="Minimum ${filter.label}" placeholder="min"
+                   ${filter.min != null ? `min="${filter.min}"` : ""}
+                   ${filter.max != null ? `max="${filter.max}"` : ""}>
+            <span class="control-dash" aria-hidden="true">–</span>
+            <input type="number" data-filter="${filter.key}" data-bound="max"
+                   aria-label="Maximum ${filter.label}" placeholder="max"
+                   ${filter.min != null ? `min="${filter.min}"` : ""}
+                   ${filter.max != null ? `max="${filter.max}"` : ""}>
+          </div>`;
+      }
+      return `
+        <div class="control control-check">
+          <input type="checkbox" id="f-${filter.key}" data-filter="${filter.key}">
+          <label for="f-${filter.key}"${
+            filter.title ? ` title="${filter.title}"` : ""
+          }>${filter.label}</label>
+        </div>`;
+    })
+    .join("");
+
+  const presetOptions = presets
+    .map((p) => `<option value="${p.id}"${p.title ? ` title="${p.title}"` : ""}>${p.label}</option>`)
+    .join("");
+
+  const pickerBoxes = columns
+    .filter((c) => c.always !== true)
+    .map(
+      (c) => `
+        <label class="col-toggle">
+          <input type="checkbox" data-column="${c.key}"> ${c.label}
+        </label>`
+    )
+    .join("");
+
+  return `
+    <div class="table-controls">
+      <div class="control control-search">
+        <label for="table-search">Search</label>
+        <input type="search" id="table-search" placeholder="City, provider…"
+               autocomplete="off" spellcheck="false">
+      </div>
+      ${filterControls}
+      <div class="control">
+        <label for="table-preset">Columns</label>
+        <select id="table-preset">${presetOptions}</select>
+      </div>
+      <details class="col-picker">
+        <summary>Customize</summary>
+        <div class="col-panel">
+          <fieldset>
+            <legend class="visually-hidden">Columns to show</legend>
+            ${pickerBoxes}
+          </fieldset>
+          <button type="button" class="col-reset">Reset to preset</button>
+        </div>
+      </details>
+      <button type="button" class="controls-clear">Clear all</button>
+    </div>
+    <div class="distribution-strip" id="distribution-strip"></div>`;
+}
+
+/**
+ * Wire the controls region to a sortable table.
+ *
+ * Owns the filter/search/preset state, pushes the narrowed rows into the
+ * table, keeps the URL in step, and repaints the distribution strip whenever
+ * the active sort column or the filtered set changes.
+ *
+ * The URL is written with `replaceState`, not `pushState`: exploring a table is
+ * a continuous adjustment, and one history entry per keystroke would make the
+ * Back button useless. The current view is still linkable, which is the point.
+ *
+ * @param {Object} cfg
+ * @param {Element} cfg.rootEl - Container the controls render into.
+ * @param {Object} cfg.table - Controller from createSortableTable.
+ * @param {Object[]} cfg.columns - All column descriptors.
+ * @param {Object[]} cfg.presets - Preset descriptors.
+ * @param {Object[]} cfg.filters - Filter descriptors.
+ * @param {string[]} cfg.searchFields - Row fields the text query searches.
+ * @param {Function} [cfg.onChange] - Called with the filtered rows after every
+ *   change, for the page's caption/result count.
+ * @returns {{setRows: Function, getFilteredRows: Function}}
+ */
+function createTableControls({
+  rootEl,
+  table,
+  columns,
+  presets,
+  filters,
+  searchFields,
+  onChange,
+}) {
+  const defaultPreset = presets[0].id;
+  let allRows = [];
+  let filtered = [];
+  const state = {
+    query: "",
+    preset: defaultPreset,
+    cols: null,
+    values: {},
+    sort: null,
+  };
+
+  rootEl.innerHTML = controlsHtml({ filters, presets, columns });
+  const searchEl = rootEl.querySelector("#table-search");
+  const presetEl = rootEl.querySelector("#table-preset");
+  const stripEl = rootEl.querySelector("#distribution-strip");
+
+  // ── state → DOM ──
+  function syncControlsToState() {
+    searchEl.value = state.query;
+    presetEl.value = state.preset;
+    for (const filter of filters) {
+      const value = state.values[filter.key];
+      if (filter.type === "range") {
+        const [minEl, maxEl] = rootEl.querySelectorAll(`[data-filter="${filter.key}"]`);
+        minEl.value = value?.min ?? "";
+        maxEl.value = value?.max ?? "";
+      } else {
+        const el = rootEl.querySelector(`[data-filter="${filter.key}"]`);
+        if (filter.type === "boolean") el.checked = value === true;
+        else el.value = value ?? "";
+      }
+    }
+    const visibleKeys = new Set(
+      resolveVisibleColumns(columns, presets, state.preset, state.cols).map((c) => c.key)
+    );
+    for (const box of rootEl.querySelectorAll("[data-column]")) {
+      box.checked = visibleKeys.has(box.dataset.column);
+    }
+  }
+
+  function updateUrl() {
+    if (typeof history === "undefined" || !history.replaceState) return;
+    const qs = serializeTableState({ ...state, sort: table.getSort() }, { filters, defaultPreset });
+    history.replaceState(null, "", qs ? `?${qs}` : location.pathname);
+  }
+
+  function repaintStrip() {
+    const sort = table.getSort();
+    const column = columns.find((c) => c.key === sort.key);
+    if (column) renderDistributionStrip(stripEl, column, filtered.map((r) => r[column.key]));
+  }
+
+  /** Re-filter, repaint the table, the strip, and the URL. */
+  function apply() {
+    filtered = applyFilters(allRows, {
+      filters,
+      values: state.values,
+      query: state.query,
+      searchFields,
+    });
+    table.setRows(filtered);
+    repaintStrip();
+    updateUrl();
+    onChange?.(filtered, allRows);
+  }
+
+  function applyColumns() {
+    table.setColumns(resolveVisibleColumns(columns, presets, state.preset, state.cols));
+  }
+
+  // ── DOM → state ──
+  let searchTimer = null;
+  searchEl.addEventListener("input", () => {
+    // Debounced: 1,501 rows re-filter and re-render on every keystroke.
+    clearTimeout(searchTimer);
+    searchTimer = setTimeout(() => {
+      state.query = searchEl.value;
+      apply();
+    }, 150);
+  });
+
+  presetEl.addEventListener("change", () => {
+    state.preset = presetEl.value;
+    state.cols = null; // an explicit preset choice discards a picker deviation
+    applyColumns();
+    syncControlsToState();
+    repaintStrip();
+    updateUrl();
+  });
+
+  /** Fold one control's current DOM value into `state` and repaint. */
+  function handleControlChange(target) {
+    if (target.dataset?.column) {
+      state.cols = [...rootEl.querySelectorAll("[data-column]")]
+        .filter((b) => b.checked)
+        .map((b) => b.dataset.column);
+      applyColumns();
+      repaintStrip();
+      updateUrl();
+      return;
+    }
+    const key = target.dataset?.filter;
+    if (!key) return;
+    const filter = filters.find((f) => f.key === key);
+    if (filter.type === "range") {
+      const [minEl, maxEl] = rootEl.querySelectorAll(`[data-filter="${key}"]`);
+      const min = Number.parseFloat(minEl.value);
+      const max = Number.parseFloat(maxEl.value);
+      state.values[key] = {
+        min: Number.isFinite(min) ? min : null,
+        max: Number.isFinite(max) ? max : null,
+      };
+    } else if (filter.type === "boolean") {
+      state.values[key] = target.checked;
+    } else {
+      state.values[key] = target.value;
+    }
+    apply();
+  }
+
+  // Selects and checkboxes settle on "change"; a number input does not fire it
+  // until blur, which would leave a typed range bound doing nothing until the
+  // reader clicked elsewhere. Range bounds therefore apply on "input" instead,
+  // and the later "change" for the same element is skipped rather than
+  // re-running the same filter pass.
+  rootEl.addEventListener("change", (event) => {
+    if (event.target.dataset?.bound) return;
+    handleControlChange(event.target);
+  });
+  rootEl.addEventListener("input", (event) => {
+    if (event.target.dataset?.bound) handleControlChange(event.target);
+  });
+
+  rootEl.querySelector(".col-reset").addEventListener("click", () => {
+    state.cols = null;
+    applyColumns();
+    syncControlsToState();
+    repaintStrip();
+    updateUrl();
+  });
+
+  rootEl.querySelector(".controls-clear").addEventListener("click", () => {
+    state.query = "";
+    state.values = {};
+    state.preset = defaultPreset;
+    state.cols = null;
+    applyColumns();
+    syncControlsToState();
+    apply();
+  });
+
+  // A header click re-sorts inside the table controller, which knows nothing
+  // about the URL or the strip — so listen on the same thead and follow up.
+  table.onSortChange?.(() => {
+    repaintStrip();
+    updateUrl();
+  });
+
+  return {
+    /** Seed or replace the full row set (called once the data has loaded). */
+    setRows(rows) {
+      allRows = rows;
+      const parsed = parseTableState(
+        typeof location !== "undefined" ? location.search : "",
+        { filters }
+      );
+      state.query = parsed.query;
+      state.preset = presets.some((p) => p.id === parsed.preset) ? parsed.preset : defaultPreset;
+      state.cols = parsed.cols;
+      state.values = parsed.values;
+      applyColumns();
+      if (parsed.sort) table.setSortTo(parsed.sort.key, parsed.sort.dir);
+      syncControlsToState();
+      apply();
+    },
+    getFilteredRows: () => filtered,
+  };
+}
+
+// Node/CommonJS export shim for the unit tests. No-op in the browser, where
+// these are plain globals loaded via <script>.
+if (typeof module !== "undefined" && module.exports) {
+  module.exports = {
+    foldForSearch,
+    matchesSearch,
+    isFilterUnset,
+    rowPassesFilter,
+    applyFilters,
+    resolveVisibleColumns,
+    parseTableState,
+    serializeTableState,
+    bucketCountFor,
+    histogramBuckets,
+    medianOf,
+    formatStripSummary,
+    renderDistributionStrip,
+    controlsHtml,
+    createTableControls,
+  };
+}

--- a/www/js/table-utils.js
+++ b/www/js/table-utils.js
@@ -7,6 +7,14 @@
  * these helpers emit (.coverage-cell, .streets-view-link, …) predate the
  * extraction and are shared by both pages via data-table.css.
  *
+ * Column descriptors are the single source of truth for BOTH the header and
+ * the body (issue #188). A descriptor carries its `label`/`title` (so the
+ * header can be rendered from JS once presets make the visible set dynamic)
+ * and a `cell(row)` function (so a column that is not in the header cannot
+ * emit a body cell). Before #188 the `<thead>` was hand-authored in each HTML
+ * file and the row renderers emitted a matching, hand-maintained sequence of
+ * `<td>`s — two parallel lists that a column change had to update in step.
+ *
  * Depends on globals from streetscape-utils.js (loaded first): coverageColor.
  */
 
@@ -78,48 +86,107 @@ function coverageCellHtml(pct) {
 }
 
 /**
- * Wire a sortable table: paints the tbody for the active sort, keeps
- * `aria-sort` and the ▲/▼ glyph in step on the headers, and re-sorts on
- * header-button clicks. A new column starts at its natural direction
- * (numbers best-first, text A–Z); clicking the active column reverses it.
+ * Header cell for one column descriptor.
  *
  * `aria-sort` on the <th> is what a screen reader announces; the ▲/▼ glyph is
  * decorative and hidden from the accessibility tree so the column is not read
- * as "City ▲".
+ * as "City ▲". The <button> is what carries the click and the keyboard focus —
+ * a click handler on a bare <th> is unreachable by keyboard.
+ *
+ * Labels and titles are code constants, not data, so they are interpolated
+ * unescaped — unlike anything row-derived, which is OSM/Nominatim content and
+ * is escaped at the point it enters innerHTML.
+ *
+ * @param {Object} column - Column descriptor.
+ * @param {{key: string, dir: string}} activeSort
+ * @returns {string} HTML for one <th>.
+ */
+function headerCellHtml(column, activeSort) {
+  // The trailing link column has nothing to sort and no visible label; it
+  // still needs a header cell so the column count matches the body rows.
+  if (column.sortable === false) {
+    return `<th scope="col"><span class="visually-hidden">${column.srLabel ?? ""}</span></th>`;
+  }
+  const isActive = column.key === activeSort.key;
+  const ariaSort = isActive ? (activeSort.dir === "asc" ? "ascending" : "descending") : "none";
+  const arrow = isActive ? (activeSort.dir === "asc" ? "▲" : "▼") : "";
+  const title = column.title ? ` title="${column.title}"` : "";
+  return `
+    <th scope="col" data-key="${column.key}" aria-sort="${ariaSort}">
+      <button type="button"${title}>${column.label} <span class="sort-arrow" aria-hidden="true">${arrow}</span></button>
+    </th>`;
+}
+
+/**
+ * Build one body row from the visible columns.
+ *
+ * Each descriptor's `cell(row)` returns its own complete cell — normally a
+ * <td>, but the first column returns a <th scope="row"> so the row has a
+ * header. Rendering from the same list the header came from is what keeps the
+ * two in step when a preset changes the visible set.
+ *
+ * @param {Object[]} columns - Visible column descriptors.
+ * @param {Object} row - A row model.
+ * @returns {string} HTML for one <tr>.
+ */
+function rowHtmlFromColumns(columns, row) {
+  return `<tr>${columns.map((column) => column.cell(row)).join("")}</tr>`;
+}
+
+/**
+ * Wire a sortable table: renders the header and body for the active sort and
+ * the active column set, and re-sorts on header clicks.
+ *
+ * The click listener is DELEGATED to the <thead> element rather than bound to
+ * each <th>'s button. The thead's innerHTML is replaced whenever the visible
+ * columns change, which destroys any per-button listeners bound at
+ * construction — delegation survives because the thead element itself is never
+ * replaced.
  *
  * @param {{columns: Object[], defaultSort: {key: string, dir: string},
- *          wrapEl: Element, tbodyEl: Element,
- *          rowHtml: (row: Object) => string}} cfg
- * @returns {{setRows: (rows: Object[]) => void, setSort: (key: string) => void,
- *            render: () => void}}
+ *          theadEl: Element, tbodyEl: Element, tieKey?: string}} cfg
+ *   `columns` is the initially visible set; change it later with setColumns.
+ * @returns {{setRows: Function, setSort: Function, setColumns: Function,
+ *            getSort: Function, getColumns: Function, render: Function}}
  */
-function createSortableTable({ columns, defaultSort, wrapEl, tbodyEl, rowHtml }) {
+function createSortableTable({ columns, defaultSort, theadEl, tbodyEl, tieKey = "cityId" }) {
   let rows = [];
+  let visible = [...columns];
   let activeSort = { ...defaultSort };
+  const sortListeners = [];
 
   function render() {
-    tbodyEl.innerHTML = sortRowsBy(columns, rows, activeSort.key, activeSort.dir)
-      .map(rowHtml)
+    theadEl.innerHTML = `<tr>${visible
+      .map((column) => headerCellHtml(column, activeSort))
+      .join("")}</tr>`;
+    tbodyEl.innerHTML = sortRowsBy(visible, rows, activeSort.key, activeSort.dir, tieKey)
+      .map((row) => rowHtmlFromColumns(visible, row))
       .join("");
-
-    for (const th of wrapEl.querySelectorAll("th[data-key]")) {
-      const isActive = th.dataset.key === activeSort.key;
-      th.setAttribute(
-        "aria-sort",
-        isActive ? (activeSort.dir === "asc" ? "ascending" : "descending") : "none"
-      );
-      const arrow = th.querySelector(".sort-arrow");
-      if (arrow) arrow.textContent = isActive ? (activeSort.dir === "asc" ? "▲" : "▼") : "";
-    }
   }
 
   function setSort(key) {
-    const column = columns.find((c) => c.key === key);
+    const column = visible.find((c) => c.key === key);
     if (!column) return;
     activeSort =
       activeSort.key === key
         ? { key, dir: activeSort.dir === "asc" ? "desc" : "asc" }
         : { key, dir: column.initial };
+    render();
+    for (const fn of sortListeners) fn(getSort());
+  }
+
+  /**
+   * Set the sort explicitly, without the click semantics (which reverse the
+   * active column). This is how a `?sort=&dir=` URL is restored: a link that
+   * says "descending" must land descending, not toggle into ascending because
+   * the page happened to open on that column.
+   *
+   * Does not notify sort listeners — the caller is the one restoring state, so
+   * echoing it straight back into the URL would be circular.
+   */
+  function setSortTo(key, dir) {
+    if (!visible.some((c) => c.key === key)) return;
+    activeSort = { key, dir: dir === "asc" ? "asc" : "desc" };
     render();
   }
 
@@ -128,11 +195,54 @@ function createSortableTable({ columns, defaultSort, wrapEl, tbodyEl, rowHtml })
     render();
   }
 
-  for (const th of wrapEl.querySelectorAll("th[data-key]")) {
-    th.querySelector("button")?.addEventListener("click", () => setSort(th.dataset.key));
+  /**
+   * Swap the visible column set (a preset change, or the column picker).
+   *
+   * If the active sort column is dropped from the view, sorting falls back to
+   * the first sortable column rather than silently sorting by a column the
+   * reader can no longer see.
+   */
+  function setColumns(next) {
+    visible = [...next];
+    if (!visible.some((c) => c.key === activeSort.key)) {
+      const fallback = visible.find((c) => c.sortable !== false);
+      if (fallback) activeSort = { key: fallback.key, dir: fallback.initial };
+    }
+    render();
   }
 
-  return { setRows, setSort, render };
+  function getSort() {
+    return { ...activeSort };
+  }
+
+  /**
+   * Subscribe to sort changes made through the header.
+   *
+   * The table controller deliberately knows nothing about the URL or the
+   * distribution strip; table-controls.js registers here to keep both in step
+   * with a header click.
+   *
+   * @param {(sort: {key: string, dir: string}) => void} fn
+   */
+  function onSortChange(fn) {
+    sortListeners.push(fn);
+  }
+
+  theadEl.addEventListener("click", (event) => {
+    const th = event.target.closest?.("th[data-key]");
+    if (th?.dataset?.key) setSort(th.dataset.key);
+  });
+
+  return {
+    setRows,
+    setSort,
+    setSortTo,
+    setColumns,
+    render,
+    getSort,
+    onSortChange,
+    getColumns: () => [...visible],
+  };
 }
 
 // Node/CommonJS export shim for the unit tests. No-op in the browser, where
@@ -143,6 +253,8 @@ if (typeof module !== "undefined" && module.exports) {
     sortRowsBy,
     formatCellNumber,
     coverageCellHtml,
+    headerCellHtml,
+    rowHtmlFromColumns,
     createSortableTable,
   };
 }

--- a/www/streets.html
+++ b/www/streets.html
@@ -61,8 +61,11 @@
         so cities appear here as they are walked and are refreshed each cycle.
         Google Street View costs one metadata request per sample point (a large
         city runs to a few hundred thousand), while Mapillary is derived from
-        its vector-tile census — so Mapillary cities fill in faster. Sort any
-        column by clicking its header.
+        its vector-tile census — so Mapillary cities fill in faster.
+        Search, filter and re-sort to narrow the table; the strip below the
+        controls shows how the sorted column is distributed across the rows
+        currently in view, and the address bar always carries the view you are
+        looking at so it can be shared.
       </p>
     </div>
 
@@ -70,52 +73,20 @@
       Loading street-level collections…
     </div>
 
+    <!-- Search, filters, column preset/picker and the distribution strip are
+         rendered into this container by table-controls.js once the data has
+         loaded (issue #188). -->
+    <div id="streets-controls" class="controls-region"></div>
+
     <div id="streets-table-wrap" class="streets-table-wrap" hidden>
       <table class="streets-table">
         <caption id="streets-caption"></caption>
-        <!-- Sortable headers: the <button> is what carries the click and the
-             keyboard focus (a bare click handler on <th> is unreachable by
-             keyboard); streets.js keeps aria-sort in step with the active
-             column. The ▲/▼ glyph is decorative, hence aria-hidden. -->
-        <thead>
-          <tr>
-            <th scope="col" data-key="label" aria-sort="none">
-              <button type="button">City <span class="sort-arrow" aria-hidden="true"></span></button>
-            </th>
-            <th scope="col" data-key="providerLabel" aria-sort="none">
-              <button type="button">Provider <span class="sort-arrow" aria-hidden="true"></span></button>
-            </th>
-            <th scope="col" data-key="networkLabel" aria-sort="none">
-              <button type="button" title="Which OSM network was walked. &quot;Roads&quot; is motorized public roads only; &quot;Roads + paths&quot; also covers alleys, footpaths, park trails, cycleways and steps. Coverage percentages are only comparable within the same network.">
-                Network <span class="sort-arrow" aria-hidden="true"></span></button>
-            </th>
-            <th scope="col" data-key="runDate" aria-sort="none">
-              <button type="button">Walked <span class="sort-arrow" aria-hidden="true"></span></button>
-            </th>
-            <th scope="col" data-key="spacing" aria-sort="none">
-              <button type="button">Sample spacing <span class="sort-arrow" aria-hidden="true"></span></button>
-            </th>
-            <th scope="col" data-key="pct" aria-sort="none">
-              <button type="button" title="Share of street-km covered by 360° imagery">
-                360° street-km <span class="sort-arrow" aria-hidden="true"></span></button>
-            </th>
-            <th scope="col" data-key="pctAny" aria-sort="none">
-              <button type="button" title="Including flat/perspective imagery; equals the 360° number for Google Street View">
-                Any imagery <span class="sort-arrow" aria-hidden="true"></span></button>
-            </th>
-            <th scope="col" data-key="changeDelta" aria-sort="none">
-              <button type="button" title="Change in 360° street-km coverage since the previous walk of this city, in percentage points. Blank for first walks.">
-                Δ coverage <span class="sort-arrow" aria-hidden="true"></span></button>
-            </th>
-            <th scope="col" data-key="edges" aria-sort="none">
-              <button type="button">Streets <span class="sort-arrow" aria-hidden="true"></span></button>
-            </th>
-            <th scope="col" data-key="fullyCovered" aria-sort="none">
-              <button type="button">Fully covered <span class="sort-arrow" aria-hidden="true"></span></button>
-            </th>
-            <th scope="col"><span class="visually-hidden">Link to city map</span></th>
-          </tr>
-        </thead>
+        <!-- Header cells are rendered by table-utils.js from the page's column
+             descriptors (STREETS_COLUMNS), not authored here: column presets
+             change the visible set at runtime, so the header and the body have
+             to come from one list or they drift. Sorting is delegated from this
+             element, which is why it survives a re-render. -->
+        <thead id="streets-thead"></thead>
         <tbody id="streets-tbody"></tbody>
       </table>
     </div>
@@ -127,6 +98,7 @@
           crossorigin="anonymous"></script>
   <script src="js/streetscape-utils.js"></script>
   <script src="js/table-utils.js"></script>
+  <script src="js/table-controls.js"></script>
   <script src="js/streets.js"></script>
 </body>
 </html>

--- a/www/streets.html
+++ b/www/streets.html
@@ -82,7 +82,7 @@
       <table class="streets-table">
         <caption id="streets-caption"></caption>
         <!-- Header cells are rendered by table-utils.js from the page's column
-             descriptors (STREETS_COLUMNS), not authored here: column presets
+             descriptors (STREET_COLUMNS), not authored here: column presets
              change the visible set at runtime, so the header and the body have
              to come from one list or they drift. Sorting is delegated from this
              element, which is why it survives a re-render. -->


### PR DESCRIPTION
First of two PRs for #188. The backend half (#189, schema v12) is merged and published the figures this needs; it changed no UI. This is the frontend half.

## Why

`grid.html` renders 1,501 rows and `streets.html` 283, both as unfiltered sortable lists that scroll sideways. At that size an alphabetical list is not browsable, and the comparative questions the pages exist to answer — where does Mapillary beat GSV, is there imagery where pedestrians actually walk — can't be asked of them at all.

**Deferred to PR 2:** provider-comparison pivot, per-highway-class row expansion (with the #97 bearing caveat inline), computed takeaways strip, methods/citation block.

## What changed

**Column descriptors are now the single source of truth for the header and the body.** Previously the `<thead>` was hand-authored in each HTML file and the row renderers emitted a matching hand-maintained sequence of `<td>`s — two parallel lists that a column change had to update in step, misaligning every row if it didn't. A descriptor now carries its own label, header tooltip and `cell(row)` renderer. That inversion is what makes runtime-variable columns possible.

**The sort listener is delegated to the `<thead>`,** not bound per button. A preset change replaces the thead's innerHTML, which destroys construction-time listeners and leaves headers that look clickable and aren't. Covered by both a unit test and an e2e test, since the failure is invisible until the page is opened in a browser.

**`table-controls.js`** — the new chassis: accent-folded text search (the worldwide frame put non-ASCII names in the table), select/range/boolean filters, column presets plus a picker, and a distribution strip.

- Range filters **exclude** rows with no measured value — the same posture `sortRowsBy` takes sinking nulls in both directions. An unmeasured city is absent, not zero.
- Range bounds apply on `input`, not `change`, or a typed bound does nothing until the reader clicks elsewhere.
- The whole view round-trips through the URL via `replaceState` (not `pushState` — one history entry per keystroke would make Back useless). Parsing is total: a stale or hand-edited URL degrades to defaults rather than blanking the page.

**Distribution strip** — a histogram of the *active sort column* over the *currently filtered* rows, so it describes what you've selected rather than the whole table. Single series, so one flat hue, no legend, no axis furniture — deliberately not the `coverageColor` ramp, which would imply bar height meant coverage rather than row count. Bucket count follows the square-root rule; a fixed 24 strands two lone bars at the edges of a filtered view.

## One decision worth flagging

**CSV export is dropped** from #188's original plan. `cities.json.gz` and `streetwalks.json.gz` are already public gzipped JSON at fixed URLs, so a CSV of the on-screen view would be a lossier duplicate of an existing public path — and pulling from the catalog on makelab2 gets the real thing rather than the trimmed manifest. The pages are an exploration tool, not an export tool.

## No horizontal scroll

Default presets are sized to the 1200px measure, asserted at 1440px against both the document and the table's own scroll container (which keeps `overflow-x` as a narrow-viewport safety net, not as the desktop layout). Fitting it needed the coverage cell's `min-width` trimmed 140px → 128px. The streets Overview preset keeps **Any imagery** — the 360°-vs-any split (#116) is the page's headline distinction for Mapillary, not something to hide behind a preset.

## Verification

Against the committed e2e fixture, which already carries every v12 field:

- **212** frontend unit tests, **27** browser e2e tests, lint clean
- New e2e coverage: a filter narrowing the rendered rows, a shared URL reproducing the view cold, the sorted column falling back when a preset drops it, the picker adding/dropping columns, the strip tracking both sort and filter, and both pages staying within their measure
- Backend suite untouched and green (356)
- Both pages rendered and visually checked in headless Chromium

🤖 Generated with [Claude Code](https://claude.com/claude-code) — Opus 5 (1M context), claude-opus-5[1m]