### PR TITLE
Name a Mapillary tile-CDN block instead of decoding it as a corrupt tile (#199)

### DIFF
--- a/streetscape_metadata_tracker/download_common.py
+++ b/streetscape_metadata_tracker/download_common.py
@@ -87,7 +87,18 @@ class AsyncRateLimiter:
 
 # Credential-bearing query parameters (GSV's key=, Mapillary's
 # access_token=) as they appear inside request URLs.
-_CREDENTIAL_PATTERN = re.compile(r"(?i)\b(key|access_token|token)=[^&\s'\"]+")
+#
+# The `%3f`/`%26`/`%3d` alternatives cover a URL that has been percent-encoded
+# *into another URL's query string*, which is exactly the shape a redirect's
+# Location takes: `.../login/?next=https%3A%2F%2F…%3Faccess_token%3DMLY…`
+# (issue #199). Matching only the literal `?key=` form let that through
+# unscrubbed — and unlike an ordinary log line, a Location is echoed straight
+# back from the provider with the token still in it.
+#
+# The value pattern deliberately does not stop at an encoded `&` (`%26`), so an
+# encoded URL is redacted through to its end. Over-redaction is the safe
+# direction: this text reaches logs and cleartext alert emails.
+_CREDENTIAL_PATTERN = re.compile(r"(?i)(\b|%3f|%26)(key|access_token|token)(?:=|%3d)[^&\s'\"]+")
 
 
 def redact_credentials(text: str) -> str:
@@ -101,10 +112,15 @@ def redact_credentials(text: str) -> str:
     key, and the scheduler pastes log tails into operator alert emails.
     Every log/raise of provider-HTTP error text must pass through here.
 
+    Handles the percent-encoded form too, since a redirect's Location carries
+    the request URL nested inside its own query string:
+
     >>> redact_credentials("HTTP 403 for https://x/tile?access_token=MLY123")
     'HTTP 403 for https://x/tile?access_token=REDACTED'
+    >>> redact_credentials("https://x/login/?next=https%3A%2F%2Fy%3Faccess_token%3DMLY123")
+    'https://x/login/?next=https%3A%2F%2Fy%3Faccess_token=REDACTED'
     """
-    return _CREDENTIAL_PATTERN.sub(r"\1=REDACTED", str(text))
+    return _CREDENTIAL_PATTERN.sub(r"\1\2=REDACTED", str(text))
 
 
 def grid_index_ranges(width_steps: int, height_steps: int) -> tuple[range, range]:

--- a/streetscape_metadata_tracker/download_mapillary.py
+++ b/streetscape_metadata_tracker/download_mapillary.py
@@ -347,6 +347,13 @@ MAX_FAILED_TILE_FRACTION = 0.02
 _TILE_MAX_TRIES = 5
 _TILE_MAX_TIME_S = 120
 
+# Content types that are an error page rather than a tile (issue #199). A
+# DENY-list, not an allow-list of protobuf types: if Mapillary ever relabels
+# real tiles (say `application/vnd.mapbox-vector-tile`), an allow-list would
+# reject every tile and halt all collection, whereas this only ever misreads a
+# genuine tile if one is served as HTML or JSON.
+_TILE_ERROR_CONTENT_TYPES = ("text/html", "application/json")
+
 
 @backoff.on_exception(
     backoff.expo,
@@ -357,15 +364,44 @@ _TILE_MAX_TIME_S = 120
 async def _fetch_tile(
     session: aiohttp.ClientSession, url: str, timeout: aiohttp.ClientTimeout
 ) -> bytes:
-    async with session.get(url, timeout=timeout) as response:
+    # allow_redirects=False is load-bearing (issue #199). When the tile CDN
+    # rate-limits a host it answers 302 → www.mapillary.com/login/, and aiohttp
+    # follows redirects by default — so the login page's own perfectly good HTTP
+    # 200 passed the status checks below and 58 bytes of HTML reached the
+    # protobuf decoder. A host-wide block then read as `DecodeError: Error
+    # parsing message with type 'vector_tile.tile'`, i.e. as corrupt data.
+    async with session.get(url, timeout=timeout, allow_redirects=False) as response:
         if response.status in (401, 403):
             raise DownloadError(
                 f"Mapillary rejected the access token (HTTP {response.status}). "
                 "Check MAPILLARY_ACCESS_TOKEN."
             )
+        if response.status in (301, 302, 303, 307, 308):
+            # Whole-city (indeed whole-host) condition, so DownloadError: the
+            # caller re-raises those immediately instead of counting them
+            # against MAX_FAILED_TILE_FRACTION, since every remaining tile
+            # would fail identically. Observed 2026-08-12 after sustaining
+            # ~370 tile requests/min from one IP; the ban is per-IP, so tokens
+            # and the Graph API keep working and only this host is refused.
+            # The Location echoes the request URL, hence redact_credentials.
+            location = redact_credentials(response.headers.get("Location", "(none)"))
+            raise DownloadError(
+                f"Mapillary tile CDN redirected to a login page (HTTP "
+                f"{response.status} → {location}). This host's IP is likely "
+                f"rate-limited on tiles.mapillary.com — the access token itself "
+                f"may still be valid (the Graph API and other IPs are "
+                f"unaffected). Retry later and collect Mapillary more slowly."
+            )
         if response.status != 200:
             # 429/5xx raise ClientResponseError, which backoff retries
             response.raise_for_status()
+        content_type = response.headers.get("Content-Type", "")
+        if any(bad in content_type.lower() for bad in _TILE_ERROR_CONTENT_TYPES):
+            raise DownloadError(
+                f"Mapillary served an error page instead of a vector tile "
+                f"(HTTP 200, Content-Type: {content_type}). This is usually a "
+                f"rate limit or a block on this host's IP, not a corrupt tile."
+            )
         return await response.read()
 
 

--- a/streetscape_metadata_tracker/download_mapillary.py
+++ b/streetscape_metadata_tracker/download_mapillary.py
@@ -386,11 +386,13 @@ async def _fetch_tile(
             # The Location echoes the request URL, hence redact_credentials.
             location = redact_credentials(response.headers.get("Location", "(none)"))
             raise DownloadError(
-                f"Mapillary tile CDN redirected to a login page (HTTP "
-                f"{response.status} → {location}). This host's IP is likely "
-                f"rate-limited on tiles.mapillary.com — the access token itself "
-                f"may still be valid (the Graph API and other IPs are "
-                f"unaffected). Retry later and collect Mapillary more slowly."
+                f"Mapillary tile CDN redirected instead of serving a tile (HTTP "
+                f"{response.status} → {location}). A redirect to a login page "
+                f"means this host's IP is rate-limited on tiles.mapillary.com — "
+                f"the access token itself may still be valid (the Graph API and "
+                f"other IPs are unaffected), so retry later and collect "
+                f"Mapillary more slowly. A redirect anywhere else means the tile "
+                f"endpoint has moved and this code needs updating."
             )
         if response.status != 200:
             # 429/5xx raise ClientResponseError, which backoff retries

--- a/tests/test_credential_redaction.py
+++ b/tests/test_credential_redaction.py
@@ -9,6 +9,7 @@ emailed log tail.
 """
 
 import asyncio
+import urllib.parse
 
 import aiohttp
 import pytest
@@ -26,6 +27,19 @@ def test_redact_credentials_scrubs_query_params():
         redact_credentials("https://tiles.mapillary.com/t?access_token=MLY%7Csecret%7C123")
         == "https://tiles.mapillary.com/t?access_token=REDACTED"
     )
