### PR TITLE
Cap every CI job's runtime so a hang fails instead of hanging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,7 @@ jobs:
     # advisory. The fast pytest/frontend jobs never depend on it.
     continue-on-error: true
     # The loosest cap in this file, and deliberately so: this is the job that
-    # hung, but it is also the only one that downloads ~350 MB of browser on a
+    # hung, but it is also the only one that downloads ~550 MB of browser on a
     # cache miss. The re-run of that same hung job spent ~14 min in "Install
     # Chromium" and then PASSED — so the obvious 15 would have killed a healthy
     # run, and the number has to clear a cold cache, not a warm one (1m31s).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,10 +25,13 @@ permissions:
 # blocked a person, who waits on all of these before merging. The cap turns a
 # 6-hour worst case into a bounded one.
 #
-# The caps are sized from measured durations (a warm-cache run on 2026-08-20:
-# lint 14 s, frontend 10 s, tests ~2m20s, e2e 1m31s) with wide headroom: they
-# exist to convert a hang into a legible failure in minutes, NOT to police
-# normal variance, so a cap that fires on a healthy run is too low by
+# The caps are sized from measured durations, with wide headroom. Warm-cache
+# run 32378798829 (2026-08-20): lint 14 s, frontend 12 s, tests 2m07s-2m35s
+# across the four legs, e2e 1m27s. The run id is here so the next re-sizing can
+# re-check the numbers instead of trusting them; durations drift, and a figure
+# with no run behind it is how the e2e cap below first got argued from a wrong
+# one. These exist to convert a hang into a legible failure in minutes, NOT to
+# police normal variance, so a cap that fires on a healthy run is too low by
 # definition and should be raised rather than debugged. Note the clock starts
 # when a job starts, not when it is queued, so these bound execution only —
 # which is the right shape here, since the incident was a hung step.
@@ -104,13 +107,29 @@ jobs:
     continue-on-error: true
     # The loosest cap in this file, and deliberately so: this is the job that
     # hung, but it is also the only one that downloads ~550 MB of browser on a
-    # cache miss. The re-run of that same hung job spent ~14 min in "Install
-    # Chromium" and then PASSED — so the obvious 15 would have killed a healthy
-    # run, and the number has to clear a cold cache, not a warm one (1m31s).
-    # 30 leaves ~2x headroom over the worst legitimate run observed while still
-    # turning a 5-hour hang into a failure inside half an hour. Because this job
-    # is continue-on-error, hitting it costs a red advisory check, not a merge —
-    # which is what makes buying that headroom cheap here and nowhere else.
+    # cache miss. The number therefore has to clear a COLD cache, not the warm
+    # 1m27s. The re-run of that same hung job spent 11m02s in "Install Chromium"
+    # and then passed (run 32273955535 attempt 2, 2026-08-19; attempt 1 is the
+    # incident — the same step, 5h22m, cancelled by hand).
+    #
+    # Note what that one sample does NOT establish: 15 would have cleared it by
+    # four minutes. The case for 30 is that the sample bounds nothing — the
+    # download's duration is set by a CDN we don't control, and the 5-hour hang
+    # is that same step failing to make progress at all, so the spread between a
+    # slow download and a stuck one is the whole question. 30 buys ~2.7x over the
+    # worst legitimate run observed while still turning a 5-hour hang into a
+    # failure inside half an hour.
+    #
+    # Hitting it SHOULD cost only a red advisory check rather than a merge,
+    # since this job is continue-on-error — but treat that as unverified. GitHub
+    # documents continue-on-error as absorbing a job that FAILS, and
+    # timeout-minutes as CANCELLING the job, and a cancel is demonstrably not
+    # absorbed: in run 32273955535 attempt 1 the e2e job was cancelled by hand,
+    # the other six jobs went green, and the whole run concluded `cancelled`. So
+    # this cap firing may well read at run level exactly like the incident did.
+    # Nothing is gated on it either way — main carries no branch protection — so
+    # the cost of being wrong is a run-level red mark, not a blocked merge, and
+    # that is what makes buying the headroom cheap here and nowhere else.
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,11 +19,19 @@ permissions:
 # 2026-08-19 a PR's e2e job sat in "Install Chromium" for 5 h before it was
 # cancelled by hand — a hang that reported as "still running", not as a
 # failure, so the signal it produced was indistinguishable from a slow queue.
+#
+# What a cap buys is TIME-TO-SIGNAL, not an unblocked merge. e2e is
+# continue-on-error, so that hang never blocked anything mechanically; it
+# blocked a person, who waits on all of these before merging. The cap turns a
+# 6-hour worst case into a bounded one.
+#
 # The caps are sized from measured durations (a warm-cache run on 2026-08-20:
 # lint 14 s, frontend 10 s, tests ~2m20s, e2e 1m31s) with wide headroom: they
 # exist to convert a hang into a legible failure in minutes, NOT to police
 # normal variance, so a cap that fires on a healthy run is too low by
-# definition and should be raised rather than debugged.
+# definition and should be raised rather than debugged. Note the clock starts
+# when a job starts, not when it is queued, so these bound execution only —
+# which is the right shape here, since the incident was a hung step.
 jobs:
   lint:
     name: Lint (ruff)
@@ -101,7 +109,8 @@ jobs:
     # run, and the number has to clear a cold cache, not a warm one (1m31s).
     # 30 leaves ~2x headroom over the worst legitimate run observed while still
     # turning a 5-hour hang into a failure inside half an hour. Because this job
-    # is continue-on-error, hitting it costs a red advisory check, not a merge.
+    # is continue-on-error, hitting it costs a red advisory check, not a merge —
+    # which is what makes buying that headroom cheap here and nowhere else.
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,20 @@ concurrency:
 permissions:
   contents: read
 
