### PR TITLE
Ignore Claude Code's per-machine files at the repo level

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,12 @@ __pycache__/
 # /archive/ — the publish rsync only walks data/, so nothing here can reach the
 # public web server. Inside the project root so CSE IT's snapshots cover it.
 /backups/
+# Claude Code. settings.json is shared project config and IS tracked (team
+# settings: permissions, hooks); the local override and worktree metadata are
+# per-machine. Claude Code normally protects settings.local.json by adding it
+# to the GLOBAL git excludes file (~/.config/git/ignore) on the machine where
+# it first writes one — which does not travel with the repo, so a checkout on
+# another host (makelab2 has no global excludes at all) would see it as an
+# ordinary untracked file and sweep it into a `git add -A`.
+.claude/settings.local.json
+.claude/worktrees/


### PR DESCRIPTION
Follow-up to #194, where a `git add -A` swept an untracked `.claude/settings.json` into an unrelated PR. The file itself is fine to keep — per [Claude Code's settings docs](https://code.claude.com/docs/en/settings), `.claude/settings.json` is *"for settings that are checked into source control and shared with your team"*. What the accident exposed is that the file which must **not** be committed had no repo-level protection.

### The gap

`.claude/settings.local.json` (personal overrides, 15 KB of accumulated permission rules here) was safe on this laptop only because of a **global** git excludes entry. The docs explain where that comes from:

> When Claude Code saves a setting to this file in a repository that doesn't already ignore it, Claude Code adds `**/.claude/settings.local.json` to your global git excludes file. […] If you create the file by hand or have Claude write it with the Write tool, add it to your gitignore yourself.

Global excludes are per-machine and don't travel with the repo. **makelab2 has no global excludes file at all** (`core.excludesFile` unset, no `~/.config/git/ignore`) and its checkout does have a `.claude/` directory — so there, the same `git add -A` would have committed the personal file to a public repo.

### The change

Two entries plus a comment explaining why the global-excludes default isn't enough:

```gitignore
.claude/settings.local.json
.claude/worktrees/
```

`.claude/settings.json` stays tracked, which is the documented intent.

### Verified

Rules checked with the global excludes explicitly disabled, so the test reflects a fresh machine rather than this one:

```
$ git -c core.excludesfile=/dev/null check-ignore -v .claude/settings.local.json .claude/worktrees/.DS_Store
.gitignore:47:.claude/settings.local.json    .claude/settings.local.json
.gitignore:48:.claude/worktrees/             .claude/worktrees/.DS_Store

$ git -c core.excludesfile=/dev/null check-ignore .claude/settings.json
(no match — stays tracked)

$ git -c core.excludesfile=/dev/null add -An .
add '.gitignore'
```

Also confirmed while looking: no credential-shaped file has ever been committed to this repo (`.env*` has been ignored throughout, and the only history hit for secret-ish paths is `tests/test_credential_redaction.py`), and the local settings file contains no secret-shaped values — only permission rules.

Docs-and-config only; no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code) — Opus 5 (1M context), claude-opus-5[1m]