+
+
+def test_redact_credentials_scrubs_a_url_nested_in_another_urls_query():
+    """A redirect's Location echoes the request URL percent-encoded inside its
+    own query string (issue #199), so `access_token=` arrives as
+    `access_token%3D`. Matching only the literal form let the token straight
+    through into logs and the alert email."""
+    tile = "https://tiles.mapillary.com/t/2/14/1/2?access_token=MLY%7CSECRET"
+    for encoder in (urllib.parse.quote, urllib.parse.quote_plus):
+        location = "https://www.mapillary.com/login/?next=" + encoder(tile, safe="")
+        out = redact_credentials(location)
+        assert "SECRET" not in out, out
+        assert "REDACTED" in out
 
 
 def test_redact_credentials_handles_multiple_and_mixed_case():

--- a/tests/test_mapillary.py
+++ b/tests/test_mapillary.py
@@ -833,3 +833,143 @@ def test_a_clean_run_reports_no_failed_tiles(monkeypatch, straddling_city):
     lat, lon = straddling_city
     result = _fetch_city(monkeypatch, _failing_fetch(set()), lat, lon)
     assert result["failed_tiles"] == []
+
+
+# ── Tile-CDN blocks are not tile corruption (issue #199) ───────────────────
+#
+# On 2026-08-12 a bulk collection sustained ~370 tile requests/min and got the
+# host's IP blocked: every tile request 302'd to www.mapillary.com/login/.
+# aiohttp followed the redirect, the login page returned a perfectly good HTTP
+# 200, and its HTML body reached mapbox_vector_tile.decode() — so a banned host
+# surfaced as `DecodeError: Error parsing message with type 'vector_tile.tile'`,
+# indistinguishable from #168's transient bad tile. These pin the diagnosis.
+
+# The real block page, verbatim: "尚未登录 / 请登录查看这一页面" ("Not logged in /
+# Please log in to view this page"). Meta serves it localized to unauthenticated
+# requests; the language carries no meaning here.
+_LOGIN_PAGE_BODY = (
+    b"<h1>\xe5\xb0\x9a\xe6\x9c\xaa\xe7\x99\xbb\xe5\xbd\x95</h1>"
+    b"<p>\xe8\xaf\xb7\xe7\x99\xbb\xe5\xbd\x95\xe6\x9f\xa5\xe7\x9c\x8b"
+    b"\xe8\xbf\x99\xe4\xb8\x80\xe9\xa1\xb5\xe9\x9d\xa2\xe3\x80\x82</p>"
+)
+
+_TILE_URL = "https://tiles.mapillary.com/maps/vtp/mly1_public/2/14/4196/6084?access_token=MLY|s3cret"
+
+
+class _FakeTileResponse:
+    def __init__(self, status, headers=None, body=b""):
+        self.status = status
+        self.headers = headers or {}
+        self._body = body
+
+    async def read(self):
+        return self._body
+
+
+class _FakeTileSession:
+    """Minimal aiohttp.ClientSession stand-in: .get() as an async CM."""
+
+    def __init__(self, response):
+        self._response = response
+        self.get_kwargs = []
+
+    def get(self, url, **kwargs):
+        self.get_kwargs.append(kwargs)
+        response = self._response
+
+        class _Ctx:
+            async def __aenter__(self):
+                return response
+
+            async def __aexit__(self, *exc):
+                return False
+
+        return _Ctx()
+
+
+def _fetch_tile(response):
+    session = _FakeTileSession(response)
+    with pytest.raises(DownloadError) as excinfo:
+        asyncio.run(_fetch_tile_coro(session))
+    return session, excinfo.value
+
+
+def _fetch_tile_coro(session):
+    return dm._fetch_tile(session, _TILE_URL, aiohttp.ClientTimeout(total=5))
+
+
+def test_tile_requests_do_not_follow_redirects():
+    """The fix hinges on seeing the 302 itself: if aiohttp follows it, the login
+    page's own HTTP 200 is what the status checks see."""
+    session = _FakeTileSession(_FakeTileResponse(200, {"Content-Type": "application/x-protobuf"}))
+    asyncio.run(_fetch_tile_coro(session))
+    assert session.get_kwargs[0]["allow_redirects"] is False
+
+
+def test_a_login_redirect_names_the_ip_rate_limit():
+    _, error = _fetch_tile(
+        _FakeTileResponse(
+            302,
+            {"Location": "https://www.mapillary.com/login/?next=" + _TILE_URL},
+        )
+    )
+    text = str(error)
+    assert "rate-limited" in text
+    assert "login" in text.lower()
+    # The old symptom must not be how this reads any more.
+    assert "parsing message" not in text
+
+
+def test_a_login_redirect_does_not_leak_the_token():
+    """Location echoes the request URL, token and all, and this text reaches
+    logs and the scheduler's alert emails."""
+    _, error = _fetch_tile(
+        _FakeTileResponse(
+            302,
+            {"Location": "https://www.mapillary.com/login/?next=" + _TILE_URL},
+        )
+    )
+    assert "s3cret" not in str(error)
+    assert "REDACTED" in str(error)
+
+
+def test_an_html_error_page_is_not_fed_to_the_protobuf_decoder():
+    """The 200-with-HTML case, i.e. what we would have seen had the redirect
+    been followed for us by something upstream."""
+    _, error = _fetch_tile(
+        _FakeTileResponse(
+            200, {"Content-Type": 'text/html; charset="utf-8"'}, _LOGIN_PAGE_BODY
+        )
+    )
+    assert "error page instead of a vector tile" in str(error)
+    assert "rate limit" in str(error)
+
+
+def test_an_unlabelled_tile_is_still_accepted():
+    """A deny-list, not an allow-list: if Mapillary relabels real tiles, an
+    allow-list would reject every tile and halt collection everywhere."""
+    body = mapbox_vector_tile.encode([])
+    session = _FakeTileSession(
+        _FakeTileResponse(200, {"Content-Type": "application/vnd.mapbox-vector-tile"}, body)
+    )
+    assert asyncio.run(_fetch_tile_coro(session)) == body
+
+
+def test_a_blocked_host_fails_the_city_by_name_not_as_a_partial_snapshot(monkeypatch):
+    """Like a rejected token, a block is a whole-city condition — every
+    remaining tile fails identically, so it must not be dressed up as tolerable
+    partial coverage."""
+    lat, lon = 41.8, -87.7
+
+    async def blocked(session, url, timeout):
+        raise DownloadError(
+            "Mapillary tile CDN redirected to a login page (HTTP 302 → "
+            "https://www.mapillary.com/login/?next=REDACTED). This host's IP is "
+            "likely rate-limited on tiles.mapillary.com"
+        )
+
+    with pytest.raises(DownloadError) as excinfo:
+        _fetch_city(monkeypatch, blocked, lat, lon)
+
+    assert "rate-limited" in str(excinfo.value)
+    assert "refusing to finalize" not in str(excinfo.value)