+# Every job below sets timeout-minutes. GitHub's default is 6 HOURS, and on
+# 2026-08-19 a PR's e2e job sat in "Install Chromium" for 5 h before it was
+# cancelled by hand — a hang that reported as "still running", not as a
+# failure, so the signal it produced was indistinguishable from a slow queue.
+# The caps are sized from measured durations (a warm-cache run on 2026-08-20:
+# lint 14 s, frontend 10 s, tests ~2m20s, e2e 1m31s) with wide headroom: they
+# exist to convert a hang into a legible failure in minutes, NOT to police
+# normal variance, so a cap that fires on a healthy run is too low by
+# definition and should be raised rather than debugged.
 jobs:
   lint:
     name: Lint (ruff)
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -36,6 +46,8 @@ jobs:
   test:
     name: Tests (py${{ matrix.python-version }})
     runs-on: ubuntu-latest
+    # Per matrix leg, not for the matrix as a whole.
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
@@ -57,6 +69,7 @@ jobs:
   frontend:
     name: Frontend (ESLint + unit tests)
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     defaults:
       run:
         working-directory: www
@@ -81,6 +94,15 @@ jobs:
     # block merges; it drives real Chromium over the committed fixture and is
     # advisory. The fast pytest/frontend jobs never depend on it.
     continue-on-error: true
+    # The loosest cap in this file, and deliberately so: this is the job that
+    # hung, but it is also the only one that downloads ~350 MB of browser on a
+    # cache miss. The re-run of that same hung job spent ~14 min in "Install
+    # Chromium" and then PASSED — so the obvious 15 would have killed a healthy
+    # run, and the number has to clear a cold cache, not a warm one (1m31s).
+    # 30 leaves ~2x headroom over the worst legitimate run observed while still
+    # turning a 5-hour hang into a failure inside half an hour. Because this job
+    # is continue-on-error, hitting it costs a red advisory check, not a merge.
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5


### PR DESCRIPTION
Adds `timeout-minutes` to all four CI jobs. None had one, so all four ran on **GitHub's 6-hour default**.

### Why

On 2026-08-19 a PR's e2e job sat in **"Install Chromium" for 5h22m** before being cancelled by hand (run 32273955535, attempt 1). For all of it the job reported as *still running* rather than as a failure — indistinguishable from a slow queue — which is why ending it took a human noticing rather than a red check.

**What a cap buys here is time-to-signal, not an unblocked merge.** e2e is `continue-on-error` (#124) and `main` carries no branch protection, so nothing was ever gated on that job mechanically; it blocked a *person*, who waits on all seven checks before merging. Worth stating plainly in the file so a later reader doesn't tighten these trying to fix a merge-blocking problem that never existed.

### The numbers

Sized from measured durations, not picked. Warm-cache run 32378798829 (2026-08-20), quoted with its run id in the file so the next re-sizing can re-check rather than trust:

| job | measured | cap |
|---|---|---|
| Lint (ruff) | 14 s | 10 min |
| Frontend (ESLint + unit tests) | 12 s | 10 min |
| Tests (pytest matrix) | 2m07s–2m35s | 20 min *(per matrix leg)* |
| Frontend e2e (Playwright) | 1m27s | **30 min** |

**e2e is the loosest on purpose.** It is the job that hung, but it is also the only one that downloads ~550 MB of browser on a cache miss (`playwright install chromium` fetches both `chromium` and `chromium_headless_shell`), so the cap has to clear a cold cache rather than the warm 1m27s. The re-run of that same hung job spent **11m02s** in "Install Chromium" and then passed (attempt 2 of the same run).

Note what that single sample does *not* establish: 15 would have cleared it by four minutes. The case for 30 is that the sample bounds nothing — the download's duration is set by a CDN we don't control, and the 5-hour hang is *that same step* failing to make progress at all, so the spread between a slow download and a stuck one is the whole question. 30 buys ~2.7× over the worst legitimate run observed while still ending a 5-hour hang inside half an hour.

All four jobs are capped rather than only the one that misbehaved — the other three are fast *today*, but "fast today" is what e2e was too.

### One claim deliberately marked unverified

The file notes that hitting the cap *should* cost only a red advisory check rather than a merge, and then says not to bank on it. GitHub documents `continue-on-error` as absorbing a job that **fails**, and `timeout-minutes` as **cancelling** the job — and a cancel is demonstrably not absorbed: in attempt 1 of that same run the e2e job was cancelled, the other six jobs went green, and the **whole run concluded `cancelled`**. So this cap firing may read at run level exactly like the incident did. Nothing is gated on it either way, so the cost of being wrong is a run-level red mark, not a blocked merge.

The rest of the intent is written into the workflow so a future tightening argues from it: these convert a hang into a legible failure in minutes, they are not there to police normal variance, and **a cap that fires on a healthy run is too low by definition** and should be raised rather than debugged. The file also records that the clock starts when a job *starts*, not when it is queued — the right shape for this incident (a hung step), but not obvious from the directive name, and the first thing to check if a cap ever seems not to have fired.

### Not fixed here

The underlying cause — Playwright's browser download stalling on the runner — isn't addressed, and can't be from this repo. The cache step keyed on the Playwright version already covers the common case; this PR just makes the miss-and-stall case fail fast.

A step-level cap on "Install Chromium" was considered and rejected: the Actions UI already shows which step was running when a job cap fires, so it would be redundant.

🤖 Generated with [Claude Code](https://claude.com/claude-code) — Opus 5 (1M context), claude-opus-5[1m]
