### PR TITLE
Raise MemoryHigh to clear the largest city's peak (#157)

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -142,7 +142,7 @@ systemctl --user enable --now streetscape-tracker.timer
 loginctl enable-linger $USER       # user services must survive logout
 ```
 
-The service ships with resource caps (`MemoryHigh=12G`, `MemoryMax=24G`,
+The service ships with resource caps (`MemoryHigh=20G`, `MemoryMax=24G`,
 `CPUQuota=400%`, `Nice=10`, `CPUWeight=50`) so nightly collection can't starve
 the other lab services that share the box and the storage array. The memory
 numbers are measured, not guessed, and the unit file carries the measurement
@@ -155,7 +155,11 @@ invisibly.** It writes a drop-in under
 take precedence over the main unit — so a property set that way keeps winning
 after you copy a new unit over, and every later edit to that property in
 `deploy/systemd/` is silently ignored. This is not hypothetical: the 12G/24G
-caps ran on makelab2 that way from 2026-08-18 until the unit caught up. If you
+caps ran on makelab2 that way from 2026-08-18 until the unit caught up, and on
+2026-08-20 the live service still read `MemoryHigh=12G` from that drop-in while
+`deploy/systemd/` said otherwise. **Raising `MemoryHigh` in this repo therefore
+changes nothing on makelab2 until the drop-in is reverted** — the two-line
+recipe below is the whole deployment step, not a cleanup afterthought. If you
 ever use `set-property` for a live emergency, fold the value into the unit file
 afterwards and then revert the override, so the repo stays authoritative:
 

--- a/deploy/systemd/streetscape-tracker.service
+++ b/deploy/systemd/streetscape-tracker.service
@@ -135,24 +135,36 @@ ReadWritePaths=/cse/web/research/makelab/public/streetscape-tracker
 # mark, still above 4G, which is why it looked like a separate "aggregate-tail
 # hang"). That night's cgroup read MemoryPeak=4297121792 — about 2 MiB above the
 # 4G threshold, i.e. held right at it, which is what a throttled cgroup looks
-# like, not a comfortable one. 12G gives the measured tail ~2.5x headroom on top
-# of the concurrently-live census structures; 24G is the hard stop.
+# like, not a comfortable one. An interim 12G gave that measured tail ~2.5x
+# headroom on top of the concurrently-live census structures.
 #
-# KNOWN REMAINING GAP: 12G does not cover the largest cities. Peak scales at
-# ~0.914 GiB per million CSV rows (5.26M -> 4.81 GiB measured), so Detroit's
-# ~16.7M rows extrapolate to ~15.3 GiB — over MemoryHigh, under MemoryMax.
-# That matters because of WHICH cap it crosses: MemoryHigh is a throttle, not a
-# limit, so exceeding it reproduces exactly the failure diagnosed above — hours
-# of silent reclaim ending in the scheduler's 180-min city timeout — rather than
-# a fast, legible OOM kill at MemoryMax. If a big-city night hangs again with no
-# output, check MemoryPeak against 12G FIRST; the fix is a bigger MemoryHigh (or
-# no MemoryHigh at all), not a longer city timeout.
+# 12G still did not cover the largest cities, and MemoryHigh is the cap where
+# that is expensive rather than legible. Peak scales at ~0.914 GiB per million
+# CSV rows (5.26M -> 4.81 GiB measured), so Detroit's ~16.7M rows extrapolate to
+# ~15.3 GiB: over 12G, under MemoryMax. Crossing MemoryHigh reproduces exactly
+# the failure diagnosed above — hours of silent reclaim ending in the
+# scheduler's 180-min city timeout — while crossing MemoryMax is a fast OOM kill
+# you can read in a log. So MemoryHigh is 20G: the extrapolated worst city plus
+# ~30%, with a deliberately narrow 20->24 gap so a genuine runaway still reaches
+# the hard stop quickly instead of reclaiming for hours on the way there.
+#
+# Two things to keep straight about that number. It RAISES NO CEILING — the
+# limit is MemoryMax and it is unchanged; MemoryHigh only moves where we start
+# throttling ourselves, which is the one burden on this host that has actually
+# been measured (its load is ZFS; CPU sits 97-99% idle). And 15.3 GiB is an
+# EXTRAPOLATION from one city's slope, not a measurement: capture MemoryPeak on
+# a real Detroit night before treating it as settled. For scale, makelab2 has
+# 188 GiB and 48 cores (checked 2026-08-20), so 20G/24G is ~11%/~13% of the box.
+#
+# If a big-city night hangs again with no output, check MemoryPeak against
+# MemoryHigh FIRST; the fix is a bigger MemoryHigh (or no MemoryHigh at all),
+# not a longer city timeout.
 #
 # Re-validate after a live night and tune:
 #   systemctl --user show streetscape-tracker.service -p MemoryPeak -p CPUUsageNSec
 Nice=10
 MemoryAccounting=true
-MemoryHigh=12G
+MemoryHigh=20G
 MemoryMax=24G
 CPUAccounting=true
 # Hard ceiling: never use more than 4 of the host's cores.

--- a/deploy/systemd/streetscape-tracker.service
+++ b/deploy/systemd/streetscape-tracker.service
@@ -140,8 +140,10 @@ ReadWritePaths=/cse/web/research/makelab/public/streetscape-tracker
 #
 # 12G still did not cover the largest cities, and MemoryHigh is the cap where
 # that is expensive rather than legible. Peak scales at ~0.914 GiB per million
-# CSV rows (5.26M -> 4.81 GiB measured), so Detroit's ~16.7M rows extrapolate to
-# ~15.3 GiB: over 12G, under MemoryMax. Crossing MemoryHigh reproduces exactly
+# CSV rows (5.26M -> 4.81 GiB measured), and the largest census in the catalog
+# is Detroit's 16,569,307 rows (runs.total_points, mapillary, 2026-07-24), so it
+# extrapolates to 15.1 GiB — call it ~15.3 GiB, rounding a floor up rather than
+# down: over 12G, under MemoryMax. Crossing MemoryHigh reproduces exactly
 # the failure diagnosed above — hours of silent reclaim ending in the
 # scheduler's 180-min city timeout — while crossing MemoryMax is a fast OOM kill
 # you can read in a log. So MemoryHigh is 20G: the extrapolated worst city plus

--- a/deploy/systemd/streetscape-tracker.service
+++ b/deploy/systemd/streetscape-tracker.service
@@ -142,7 +142,7 @@ ReadWritePaths=/cse/web/research/makelab/public/streetscape-tracker
 # that is expensive rather than legible. Peak scales at ~0.914 GiB per million
 # CSV rows (5.26M -> 4.81 GiB measured), and the largest census in the catalog
 # is Detroit's 16,569,307 rows (runs.total_points, mapillary, 2026-07-24), so it
-# extrapolates to 15.1 GiB — call it ~15.3 GiB, rounding a floor up rather than
+# extrapolates to 15.1 — carried as ~15.3 GiB, rounding a floor up rather than
 # down: over 12G, under MemoryMax. Crossing MemoryHigh reproduces exactly
 # the failure diagnosed above — hours of silent reclaim ending in the
 # scheduler's 180-min city timeout — while crossing MemoryMax is a fast OOM kill
@@ -150,10 +150,24 @@ ReadWritePaths=/cse/web/research/makelab/public/streetscape-tracker
 # ~30%, with a deliberately narrow 20->24 gap so a genuine runaway still reaches
 # the hard stop quickly instead of reclaiming for hours on the way there.
 #
+# THE FLOOR PRICES A FIRST RUN, and Detroit's next run is not one. 15.3 GiB is
+# one census frame plus the per-run JSON tail — the shape of 2026-07-24, which
+# had no previous Mapillary run to diff against. A run that DOES have one holds
+# both frames at once by construction: cli.py hands the live new frame to
+# _compute_and_record_diff and still needs it afterwards for the per-run JSON,
+# the diff loads the previous run's CSV alongside it, and compute_run_diff then
+# builds two deduplicated copies plus a Python set of every pano_id on each side
+# (~15.3M boxed strings apiece for Detroit). Unmeasured, so no multiplier is
+# quoted here — but it is several times one frame, i.e. plausibly through
+# MemoryMax as well as MemoryHigh. That is the LEGIBLE failure by the argument
+# above, so it is not on its own a reason to move a number; it IS a reason not
+# to read "worst city plus ~30%" as covering every night. Measure a diff night
+# (the next Detroit collection is one) before sizing against it.
+#
 # Two things to keep straight about that number. It RAISES NO CEILING — the
 # limit is MemoryMax and it is unchanged; MemoryHigh only moves where we start
 # throttling ourselves, which is the one burden on this host that has actually
-# been measured (its load is ZFS; CPU sits 97-99% idle). And 15.3 GiB is an
+# been measured (its load is ZFS; CPU sits 97-99% idle). And ~15.3 GiB is an
 # EXTRAPOLATION from one city's slope, not a measurement: capture MemoryPeak on
 # a real Detroit night before treating it as settled. For scale, makelab2 has
 # 188 GiB and 48 cores (checked 2026-08-20), so 20G/24G is ~11%/~13% of the box.

--- a/streetscape_metadata_tracker/scheduler.py
+++ b/streetscape_metadata_tracker/scheduler.py
@@ -2021,8 +2021,10 @@ def _run_collection_subprocess(
     by the service account: every ``collection failed`` line in the scheduler log
     had its actual cause discarded. Redirecting to a file per attempt keeps the
     full output greppable in logs/ and streams it to disk rather than buffering a
-    multi-hour run in this process's memory (``capture_output=True`` would, on a
-    host whose cgroup is capped at MemoryHigh=4G).
+    multi-hour run in this process's memory (``capture_output=True`` would, inside
+    a cgroup whose memory is capped — see deploy/systemd/; deliberately not
+    quoting the cap here, since it has moved twice and the argument does not
+    depend on its value).
 
     The tail of a failed run is also copied into the scheduler log so it reaches
     the [alerts] email, which sends only that log's tail.

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -3440,6 +3440,12 @@ def test_stop_timeout_covers_the_publish_tail_it_waits_for():
 
     Asserted against the DIRECTIVE line, not the prose around it — a comment is
     not what systemd runs.
+
+    It ALSO pins the unit's prose to `_MEASURED_TAIL_AGGREGATE_S` via
+    `_assert_unit_quotes`, which the test name does not advertise: that constant
+    has no other test, and a failure here can therefore be about the quoted
+    figure rather than about TimeoutStopSec itself. The assertion message says
+    which.
     """
     from streetscape_metadata_tracker import catalog_backup
 
@@ -3477,13 +3483,24 @@ def test_stop_timeout_covers_the_publish_tail_it_waits_for():
     )
 
 
-# Extrapolated peak RSS of the largest city we track, in GiB: the per-run JSON
-# tail measured 4.81 GiB on Ho Chi Minh City's 5.26M-row census (2026-08-18),
-# i.e. ~0.914 GiB per million rows, and Detroit is ~16.7M rows. A named constant
-# for the same reason _MEASURED_TAIL_AGGREGATE_S is one — the unit file quotes
-# this figure, and the next re-sizing has to argue from it. NOTE it is an
-# EXTRAPOLATION from one city's slope, not a measurement; replace it with a real
-# MemoryPeak the first night a big city runs to completion.
+# Extrapolated peak RSS of the largest city we track, in GiB. Both inputs are
+# traceable, which matters because this figure is a floor the caps are sized
+# against: the per-run JSON tail measured 4.81 GiB on Ho Chi Minh City's 5.26M-row
+# census (2026-08-18), i.e. ~0.914 GiB per million rows, and the largest census
+# in the catalog is Detroit's 16,569,307 rows —
+#
+#   sqlite3 data/streetscape_tracker.db \
+#     "SELECT city_id, run_date, MAX(total_points) FROM runs WHERE provider='mapillary';"
+#
+# (runs.total_points IS the CSV row count for a Mapillary census: one row per
+# pano plus the ZERO_RESULTS/FLAT_ONLY fill, and it sums the status columns
+# exactly). 16.569M x 0.914 = 15.1 GiB, rounded UP to 15.3 here — a floor should
+# err high, and the slope is one city's.
+#
+# A named constant for the same reason _MEASURED_TAIL_AGGREGATE_S is one: the
+# unit file quotes this figure and the next re-sizing has to argue from it. NOTE
+# it is an EXTRAPOLATION from one city's slope, not a measurement; replace it
+# with a real MemoryPeak the first night a big city runs to completion.
 _EXTRAPOLATED_LARGEST_CITY_PEAK_GIB = 15.3
 
 
@@ -3518,8 +3535,12 @@ def test_memory_high_is_a_throttle_below_the_hard_limit_and_clears_the_worst_cit
     )
 
     def _raw(directive):
-        m = re.search(rf"^{directive}=(\S+)\s*$", unit, re.M)
-        return m.group(1) if m else None
+        # LAST match, not the first: systemd is last-wins for a repeated
+        # directive, so a duplicated MemoryHigh= line would otherwise be
+        # validated at the copy the kernel ignores — this test passing on a
+        # value that is not in force is the one way it could mislead.
+        found = re.findall(rf"^{directive}=(\S+)\s*$", unit, re.M)
+        return found[-1] if found else None
 
     def _bytes(directive, value):
         m = re.fullmatch(r"(\d+)([KMGT]?)", value)

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -3401,6 +3401,25 @@ def test_backup_check_unit_matches_the_collection_unit(tmp_path):
     assert "[Install]" in timer and "OnCalendar=" in timer
 
 
+def _assert_unit_quotes(unit, rendered, constant):
+    """Pin the two copies of a measurement to each other.
+
+    The figures the resource directives are sized from live twice by design: as
+    a constant here, which is what the test ENFORCES, and in the unit file's
+    rationale block, which is what the next person re-sizing a directive
+    actually READS. Nothing else stops those drifting, and the drift is silent
+    and bad in a specific way — the cap ends up justified by one number and
+    enforced against another, so an operator argues from a figure no test holds
+    anyone to. Cheap to assert, so assert it.
+    """
+    assert rendered in unit, (
+        f"{constant} renders as {rendered!r}, which no longer appears in "
+        f"deploy/systemd/streetscape-tracker.service. Update BOTH copies — the "
+        f"constant is what this suite enforces, the unit's prose is what the "
+        f"next operator reads before changing the directive."
+    )
+
+
 # Worst aggregate + streetwalk-manifest rebuild measured on prod: 7m15s on the
 # 19-city night of 2026-08-18 (a small night is ~1.6 s). A named constant rather
 # than a literal because it is a MEASUREMENT — the unit file quotes the same
@@ -3431,6 +3450,11 @@ def test_stop_timeout_covers_the_publish_tail_it_waits_for():
     m = re.search(r"^TimeoutStopSec=(\d+)(s|min|h)?\s*$", unit, re.M)
     assert m, "the unit must set TimeoutStopSec explicitly; systemd's default is 90 s (#206)"
     stop_s = int(m.group(1)) * {None: 1, "s": 1, "min": 60, "h": 3600}[m.group(2)]
+    _assert_unit_quotes(
+        unit,
+        f"{_MEASURED_TAIL_AGGREGATE_S // 60}m{_MEASURED_TAIL_AGGREGATE_S % 60:02d}s",
+        "_MEASURED_TAIL_AGGREGATE_S",
+    )
 
     # The floor is the SUM of the tail's two large known terms, not the larger of
     # them. Asserting only `> BACKUP_TIMEOUT_S` accepted 11min — which the very
@@ -3489,6 +3513,9 @@ def test_memory_high_is_a_throttle_below_the_hard_limit_and_clears_the_worst_cit
     """
     unit = Path(_PROJECT_ROOT, "deploy", "systemd", "streetscape-tracker.service").read_text()
     floor = _EXTRAPOLATED_LARGEST_CITY_PEAK_GIB * 2**30
+    _assert_unit_quotes(
+        unit, f"{_EXTRAPOLATED_LARGEST_CITY_PEAK_GIB} GiB", "_EXTRAPOLATED_LARGEST_CITY_PEAK_GIB"
+    )
 
     def _raw(directive):
         m = re.search(rf"^{directive}=(\S+)\s*$", unit, re.M)

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -3411,6 +3411,14 @@ def _assert_unit_quotes(unit, rendered, constant):
     and bad in a specific way — the cap ends up justified by one number and
     enforced against another, so an operator argues from a figure no test holds
     anyone to. Cheap to assert, so assert it.
+
+    It is a SUBSTRING check, so it only pins the constant as tightly as the
+    prose is unambiguous: if the unit spells a near-miss of the same quantity
+    the same way — the unrounded product beside the rounded floor, both suffixed
+    `GiB` — then lowering the constant to that near-miss still passes. Which is
+    why the unit writes the product bare (`extrapolates to 15.1`) and reserves
+    the unit suffix for the figure the caps are actually sized from. Keep it
+    that way rather than making this matcher cleverer.
     """
     assert rendered in unit, (
         f"{constant} renders as {rendered!r}, which no longer appears in "
@@ -3497,6 +3505,23 @@ def test_stop_timeout_covers_the_publish_tail_it_waits_for():
 # exactly). 16.569M x 0.914 = 15.1 GiB, rounded UP to 15.3 here — a floor should
 # err high, and the slope is one city's.
 #
+# WHY THE QUERY FILTERS ON PROVIDER, since dropping the filter finds a bigger
+# number and the exclusion should be an argument rather than an omission: the
+# slope is a property of the CSV row count, not of the provider, and
+# analysis.calculate_run_stats writes total_points as len(df) for every one. Run
+# it without the WHERE and the top row is juneau--alaska--united-states, gsv,
+# 2025-01-08, 39,346,564 rows — 2.4x Detroit. Those are is_baseline=1 archival
+# imports (issue #93) on pre-#166 geometry, and no future night re-collects at
+# that size: the 40 km cap bounds a fresh gsv run at (40000/20)^2 = 4M points,
+# hence 4M rows, hence ~3.7 GiB. A census has no such bound — its rows are
+# imagery, not lattice points — which is why the largest live workload is a
+# Mapillary one and why the filter belongs there.
+#
+# Also worth re-running on PROD rather than a dev checkout before trusting it as
+# a catalog-wide maximum: a laptop catalog may hold only a handful of Mapillary
+# runs, in which case the query returns the largest of those and not the largest
+# we collect.
+#
 # A named constant for the same reason _MEASURED_TAIL_AGGREGATE_S is one: the
 # unit file quotes this figure and the next re-sizing has to argue from it. NOTE
 # it is an EXTRAPOLATION from one city's slope, not a measurement; replace it
@@ -3543,12 +3568,23 @@ def test_memory_high_is_a_throttle_below_the_hard_limit_and_clears_the_worst_cit
         return found[-1] if found else None
 
     def _bytes(directive, value):
-        m = re.fullmatch(r"(\d+)([KMGT]?)", value)
+        # Decimal sizes are accepted because systemd accepts them and they are
+        # still comparable. PERCENTAGES are not, and that is a requirement
+        # rather than a parser limitation: the floor below is an absolute
+        # measurement in GiB, so a percentage would silently re-scale both caps
+        # with the host's RAM and make the comparison meaningless on any box but
+        # the one it was written for. Say so, rather than failing as "cannot
+        # interpret that spelling".
+        m = re.fullmatch(r"(\d+(?:\.\d+)?)([KMGT]?)", value)
         assert m, (
-            f"{directive}={value} is not a plain byte size; this test compares "
-            f"the two caps numerically and cannot interpret that spelling"
+            f"{directive}={value} must be an absolute byte size (e.g. 20G). This "
+            f"test compares the caps against a measured GiB floor, so a "
+            f"percentage-of-RAM spelling cannot be checked and would mean a "
+            f"different cap on every host the unit is copied to."
         )
-        return int(m.group(1)) * {"": 1, "K": 2**10, "M": 2**20, "G": 2**30, "T": 2**40}[m.group(2)]
+        return (
+            float(m.group(1)) * {"": 1, "K": 2**10, "M": 2**20, "G": 2**30, "T": 2**40}[m.group(2)]
+        )
 
     hard_raw = _raw("MemoryMax")
     assert hard_raw and hard_raw != "infinity", (

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -3471,34 +3471,68 @@ def test_memory_high_is_a_throttle_below_the_hard_limit_and_clears_the_worst_cit
     nothing (measured 2026-08-18, issue #157). MemoryMax is a hard limit, whose
     breach is a fast OOM kill an operator can actually read.
 
-    So two independent properties, neither of which systemd will complain about:
-    a MemoryHigh at or above MemoryMax is INERT — the soft brake never engages
-    and every overrun becomes the hard kill — and a MemoryHigh below the largest
-    city's peak reproduces the 2026-08-18 hang on exactly the nights that matter
-    most. Asserted against the directive lines, not the prose around them.
+    So the hard limit must clear the largest city's peak no matter what, and IF
+    a soft brake is configured it has to sit in the band where it is useful:
+    strictly below MemoryMax (at or above it the brake is INERT — it never
+    engages and every overrun becomes the hard kill) and above the largest
+    city's peak (below it, the biggest nights throttle into the 180-min city
+    timeout — the 2026-08-18 failure).
+
+    "IF" is load-bearing: the unit file offers "no MemoryHigh at all" as a valid
+    answer to a big-city hang, so this must not be the test that forbids the fix
+    its own subject recommends. Absent — and systemd's `infinity` spelling of
+    the same thing — is accepted, and the MemoryMax floor below is then the only
+    thing standing between a big city and an OOM kill, which is why that
+    assertion is unconditional rather than part of the MemoryHigh branch.
+
+    Asserted against the directive lines, not the prose around them.
     """
     unit = Path(_PROJECT_ROOT, "deploy", "systemd", "streetscape-tracker.service").read_text()
+    floor = _EXTRAPOLATED_LARGEST_CITY_PEAK_GIB * 2**30
 
-    def _bytes(directive):
-        m = re.search(rf"^{directive}=(\d+)([KMGT]?)\s*$", unit, re.M)
-        assert m, f"the unit must set {directive} explicitly"
+    def _raw(directive):
+        m = re.search(rf"^{directive}=(\S+)\s*$", unit, re.M)
+        return m.group(1) if m else None
+
+    def _bytes(directive, value):
+        m = re.fullmatch(r"(\d+)([KMGT]?)", value)
+        assert m, (
+            f"{directive}={value} is not a plain byte size; this test compares "
+            f"the two caps numerically and cannot interpret that spelling"
+        )
         return int(m.group(1)) * {"": 1, "K": 2**10, "M": 2**20, "G": 2**30, "T": 2**40}[m.group(2)]
 
-    high, hard = _bytes("MemoryHigh"), _bytes("MemoryMax")
+    hard_raw = _raw("MemoryMax")
+    assert hard_raw and hard_raw != "infinity", (
+        "the unit must set MemoryMax to a real ceiling: it is the only cap whose "
+        "breach is a fast, legible OOM kill rather than silent reclaim"
+    )
+    hard = _bytes("MemoryMax", hard_raw)
+    assert hard > floor, (
+        f"MemoryMax={hard / 2**30:.1f}G is under the largest city's "
+        f"~{_EXTRAPOLATED_LARGEST_CITY_PEAK_GIB}GiB extrapolated peak, so the "
+        f"biggest nights are OOM-killed outright (issue #157)."
+    )
+
+    high_raw = _raw("MemoryHigh")
+    if high_raw is None or high_raw == "infinity":
+        return  # No soft brake by choice — see the docstring.
+    high = _bytes("MemoryHigh", high_raw)
 
     assert high < hard, (
-        f"MemoryHigh={high} is not below MemoryMax={hard}: the soft brake can "
-        f"never engage, so every overrun skips the throttle and becomes an OOM "
-        f"kill. If that is genuinely wanted, drop MemoryHigh rather than raising "
-        f"it to meet MemoryMax, so the intent is visible in the unit."
+        f"MemoryHigh={high / 2**30:.1f}G is not below MemoryMax={hard / 2**30:.1f}G: "
+        f"the soft brake can never engage, so every overrun skips the throttle and "
+        f"becomes an OOM kill. If that is genuinely wanted, DROP MemoryHigh (or set "
+        f"it to `infinity`) rather than raising it to meet MemoryMax, so the intent "
+        f"is visible in the unit."
     )
-    floor = _EXTRAPOLATED_LARGEST_CITY_PEAK_GIB * 2**30
     assert high > floor, (
         f"MemoryHigh={high / 2**30:.1f}G is under the largest city's "
         f"~{_EXTRAPOLATED_LARGEST_CITY_PEAK_GIB}GiB extrapolated peak, so the "
         f"biggest nights throttle into the 180-min city timeout instead of "
         f"finishing — the 2026-08-18 failure, which is what raising this cap "
-        f"exists to prevent (issues #157/#206)."
+        f"exists to prevent (issues #157/#206). If a real measurement lands above "
+        f"MemoryMax={hard / 2**30:.1f}G, both caps have to move, not just this one."
     )
 
 

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -3453,6 +3453,55 @@ def test_stop_timeout_covers_the_publish_tail_it_waits_for():
     )
 
 
+# Extrapolated peak RSS of the largest city we track, in GiB: the per-run JSON
+# tail measured 4.81 GiB on Ho Chi Minh City's 5.26M-row census (2026-08-18),
+# i.e. ~0.914 GiB per million rows, and Detroit is ~16.7M rows. A named constant
+# for the same reason _MEASURED_TAIL_AGGREGATE_S is one — the unit file quotes
+# this figure, and the next re-sizing has to argue from it. NOTE it is an
+# EXTRAPOLATION from one city's slope, not a measurement; replace it with a real
+# MemoryPeak the first night a big city runs to completion.
+_EXTRAPOLATED_LARGEST_CITY_PEAK_GIB = 15.3
+
+
+def test_memory_high_is_a_throttle_below_the_hard_limit_and_clears_the_worst_city():
+    """
+    The two memory caps do different jobs and only mean something together.
+    MemoryHigh is a THROTTLE: crossing it costs hours of silent reclaim that end
+    in the scheduler's 180-min city timeout SIGKILLing a child that printed
+    nothing (measured 2026-08-18, issue #157). MemoryMax is a hard limit, whose
+    breach is a fast OOM kill an operator can actually read.
+
+    So two independent properties, neither of which systemd will complain about:
+    a MemoryHigh at or above MemoryMax is INERT — the soft brake never engages
+    and every overrun becomes the hard kill — and a MemoryHigh below the largest
+    city's peak reproduces the 2026-08-18 hang on exactly the nights that matter
+    most. Asserted against the directive lines, not the prose around them.
+    """
+    unit = Path(_PROJECT_ROOT, "deploy", "systemd", "streetscape-tracker.service").read_text()
+
+    def _bytes(directive):
+        m = re.search(rf"^{directive}=(\d+)([KMGT]?)\s*$", unit, re.M)
+        assert m, f"the unit must set {directive} explicitly"
+        return int(m.group(1)) * {"": 1, "K": 2**10, "M": 2**20, "G": 2**30, "T": 2**40}[m.group(2)]
+
+    high, hard = _bytes("MemoryHigh"), _bytes("MemoryMax")
+
+    assert high < hard, (
+        f"MemoryHigh={high} is not below MemoryMax={hard}: the soft brake can "
+        f"never engage, so every overrun skips the throttle and becomes an OOM "
+        f"kill. If that is genuinely wanted, drop MemoryHigh rather than raising "
+        f"it to meet MemoryMax, so the intent is visible in the unit."
+    )
+    floor = _EXTRAPOLATED_LARGEST_CITY_PEAK_GIB * 2**30
+    assert high > floor, (
+        f"MemoryHigh={high / 2**30:.1f}G is under the largest city's "
+        f"~{_EXTRAPOLATED_LARGEST_CITY_PEAK_GIB}GiB extrapolated peak, so the "
+        f"biggest nights throttle into the 180-min city timeout instead of "
+        f"finishing — the 2026-08-18 failure, which is what raising this cap "
+        f"exists to prevent (issues #157/#206)."
+    )
+
+
 def test_restore_backup_subcommand_restores_and_then_refuses(conn, monkeypatch, tmp_path, capsys):
     """The incident-time handle. It must work, and it must refuse the second
     time — restoring onto a catalog that is already there would destroy the


### PR DESCRIPTION
Raises `MemoryHigh` from 12G to 20G in the collection unit. **`MemoryMax` stays 24G**, so this raises no ceiling — it moves only the point where we start throttling *ourselves*, which is the one burden on makelab2 that has actually been measured (the box's load is ZFS; CPU sits 97–99% idle, and the old 4G `MemoryHigh` was the real cost).

### Why

12G was already documented in the unit as not covering the largest cities. Peak RSS scales at ~0.914 GiB per million CSV rows (Ho Chi Minh City: 5.26M rows → **4.81 GiB measured** 2026-08-18), and the largest census in the catalog is Detroit's **16,569,307 rows** (`runs.total_points`, mapillary, 2026-07-24 — for a census that is exactly the CSV row count), so it extrapolates to **15.1 GiB**, carried as ~15.3 GiB since it is a floor the caps are sized against and should err high. Either way: above 12G, below `MemoryMax`.

That is the expensive side of the pair to cross. `MemoryHigh` is a *throttle*: exceeding it is hours of silent reclaim ending in the scheduler's 180-min city timeout SIGKILLing a child that printed nothing — exactly the 2026-08-18 failure. `MemoryMax` is a hard limit whose breach is a fast OOM kill you can read in a log. 20G clears the extrapolated worst city by ~30% and keeps a narrow 20→24 gap so a genuine runaway still fails legibly instead of reclaiming for hours on the way there.

Sizing context, checked on makelab2 today: **188 GiB RAM, 48 cores** — so 20G/24G is ~11%/~13% of the box. Also checked that `[resource_guard]` can't interact: it reads host `/proc/meminfo` `MemAvailable`, not the cgroup.

### Two caveats, kept in the unit file rather than only here

1. **15.3 GiB is an extrapolation from one city's slope, not a measurement** — the row count is catalog-traceable, the GiB-per-row slope is one city's. Capture `MemoryPeak` on a real Detroit night before treating it as settled.
2. **This changes nothing on prod by itself.** As of 2026-08-20 the live service reads `MemoryHigh=12G` from a `systemctl --user set-property` drop-in, which overrides the unit file. `deploy/README.md` already documented that hazard; this PR sharpens it to say that raising the cap here is inert until the drop-in is reverted, and points at the existing `systemctl --user revert` recipe as the deployment step rather than a cleanup afterthought.

### Tests

One new test, covering the properties that make the two caps meaningful together and that systemd itself will never complain about:

- `MemoryMax` **must clear the largest city's peak, unconditionally** — with no soft brake it is the only thing between a big city and an OOM kill.
- *If* a soft brake is configured, it must be **strictly below `MemoryMax`** (at or above it the brake is inert — it never engages and every overrun becomes the hard kill) and **above the peak** (below it, the biggest nights throttle into the city timeout).

The conditional matters: the unit offers "no `MemoryHigh` at all" as a valid answer to a big-city hang, so absent — and systemd's `infinity` spelling — are accepted rather than failing with a message that contradicts the file. Negative-tested by mutation: `12G`, `24G`, `30G` and `MemoryMax=8G` all fail; `infinity` and a removed line pass.

A second small guard pins each measured figure's **two copies** to each other — the constant the test enforces, and the number the unit's prose quotes for the next person re-sizing a directive. Applied to the new peak figure and to the pre-existing `_MEASURED_TAIL_AGGREGATE_S` / `7m15s` pair beside it. Without it the cap can end up justified by one number and enforced against another.

### Also

`_run_collection_subprocess`'s docstring cited "`MemoryHigh=4G`" to justify streaming child output to disk — stale twice over. It now points at `deploy/systemd/` rather than quoting a figure that has moved twice.

### Open question, deliberately not decided here

Every `MemoryHigh` we have set has turned out too low, each discovered by a night dying. If the unit's own argument is right — that crossing `MemoryHigh` is the *bad* failure and crossing `MemoryMax` is the *good* one — the case for having a soft brake at all is co-tenant protection, which on a 188 GiB box idling at 0.6 load buys little. `MemoryHigh=infinity` with `MemoryMax=24G` as the sole cap is defensible, and the test now permits it. 20G is the smaller step.

### Second-pass review fixes

A follow-up review raised two things about the sizing *argument* (the directives were fine either way) plus two test nits. All four are fixed in `738de09`:

1. **15.3 GiB prices a first run, and the unit now says so.** Detroit's 2026-07-24 census had no previous Mapillary run to diff against; its next collection will, and that night holds both runs' frames at once by construction — `cli.py` hands the live new frame to `_compute_and_record_diff` and still needs it afterwards for the per-run JSON, the diff loads the previous CSV alongside it, and `compute_run_diff` then builds two deduplicated copies plus a Python set of every `pano_id` on each side (~15.3M boxed strings apiece). Unmeasured, so no multiplier is quoted — but it is several times one frame, plausibly through `MemoryMax` too. By this file's own argument that is the *legible* failure, so it is not a reason to move a number; it is a reason not to read "worst city plus ~30%" as covering every night.
2. **The query's `provider='mapillary'` filter now argues for itself.** The slope is a property of the CSV row count, not the provider, and dropping the `WHERE` finds `juneau gsv 2025-01-08` at **39,346,564 rows** — 2.4× Detroit. Those are `is_baseline=1` archival imports on pre-#166 geometry that no future night re-collects: the 40 km cap bounds a fresh gsv run at 4M points. A census has no such bound, which is why the largest live workload is a Mapillary one. Also noted that the query belongs on prod rather than a dev checkout before it establishes a catalog-wide maximum.
3. `_bytes` accepts decimal sizes (systemd does) and rejects percentages as a **stated requirement** — the floor is an absolute GiB measurement, so a percentage would re-scale both caps per host — rather than as "cannot interpret that spelling".
4. `_assert_unit_quotes` is a substring check, so the unit carrying both `15.1 GiB` and `15.3 GiB` let the constant be lowered to the unrounded product with the test still green. The unit now writes that product bare (`extrapolates to 15.1`) and the docstring says why.

Mutation-checked again after the change: `12G`, `24G`, `30G`, `80%`, `MemoryMax=8G` and a `15.1` constant all fail; `infinity`, a removed line and `20.5G` pass.

Related: #157, #206.

🤖 Generated with [Claude Code](https://claude.com/claude-code) — Opus 5 (1M context), claude-opus-5[1m]