--- a/tests/test_mapillary.py
+++ b/tests/test_mapillary.py
@@ -8,6 +8,7 @@ import asyncio
 import gzip
 import math
 import re
+import urllib.parse
 from datetime import UTC, datetime
 
 import aiohttp
@@ -853,7 +854,9 @@ _LOGIN_PAGE_BODY = (
     b"\xe8\xbf\x99\xe4\xb8\x80\xe9\xa1\xb5\xe9\x9d\xa2\xe3\x80\x82</p>"
 )
 
-_TILE_URL = "https://tiles.mapillary.com/maps/vtp/mly1_public/2/14/4196/6084?access_token=MLY|s3cret"
+_TILE_URL = (
+    "https://tiles.mapillary.com/maps/vtp/mly1_public/2/14/4196/6084?access_token=MLY|s3cret"
+)
 
 
 class _FakeTileResponse:
@@ -864,6 +867,21 @@ class _FakeTileResponse:
 
     async def read(self):
         return self._body
+
+    def raise_for_status(self):
+        """As aiohttp does it — without this the fake cannot reach the 4xx/5xx
+        path at all, and a test aimed at the block checks fails with an
+        AttributeError instead of its own assertion."""
+        if self.status >= 400:
+            request_info = aiohttp.RequestInfo(
+                url=yarl.URL(_TILE_URL),
+                method="GET",
+                headers=CIMultiDictProxy(CIMultiDict()),
+                real_url=yarl.URL(_TILE_URL),
+            )
+            raise aiohttp.ClientResponseError(
+                request_info=request_info, history=(), status=self.status, message="error"
+            )
 
 
 class _FakeTileSession:
