### PR TITLE
Link flat-only markers to their Mapillary image (issue #116)

### DIFF
--- a/www/js/city.js
+++ b/www/js/city.js
@@ -1261,6 +1261,43 @@ function buildPopupHtml(captureDate, ageFormatted, panoId, photographer) {
 }
 
 /**
+ * Build a popup HTML string for a flat-only marker (issue #116).
+ *
+ * A FLAT_ONLY row is a presence marker: the grid point has flat/perspective
+ * imagery but no 360° pano. It carries the nearest flat image's id and
+ * copyright, but its capture_date is deliberately null — flat timestamps are
+ * kept out of every dated-stat path — so this popup shows no date or age.
+ * The image itself is still viewable, and `viewerUrl` takes any image key,
+ * pano or flat, so the deep-link works unchanged.
+ *
+ * Falls back to the bare explanation when the row carries no image id (every
+ * FLAT_ONLY row written to date does, but a link to nowhere is worse than none).
+ *
+ * @param {string} panoId - Mapillary image id, possibly empty.
+ * @param {string} photographer - Mapillary contributor credit, possibly empty.
+ * @returns {string} HTML string.
+ */
+function buildFlatOnlyPopupHtml(panoId, photographer) {
+  const provider = PROVIDERS[providerGlobal];
+  const note = "Flat imagery only — no 360° panorama here";
+  if (!panoId) return `<div style="font-family:sans-serif">${note}</div>`;
+  // photographer and panoId are third-party content straight from the CSV —
+  // both must be escaped before entering popup HTML (cf. buildPopupHtml).
+  return `
+    <div style="font-family:sans-serif">
+      ${note}<br><br>
+      ${photographer ? `<strong>Photographer:</strong> ${escapeHtml(photographer)}<br>` : ""}
+      <strong>Image ID:</strong> ${escapeHtml(panoId)}<br><br>
+      <a href="${provider.viewerUrl(panoId)}"
+         target="_blank" rel="noopener"
+         style="color:#2196F3;text-decoration:none">
+         ${provider.viewerLabel}
+      </a>
+    </div>
+  `;
+}
+
+/**
  * Load, decompress, and parse the CSV data file for the target city.
  *
  * Uses a native browser streaming pipeline to avoid V8's string-length
@@ -1498,7 +1535,8 @@ async function loadData() {
             weight: 0,
             fillOpacity: 0.55,
           });
-          flatMarker.bindPopup("Flat imagery only — no 360° panorama here");
+          flatMarker.bindPopup(
+            buildFlatOnlyPopupHtml(row.pano_id, row.copyright_info));
           flatOnlyMarkers.push(flatMarker);
           if (showFlatOnly) flatMarker.addTo(map);
           continue;


### PR DESCRIPTION
## What

A `FLAT_ONLY` marker's popup was a dead end — the bare string *"Flat imagery only — no 360° panorama here"*, with no way to reach the image it marks.

For a city like Addis Ababa (collected 2026-08-12) that is most of the street-level imagery there is: **36,140 flat-only points against 6,306 with a 360° pano, and zero official `© Google` panos** — Google has never driven Addis. So the layer was pointing at the only imagery available and offering no way to look at it.

| | before | after |
|---|---|---|
| popup | bare note | note + contributor + image ID + **View in Mapillary** |

## How

The row already carries everything a link needs. `FLAT_ONLY` is a presence marker holding the *nearest flat image*, so `pano_id` and `copyright_info` are populated — verified across Addis Ababa's 36,140 and Tel Aviv's 23,985 flat-only rows, **none missing**. And `PROVIDERS.mapillary.viewerUrl()` already builds the deep-link (`pKey` takes any image key, flat or pano), so no new plumbing.

`buildFlatOnlyPopupHtml()` mirrors `buildPopupHtml()` minus the date and age lines: a `FLAT_ONLY` row's `capture_date` is deliberately null, since #116 keeps flat timestamps out of every dated-stat path. It falls back to the bare note when `pano_id` is empty (a link to nowhere is worse than no link) and escapes both third-party fields on the way in.

## Testing

- `npm run lint` clean, `npm test` 214/214 pass
- Manually verified against the published Addis Mapillary run, serving the edited JS locally against live data

**Not covered by a node test.** `city.js` has no `module.exports` and executes top-level browser code (`window.location.search` at load), so making it requirable is a refactor rather than a test addition — unlike `street-coverage.js`, which already has the export guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code) — Opus 5 (1M context), claude-opus-5[1m]