### PR TITLE
Ignore virtualenvs and the uv toolchain (public-repo hygiene)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,12 @@ __pycache__/
 # ordinary untracked file and sweep it into a `git add -A`.
 .claude/settings.local.json
 .claude/worktrees/
+# Virtualenvs and the uv toolchain. Python's `venv` writes a self-ignoring
+# `.venv/.gitignore` containing `*`, which is why this repo got away without an
+# entry — but that protection lives INSIDE the venv, so it is absent from any
+# env created another way. On makelab2 the checkout's `.venv/` has no such file,
+# and `git add -A` there would have staged 7,362 files into this public repo.
+# Cover every variant, since the production interpreter is `.venv-makelab2/`.
+.venv/
+.venv-*/
+.tooling/


### PR DESCRIPTION
Found while verifying #195 on makelab2. The `.claude` fix was the small version of this problem; this is the large one.

### What's wrong

`.gitignore` has never contained a `.venv` entry. That has been harmless so far only by accident: Python's `venv` module writes a **self-ignoring `.venv/.gitignore` containing `*`** inside the environment it creates. The protection lives *inside* the venv, so it is absent from any environment created another way.

makelab2's checkout has exactly that case — a `.venv/` with no `.gitignore`:

| path | self-protecting? |
|---|---|
| `.venv/` (makelab2) | **no** |
| `.venv-makelab2/` (the production interpreter) | yes |
| `.tooling/` (uv, uvx binaries) | **no** |
| `.venv/` (laptop) | yes |

So on the production host, `git add -A` would stage **7,362 files** into this public repo. I ran that exact command in this repo earlier today; it was safe only because I happened to be on the laptop.

### The change

```gitignore
.venv/
.venv-*/
.tooling/
```

`.venv-*/` is included deliberately: production runs `.venv-makelab2/`, and relying on its internal `.gitignore` is the same bet that just failed next door.

### Verified

```
$ git -c core.excludesfile=/dev/null check-ignore -v .venv/bin/activate .tooling/bin/uv
.gitignore:55:.venv/      .venv/bin/activate
.gitignore:57:.tooling/   .tooling/bin/uv
```

Checked with global excludes disabled so the result does not depend on any one machine's config.

### Also noticed, not changed

Two untracked operator scripts sit in makelab2's checkout root — `finish_backlog.sh` (Jul 30) and `ondemand_2026-08-12.sh` (today). Both scanned clean for key-shaped values, and they would have been swept in by the same command. They are yours to keep, move, or delete; I left them alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code) — Opus 5 (1M context), claude-opus-5[1m]