@@ -920,14 +938,24 @@ def test_a_login_redirect_names_the_ip_rate_limit():
     assert "parsing message" not in text
 
 
-def test_a_login_redirect_does_not_leak_the_token():
+@pytest.mark.parametrize(
+    "next_param",
+    [
+        _TILE_URL,
+        # The shape a real Location takes: the request URL percent-encoded into
+        # the login page's own query string. `access_token=` becomes
+        # `access_token%3D`, which the pre-#199 redaction pattern did not match
+        # at all — so the token travelled to the logs in full.
+        urllib.parse.quote(_TILE_URL, safe=""),
+        urllib.parse.quote_plus(_TILE_URL),
+    ],
+    ids=["unencoded", "quoted", "quoted_plus"],
+)
+def test_a_login_redirect_does_not_leak_the_token(next_param):
     """Location echoes the request URL, token and all, and this text reaches
     logs and the scheduler's alert emails."""
     _, error = _fetch_tile(
-        _FakeTileResponse(
-            302,
-            {"Location": "https://www.mapillary.com/login/?next=" + _TILE_URL},
-        )
+        _FakeTileResponse(302, {"Location": "https://www.mapillary.com/login/?next=" + next_param})
     )
     assert "s3cret" not in str(error)
     assert "REDACTED" in str(error)
@@ -937,12 +965,21 @@ def test_an_html_error_page_is_not_fed_to_the_protobuf_decoder():
     """The 200-with-HTML case, i.e. what we would have seen had the redirect
     been followed for us by something upstream."""
     _, error = _fetch_tile(
-        _FakeTileResponse(
-            200, {"Content-Type": 'text/html; charset="utf-8"'}, _LOGIN_PAGE_BODY
-        )
+        _FakeTileResponse(200, {"Content-Type": 'text/html; charset="utf-8"'}, _LOGIN_PAGE_BODY)
     )
     assert "error page instead of a vector tile" in str(error)
     assert "rate limit" in str(error)
