### PR TITLE
Interactive strip, city links, and layout fixes from live testing (#188 follow-up)

### DIFF
--- a/tests/e2e/test_smoke.py
+++ b/tests/e2e/test_smoke.py
@@ -474,13 +474,20 @@ def test_streets_page_lists_published_road_walks(page: Page, base_url):
     # row's own network type, so the city page draws the walk the row advertises
     # rather than defaulting to 'drive' (these fixtures ARE drive walks, hence
     # the explicit token even though it matches the default).
-    expect(alpha_row.locator("a.streets-view-link")).to_have_attribute(
-        "href", f"city.html?file={ALPHA_LATEST}&network=drive"
-    )
+    link = alpha_row.locator("a.streets-view-link")
+    expect(link).to_have_attribute("href", f"city.html?file={ALPHA_LATEST}&network=drive")
+    # The link lives on the row's own name cell now (issue #188 follow-up: the
+    # separate "View on map" column was folded in) — a whole trailing column
+    # existed only to carry the one link every row already has a natural home
+    # for. There is no longer a dedicated actions/link header, and every row
+    # with a published run links out through its own <th>.
+    expect(link).to_have_text("Alpha City, Alphastate, Testland")
+    expect(page.locator("th[scope='row'] a.streets-view-link")).to_have_count(2)
+    expect(page.locator("thead").get_by_text("Link to city map")).to_have_count(0)
     expect(page.locator("#streets-caption")).to_contain_text("2 published road-walk collections")
 
     # And it actually lands on the city page with the overlay.
-    alpha_row.locator("a.streets-view-link").click()
+    link.click()
     page.wait_for_url(f"**/city.html?file={ALPHA_LATEST}&network=drive")
     expect(page.locator("#street-coverage-container")).to_be_visible()
 
@@ -615,10 +622,13 @@ def test_grid_page_lists_city_runs(page: Page, base_url):
     expect(rows.nth(1)).to_contain_text("Map Ville")
     expect(rows.nth(2)).to_contain_text("Zero City")
 
-    # Rows link to the city page via the latest run filename.
+    # Rows link to the city page via the latest run filename, from the row's
+    # own name cell — there is no separate "View on map" column (issue #188
+    # follow-up: folded into City, the one place every row already has).
     expect(rows.first.locator("a.streets-view-link")).to_have_attribute(
         "href", f"city.html?file={ALPHA_LATEST}"
     )
+    expect(page.locator("thead").get_by_text("Link to city map")).to_have_count(0)
     expect(page.locator("#grid-caption")).to_contain_text("3 city grid-run series")
 
     # A header click re-sorts (grid coverage, best first: the 0-pano city sinks).
@@ -878,8 +888,10 @@ def test_unchecking_every_optional_column_actually_empties_the_table(page: Page,
     """Regression: resolveVisibleColumns used to treat an explicit "every box
     unchecked" selection the same as "no picker override" and silently kept
     rendering the preset's columns while the checkboxes read unchecked. Only
-    the always-on columns (City, the link) should survive unchecking
-    everything, and a reload of the resulting link must reproduce that."""
+    the always-on City column (which also carries the row's link, since the
+    separate "View on map" column was folded into it) should survive
+    unchecking everything, and a reload of the resulting link must reproduce
+    that."""
     errors = _capture_errors(page)
     page.goto(f"{base_url}/grid.html")
 
@@ -889,8 +901,8 @@ def test_unchecking_every_optional_column_actually_empties_the_table(page: Page,
     for i in range(count):
         boxes.nth(i).uncheck()
 
-    # Only the two always-on columns remain: City and the trailing link.
-    expect(page.locator("#grid-thead th")).to_have_count(2)
+    # Only the one always-on column remains: City.
+    expect(page.locator("#grid-thead th")).to_have_count(1)
     expect(page.locator('th[data-key="providerLabel"]')).to_have_count(0)
     for i in range(count):
         expect(boxes.nth(i)).not_to_be_checked()
@@ -902,7 +914,7 @@ def test_unchecking_every_optional_column_actually_empties_the_table(page: Page,
     # ...and reloading it cold reproduces the same empty-but-not-default view,
     # rather than snapping back to the preset's columns.
     page.goto(reload_url)
-    expect(page.locator("#grid-thead th")).to_have_count(2)
+    expect(page.locator("#grid-thead th")).to_have_count(1)
     page.locator(".col-picker summary").click()
     for i in range(page.locator("input[data-column]").count()):
         expect(page.locator("input[data-column]").nth(i)).not_to_be_checked()
@@ -927,6 +939,85 @@ def test_distribution_strip_describes_the_sorted_column(page: Page, base_url):
     # Filtering repoints it at the narrowed set.
     page.locator('select[data-filter="provider"]').select_option("gsv")
     expect(summary).to_contain_text("across 1 rows")
+
+    assert errors == []
+
+
+def test_distribution_strip_bars_are_clickable_when_a_matching_filter_exists(page: Page, base_url):
+    """A bucket becomes a real, focusable <button> exactly when the active sort
+    column has a matching range filter, and clicking it sets that filter to the
+    bucket's bounds — both narrowing the table and populating the min/max
+    inputs, not just one or the other."""
+    errors = _capture_errors(page)
+    page.goto(f"{base_url}/streets.html")
+
+    # Default sort is 360° street-km % (pct), which the "cov" range filter
+    # matches, so the strip's two buckets (Alpha City ~85%, Map Ville 0%) are
+    # clickable — spans on any other page would not be.
+    bars = page.locator("#distribution-strip .strip-bar")
+    expect(bars).to_have_count(2)
+    assert page.evaluate("() => document.querySelector('.strip-bar').tagName") == "BUTTON"
+
+    # The higher bucket covers Alpha City's ~85% (two buckets split the 0-85.1%
+    # range at its midpoint, not at wherever the values actually cluster, so
+    # the exact bound is a data-shape detail — read it off the button rather
+    # than hardcoding it). The DOM is rebuilt on click, so read data-from/-to
+    # before clicking rather than off a now-stale locator afterward.
+    last_bar = bars.last
+    expected_min = last_bar.get_attribute("data-from")
+    expected_max = last_bar.get_attribute("data-to")
+    last_bar.click()
+
+    rows = page.locator("#streets-tbody tr")
+    expect(rows).to_have_count(1)
+    expect(rows.first).to_contain_text("Alpha City")
+    min_val = page.locator('input[data-filter="cov"][data-bound="min"]').input_value()
+    max_val = page.locator('input[data-filter="cov"][data-bound="max"]').input_value()
+    assert min_val == expected_min, (
+        f"expected the min bound to match the clicked bucket's data-from "
+        f"({expected_min!r}), got {min_val!r}"
+    )
+    assert max_val == expected_max, (
+        f"expected the max bound to match the clicked bucket's data-to "
+        f"({expected_max!r}), got {max_val!r}"
+    )
+
+    assert errors == []
+
+
+def test_distribution_strip_bars_are_inert_without_a_matching_filter(page: Page, base_url):
+    """Sorting by a column with no matching range filter (e.g. Median age has
+    none on streets.html) must not offer a click that goes nowhere."""
+    errors = _capture_errors(page)
+    page.goto(f"{base_url}/streets.html")
+
+    page.locator('th[data-key="medianAge"] button').click()
+    assert page.evaluate("() => document.querySelector('.strip-bar').tagName") == "SPAN"
+    expect(page.locator("#distribution-strip .strip-bars")).to_have_attribute("aria-hidden", "true")
+
+    assert errors == []
+
+
+@pytest.mark.parametrize("path", ["grid.html", "streets.html"])
+def test_city_name_cell_is_truncated_not_left_to_overflow(page: Page, base_url, path):
+    """The committed fixture's city names are short ("Alpha City"), so this
+    can't observe an actual ellipsis firing — it instead confirms the CSS rule
+    that handles the real worldwide-frame names (60+ chars, issue #115) is
+    actually wired onto the live cell, not just sitting unused in the
+    stylesheet. Regression: this column used to have no width limit at all, so
+    a single long production label could push the whole table into horizontal
+    scroll even though the short-named fixture never triggered it."""
+    errors = _capture_errors(page)
+    page.goto(f"{base_url}/{path}")
+    cell = page.locator("tbody th[scope='row']").first
+    expect(cell).to_be_visible()
+    style = cell.evaluate(
+        "el => { const s = getComputedStyle(el); "
+        "return {maxWidth: s.maxWidth, overflow: s.overflow, textOverflow: s.textOverflow}; }"
+    )
+    assert style["maxWidth"] not in ("none", ""), "city-name cell has no max-width set"
+    assert style["overflow"] == "hidden"
+    assert style["textOverflow"] == "ellipsis"
 
     assert errors == []
 

--- a/www/css/data-table.css
+++ b/www/css/data-table.css
@@ -130,6 +130,18 @@
 
 .streets-table tbody th {
   font-weight: bold;
+  /* The row label ("City, State, Country") comes from OSM/Nominatim and is
+     unbounded — the worldwide frame (issue #115) put labels in the table up
+     to 60+ characters ("Stara Pazova Municipality, Srem Administrative
+     District, Serbia"). Left to `white-space: nowrap` alone (see the shared
+     th/td rule above) a label that long single-handedly pushes the table past
+     its 1200px measure; the committed e2e fixture never catches this because
+     its synthetic city names are short. Truncate with an ellipsis instead and
+     carry the untruncated name in `title` (set alongside the cell markup) so
+     it's still available on hover/long-press. */
+  max-width: 220px;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .streets-table tbody tr:hover {
@@ -161,6 +173,12 @@
   position: relative;
 }
 
+/* The city-name link (issue #188 follow-up: absorbed the old separate "View
+   on map" column — every row already has one natural place for its one
+   link). Bold like the row header it lives inside, colored to still read as
+   a link. A row with nothing to link to just renders the plain label — no
+   dedicated "unlinked" styling needed since it isn't a distinct column
+   anymore. */
 .streets-view-link {
   color: #1a6b1d;
   text-decoration: none;
@@ -170,10 +188,6 @@
 .streets-view-link:hover,
 .streets-view-link:focus-visible {
   text-decoration: underline;
-}
-
-.streets-no-link {
-  color: #999;
 }
 
 /* ── Exploration controls (issue #188) ─────────────────────────────────────
@@ -360,6 +374,30 @@
   min-width: 2px;
   background: #6c8ba0; /* 3.6:1 on the white surface — above the 3:1 floor */
   border-radius: 2px 2px 0 0; /* rounded data-end, anchored to the baseline */
+  /* Reset browser <button> chrome (border/padding/font/background) — a bar is
+     a <button> exactly when its bucket is clickable (renderDistributionStrip
+     emits a plain, non-interactive <span> otherwise), and these are no-ops on
+     a <span>, so one rule covers both without a tag selector. */
+  display: block;
+  border: 0;
+  padding: 0;
+  font: inherit;
+  appearance: none;
+}
+
+/* Only a <button> (a clickable bucket) gets pointer affordance and
+   interaction states; the plain <span> case has nothing to hover into. */
+button.strip-bar {
+  cursor: pointer;
+}
+
+button.strip-bar:hover {
+  background: #557089;
+}
+
+button.strip-bar:focus-visible {
+  outline: 2px solid #1a73e8;
+  outline-offset: 1px;
 }
 
 .strip-summary {

--- a/www/js/__tests__/grid.test.js
+++ b/www/js/__tests__/grid.test.js
@@ -103,6 +103,14 @@ test("gridRowHtml: one cell per column, linking to city.html", () => {
   assert.match(html, /3\.4 yrs/);
 });
 
+test("gridRowHtml: the label cell carries its full text as a title, for ellipsis truncation", () => {
+  // OSM/Nominatim labels are unbounded (issue #115's worldwide names run 60+
+  // chars); the CSS truncates the cell with an ellipsis, so the untruncated
+  // name needs to survive on hover via `title`.
+  const html = gridRowHtml(gridRowModel(SEATTLE));
+  assert.match(html, /<th scope="row" title="Seattle, Washington, United States">/);
+});
+
 test("gridRowHtml: null stats render em dashes and no link", () => {
   const html = gridRowHtml(gridRowModel({ provider: "gsv", city_id: "x--y", city: "X" }));
   assert.match(html, /—/);

--- a/www/js/__tests__/streets.test.js
+++ b/www/js/__tests__/streets.test.js
@@ -341,6 +341,19 @@ test("walkRowHtml: city names are HTML-escaped (OSM data is publicly editable)",
   assert.match(html, /&lt;script&gt;/);
 });
 
+test("walkRowHtml: the label cell carries its full text as a title, for ellipsis truncation", () => {
+  // Worldwide-frame labels (issue #115) run 60+ chars; the CSS truncates the
+  // cell with an ellipsis, so the untruncated name needs to survive on hover.
+  const html = walkRowHtml(
+    toRowModel(SEATTLE_WALK, {
+      city: "Seattle",
+      state: { name: "Washington" },
+      country: { name: "United States" },
+    })
+  );
+  assert.match(html, /<th scope="row" title="Seattle, Washington, United States">/);
+});
+
 // --- walkChangeCellHtml (issue #101) ---------------------------------------
 
 const CHANGE_BLOCK = {

--- a/www/js/__tests__/table-controls.test.js
+++ b/www/js/__tests__/table-controls.test.js
@@ -26,6 +26,7 @@ const {
   histogramBuckets,
   medianOf,
   formatStripSummary,
+  renderDistributionStrip,
   controlsHtml,
 } = require("../table-controls.js");
 
@@ -305,6 +306,36 @@ test("formatStripSummary: carries min/median/max as text for screen readers", ()
 test("formatStripSummary: says so plainly when the filtered view has no values", () => {
   const column = { key: "pct", label: "Grid coverage", type: "number" };
   assert.match(formatStripSummary(column, [null, null]), /No grid coverage values/);
+});
+
+// --- renderDistributionStrip (clickable bars) --------------------------------
+
+const STRIP_EL = () => ({ innerHTML: "" });
+const STRIP_COLUMN = { key: "pct", label: "Coverage", type: "number", unit: "%", digits: 1 };
+
+test("renderDistributionStrip: plain, non-interactive spans when the caller passes no filter", () => {
+  const el = STRIP_EL();
+  renderDistributionStrip(el, STRIP_COLUMN, [10, 50, 90]);
+  assert.match(el.innerHTML, /<div class="strip-bars" aria-hidden="true">/);
+  assert.match(el.innerHTML, /<span class="strip-bar"/);
+  assert.doesNotMatch(el.innerHTML, /<button/);
+});
+
+test("renderDistributionStrip: clickable buttons carrying rounded bounds when a matching filter exists", () => {
+  const el = STRIP_EL();
+  renderDistributionStrip(el, STRIP_COLUMN, [10, 50, 90], true);
+  // No aria-hidden on the container once its bars are real, focusable buttons.
+  assert.doesNotMatch(el.innerHTML, /aria-hidden="true"/);
+  assert.match(el.innerHTML, /<button type="button" class="strip-bar" data-from="[\d.]+" data-to="[\d.]+"/);
+  assert.match(el.innerHTML, /click to filter to this range/);
+});
+
+test("renderDistributionStrip: a non-numeric or empty column never renders buttons, even if asked", () => {
+  // clickable=true from a stale sort state must not produce a strip with
+  // nothing behind it to filter.
+  const el = STRIP_EL();
+  renderDistributionStrip(el, { key: "label", label: "City", type: "text" }, [], true);
+  assert.doesNotMatch(el.innerHTML, /<button/);
 });
 
 // --- controls markup --------------------------------------------------------

--- a/www/js/grid.js
+++ b/www/js/grid.js
@@ -16,17 +16,28 @@
  */
 
 /**
- * Cell for the "View on map" link.
+ * Cell for the "City" column: the label, hyperlinked to the city page when
+ * this row has a published run to link to.
+ *
+ * Absorbs the "View on map" link — a follow-up to issue #188. A whole extra
+ * trailing column existed only to carry one link per row, when every row
+ * already has exactly one natural place for it: its own name. A row with
+ * nothing to link to (no published run) still renders, just as plain text —
+ * the same degrade-not-disappear posture the old placeholder cell had.
+ *
+ * `title` carries the full, untruncated label either way — the cell itself is
+ * ellipsis-truncated in CSS (data-table.css) because OSM/Nominatim labels are
+ * unbounded and a long one alone can push the table past its measure.
  *
  * @param {Object} row - From gridRowModel.
- * @returns {string} HTML for one <td>.
+ * @returns {string} HTML for one <th scope="row">.
  */
-function gridLinkCellHtml(row) {
-  const link = row.filename
-    ? `<a class="streets-view-link"
-          href="city.html?file=${encodeURIComponent(row.filename)}">View on map</a>`
-    : `<span class="streets-no-link" title="This city has no published run to link to">—</span>`;
-  return `<td>${link}</td>`;
+function gridLabelCellHtml(row) {
+  const label = escapeHtml(row.label);
+  const content = row.filename
+    ? `<a class="streets-view-link" href="city.html?file=${encodeURIComponent(row.filename)}">${label}</a>`
+    : label;
+  return `<th scope="row" title="${label}">${content}</th>`;
 }
 
 /**
@@ -51,7 +62,7 @@ const GRID_COLUMNS = [
     type: "text",
     initial: "asc",
     always: true,
-    cell: (r) => `<th scope="row">${escapeHtml(r.label)}</th>`,
+    cell: gridLabelCellHtml,
   },
   {
     key: "providerLabel",
@@ -158,14 +169,6 @@ const GRID_COLUMNS = [
     initial: "desc",
     title: "Number of dated collection runs; repeat runs enable change tracking over time",
     cell: (r) => `<td>${formatCellNumber(r.snapshots)}</td>`,
-  },
-  {
-    key: "actions",
-    label: "",
-    sortable: false,
-    always: true,
-    srLabel: "Link to city map",
-    cell: gridLinkCellHtml,
   },
 ];
 

--- a/www/js/streets.js
+++ b/www/js/streets.js
@@ -94,7 +94,14 @@ function walkChangeCellHtml(row) {
 }
 
 /**
- * Cell for the "View on map" link.
+ * Cell for the "City" column: the label, hyperlinked to the city page when
+ * this row has a published run to link to.
+ *
+ * Absorbs the "View on map" link — a follow-up to issue #188. A whole extra
+ * trailing column existed only to carry one link per row, when every row
+ * already has exactly one natural place for it: its own name. A row with
+ * nothing to link to (no published run) still renders, just as plain text —
+ * the same degrade-not-disappear posture the old placeholder cell had.
  *
  * The link carries THIS row's network type: city.html selects the walk to draw
  * by network type and defaults to 'drive', so without it a "Roads + paths" row
@@ -103,17 +110,22 @@ function walkChangeCellHtml(row) {
  * metric entirely. Advertising a row the link cannot reach is worse than not
  * listing it.
  *
+ * `title` carries the full, untruncated label either way — the cell itself is
+ * ellipsis-truncated in CSS (data-table.css) because OSM/Nominatim labels are
+ * unbounded and a long one alone can push the table past its measure.
+ *
  * @param {Object} row - From toRowModel.
- * @returns {string} HTML for one <td>.
+ * @returns {string} HTML for one <th scope="row">.
  */
-function walkLinkCellHtml(row) {
-  const link = row.filename
+function walkLabelCellHtml(row) {
+  const label = escapeHtml(row.label);
+  const content = row.filename
     ? `<a class="streets-view-link"
           href="city.html?file=${encodeURIComponent(row.filename)}&network=${encodeURIComponent(
         row.networkType
-      )}">View on map</a>`
-    : `<span class="streets-no-link" title="This city has no published run to link to">—</span>`;
-  return `<td>${link}</td>`;
+      )}">${label}</a>`
+    : label;
+  return `<th scope="row" title="${label}">${content}</th>`;
 }
 
 /**
@@ -138,7 +150,7 @@ const STREET_COLUMNS = [
     type: "text",
     initial: "asc",
     always: true,
-    cell: (r) => `<th scope="row">${escapeHtml(r.label)}</th>`,
+    cell: walkLabelCellHtml,
   },
   {
     key: "providerLabel",
@@ -269,14 +281,6 @@ const STREET_COLUMNS = [
     type: "number",
     initial: "desc",
     cell: (r) => `<td>${num(r.fullyCovered)}</td>`,
-  },
-  {
-    key: "actions",
-    label: "",
-    sortable: false,
-    always: true,
-    srLabel: "Link to city map",
-    cell: walkLinkCellHtml,
   },
 ];
 

--- a/www/js/table-controls.js
+++ b/www/js/table-controls.js
@@ -143,9 +143,9 @@ function applyFilters(rows, { filters, values, query, searchFields }) {
  * URL was assembled. Unknown keys are ignored rather than throwing: a stale
  * link from before a column was renamed should degrade, not break the page.
  *
- * Non-sortable trailing columns (the "View on map" link) are `always: true`
- * and appear in every preset — including when the picker has zeroed out
- * every optional column.
+ * Structural columns — currently just City, which also carries the row's
+ * link out to the city page — are `always: true` and appear in every preset,
+ * including when the picker has zeroed out every optional column.
  *
  * @param {Object[]} columns - All column descriptors.
  * @param {Object[]} presets - Preset descriptors ({id, label, columns}).
@@ -350,11 +350,22 @@ function formatStripSummary(column, values) {
  * deliberately NOT painted with `coverageColor` — these encode row counts, and
  * reusing the coverage ramp here would imply the height meant coverage.
  *
+ * When the active sort column has a matching range filter, each bucket
+ * becomes a real `<button>` carrying its bounds in `data-from`/`data-to` —
+ * `createTableControls` delegates a click listener to the container (bars are
+ * rebuilt on every repaint, so a per-bar listener would need re-binding every
+ * time; delegation on the container survives the innerHTML replacement, the
+ * same reason the header's sort click is delegated to the `<thead>`). Without
+ * a matching filter the bars stay plain, `aria-hidden` `<span>`s exactly as
+ * before — there is nothing a click on them could narrow.
+ *
  * @param {Element} el - Container.
  * @param {Object} column - Active sort column descriptor.
  * @param {Array<?number>} values
+ * @param {boolean} [clickable] - Whether the active sort column has a range
+ *   filter a bar click can set.
  */
-function renderDistributionStrip(el, column, values) {
+function renderDistributionStrip(el, column, values, clickable = false) {
   const stats = histogramBuckets(values);
   const summary = formatStripSummary(column, values);
   if (!stats || column.type !== "number") {
@@ -366,21 +377,31 @@ function renderDistributionStrip(el, column, values) {
   const tallest = Math.max(...stats.buckets.map((b) => b.count));
   const unit = column.unit ?? "";
   const digits = column.digits ?? 1;
+  // Bucket bounds are rounded to the column's own display precision before
+  // being used anywhere — as the label text AND as the value a click writes
+  // into the filter — so a bar's tooltip and the range it actually selects
+  // always agree (rather than a label reading "58.7%" while the click quietly
+  // filters to the unrounded 58.6987…%).
+  const roundToDigits = (v) => Math.round(v * 10 ** digits) / 10 ** digits;
   const bars = stats.buckets
     .map((bucket) => {
       const height = tallest === 0 ? 0 : Math.round((bucket.count / tallest) * 100);
+      const from = roundToDigits(bucket.from);
+      const to = roundToDigits(bucket.to);
       const label =
-        `${formatCellNumber(bucket.from, digits)}${unit}–` +
-        `${formatCellNumber(bucket.to, digits)}${unit}: ` +
-        `${formatCellNumber(bucket.count)} row${bucket.count === 1 ? "" : "s"}`;
+        `${formatCellNumber(from, digits)}${unit}–${formatCellNumber(to, digits)}${unit}: ` +
+        `${formatCellNumber(bucket.count)} row${bucket.count === 1 ? "" : "s"}` +
+        (clickable ? " — click to filter to this range" : "");
       // min-height keeps a non-empty bucket visible instead of rounding it away.
-      return `<span class="strip-bar" title="${label}" style="height:${
-        bucket.count > 0 ? Math.max(height, 2) : 0
-      }%"></span>`;
+      const heightPct = bucket.count > 0 ? Math.max(height, 2) : 0;
+      return clickable
+        ? `<button type="button" class="strip-bar" data-from="${from}" data-to="${to}"
+                   title="${label}" aria-label="${label}" style="height:${heightPct}%"></button>`
+        : `<span class="strip-bar" title="${label}" style="height:${heightPct}%"></span>`;
     })
     .join("");
   el.innerHTML =
-    `<div class="strip-bars" aria-hidden="true">${bars}</div>` +
+    `<div class="strip-bars"${clickable ? "" : ' aria-hidden="true"'}>${bars}</div>` +
     `<p class="strip-summary">${summary}</p>`;
 }
 
@@ -555,10 +576,22 @@ function createTableControls({
     history.replaceState(null, "", qs ? `?${qs}` : location.pathname);
   }
 
+  /** The range filter a click on the strip's bars would set, if any. */
+  function rangeFilterFor(column) {
+    return filters.find((f) => f.type === "range" && f.field === column.key);
+  }
+
   function repaintStrip() {
     const sort = table.getSort();
     const column = columns.find((c) => c.key === sort.key);
-    if (column) renderDistributionStrip(stripEl, column, filtered.map((r) => r[column.key]));
+    if (column) {
+      renderDistributionStrip(
+        stripEl,
+        column,
+        filtered.map((r) => r[column.key]),
+        Boolean(rangeFilterFor(column))
+      );
+    }
   }
 
   /** Re-filter, repaint the table, the strip, and the URL. */
@@ -648,6 +681,30 @@ function createTableControls({
     // settled figure is ever applied.
     clearTimeout(rangeTimer);
     rangeTimer = setTimeout(() => handleControlChange(event.target), 150);
+  });
+
+  // Distribution strip: a bar click sets the range filter matching the
+  // ACTIVE SORT COLUMN to that bucket's bounds (renderDistributionStrip only
+  // emits <button>s, rather than the plain aria-hidden <span>s, when such a
+  // filter exists — so a stray click elsewhere in the strip's whitespace is
+  // simply not on a `.strip-bar[data-from]` and no-ops here). Delegated on
+  // the container rather than bound per-bar: repaintStrip replaces the strip's
+  // innerHTML on every sort/filter change, which would silently drop a
+  // per-button listener the same way an un-delegated header click would (see
+  // createSortableTable's own listener for that exact regression).
+  stripEl.addEventListener("click", (event) => {
+    const bar = event.target.closest?.(".strip-bar[data-from]");
+    if (!bar) return;
+    const sort = table.getSort();
+    const column = columns.find((c) => c.key === sort.key);
+    const filter = column && rangeFilterFor(column);
+    if (!filter) return;
+    state.values[filter.key] = {
+      min: Number.parseFloat(bar.dataset.from),
+      max: Number.parseFloat(bar.dataset.to),
+    };
+    syncControlsToState();
+    apply();
   });
 
   rootEl.querySelector(".col-reset").addEventListener("click", () => {

--- a/www/js/table-utils.js
+++ b/www/js/table-utils.js
@@ -102,8 +102,9 @@ function coverageCellHtml(pct) {
  * @returns {string} HTML for one <th>.
  */
 function headerCellHtml(column, activeSort) {
-  // The trailing link column has nothing to sort and no visible label; it
-  // still needs a header cell so the column count matches the body rows.
+  // A non-sortable column (none currently defined, but the mechanism stays
+  // general) still needs a header cell so the column count matches the body
+  // rows, even with nothing to sort and no visible label.
   if (column.sortable === false) {
     return `<th scope="col"><span class="visually-hidden">${column.srLabel ?? ""}</span></th>`;
   }


### PR DESCRIPTION
Follow-up to #191, from live testing on prod after that PR shipped:

- **Distribution strip bars are now clickable** when the active sort
  column has a matching range filter: a click sets that filter to the
  bucket's bounds and narrows the table. Bars for a column with no
  matching filter stay the plain, non-interactive `<span>`s they were
  before — nothing to click into.

- **City name is now the row's link out** to `city.html` (when a
  published run exists), folding in what was a separate trailing
  "View on map" column. One fewer column, one natural home for the one
  link every row already had.

- **Fixed a real horizontal-scroll regression**: the committed e2e
  fixture uses short synthetic city names, so the layout-overflow test
  never exercised the real worldwide-frame labels (some 60+ characters,
  e.g. "Stara Pazova Municipality, Srem Administrative District,
  Serbia"). Long labels are now ellipsis-truncated with the full name
  in `title`.

212 → 219 frontend unit tests, plus new/updated e2e coverage for the
strip click, the folded-in city link, and the truncation CSS actually
being wired onto the live cell (not just present in the stylesheet).
Lint clean.

Also: the street-km columns being blank on prod (a separate,
data-side issue — 363 walks predating schema v12) is already fixed
and live, via `scripts/backfill_streetwalk_length.py --execute` +
`regenerate-aggregate --publish`, run directly on makelab1.

🤖 Generated with [Claude Code](https://claude.com/claude-code) — Sonnet 5, claude-sonnet-5