+
+
+def test_a_5xx_tile_is_left_to_the_retry_layer():
+    """The new checks must not swallow the transient path. A 429/5xx is still
+    a ClientResponseError for backoff to retry and, past that, one tolerable
+    bad tile under MAX_FAILED_TILE_FRACTION (issue #168) — NOT a DownloadError,
+    which would fail the whole city. Called through __wrapped__ to skip the
+    retry sleeps."""
+    session = _FakeTileSession(_FakeTileResponse(503))
+    with pytest.raises(aiohttp.ClientResponseError):
+        asyncio.run(dm._fetch_tile.__wrapped__(session, _TILE_URL, aiohttp.ClientTimeout(total=5)))
 
 
 def test_an_unlabelled_tile_is_still_accepted():


### PR DESCRIPTION
Fixes #199.

## What was wrong

When Mapillary's tile CDN rate-limits a host it answers **302 →
`www.mapillary.com/login/`**. aiohttp follows redirects by default, so the login
page's own perfectly good **HTTP 200** passed `_fetch_tile`'s status checks and
58 bytes of HTML went to the protobuf decoder. A **host-wide IP block** thus
surfaced as:

```
DecodeError: Error parsing message with type 'vector_tile.tile'
...
DownloadError: Mapillary tile download failed: 30/64 tiles failed: ...
(46.9% > 2% tolerated); refusing to finalize an incomplete snapshot
```

That reads as corrupt data — indistinguishable from #168's transient bad tile —
and invites all the wrong hypotheses: bad token, exhausted daily quota, or
(because Meta serves the login page localized in Chinese) a DNS hijack. Ruling
that last one out took a TLS cert check.

The refusal to finalize is correct behaviour from #168. Only the diagnosis was
wrong.

## The fix

In `_fetch_tile`:

- `allow_redirects=False` — load-bearing, since seeing the 302 *is* the signal
- a 3xx raises a named `DownloadError` pointing at the likely per-IP rate limit,
  and notes the token may still be fine (the Graph API and other IPs were
  unaffected)
- a `Content-Type` **deny-list** (`text/html`, `application/json`) catches the
  200-with-HTML shape
- the `Location` header goes through `redact_credentials` — it echoes the
  request URL, token and all, and this text reaches logs and alert emails

Deny-list rather than an allow-list of protobuf types on purpose: if Mapillary
ever relabels real tiles (say `application/vnd.mapbox-vector-tile`), an
allow-list would reject every tile and halt all collection. A test pins that.

`DownloadError` is already routed as a whole-city condition by
`fetch_city_images_async` (the path #168 added for rejected tokens), so a
blocked host now fails **fast and by name** instead of burning five retries per
tile inside a 120 s backoff window on its way to a misleading message.

## Tests

Seven new test functions in the file's existing style — a minimal
`aiohttp.ClientSession` stand-in, no network — plus one in
`test_credential_redaction.py`; ten cases once the token-leak test is
parametrized over the encoded Location shapes. Four fail without the source
change. The rest are guards: one against over-strict content-type checking, one
pinning #168's whole-city routing, and one pinning that a 503 stays a retryable
`ClientResponseError` rather than becoming a whole-city `DownloadError`. Full
suite green, 791 passed.

### Review follow-up (156e8bf)

A code review found that `_CREDENTIAL_PATTERN` did not match a **percent-encoded**
`Location` — a real one nests the request URL in the login page's query string, so
`access_token=` arrives as `access_token%3D` and the token reached the logs and the
alert email in full. The original test pinned only the unencoded shape, so it passed
while the realistic shape leaked. Fixed in `download_common.py` (so every caller
benefits) and parametrized over `quote`/`quote_plus`. The same commit hedges the 3xx
message (a redirect somewhere other than a login page means the endpoint moved, not
that we are blocked) and completes `_FakeTileResponse` with `raise_for_status`.

## Provenance

Found in production on 2026-08-12 while collecting the Mapillary grid backlog:
663 cities landed, then ~370 tile requests/min got makelab2's IP blocked at a
total spend of 10,659 requests — about **21% of the 50k/day per-application cap**
we have always paced against. Both Mapillary applications were blocked at once
while the same token kept working from another IP, which is what identifies it
as per-IP. Prevention is #198; this PR only makes the failure legible.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) — Opus 5 (1M context), claude-opus-5[1m]

