### PR TITLE
Re-measure the undated-imagery share on prod (#257 follow-up)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -248,7 +248,7 @@ Dated copies go through SQLite's **online backup API**, to a per-writer staging 
 
 **Street coverage and road walks → [`docs/street-coverage.md`](docs/street-coverage.md).** A second, active collection modality beside the grid: walk each frozen OSM edge, sample every `--spacing` m, and query the provider at each sample, so association is by construction and coverage is fractional per edge.
 **A sample counts as covered when its status is PRESENT — `OK` *or* `NO_DATE` — never `OK` alone** (`analysis.PRESENT_STATUSES`, the grid's vocabulary): an undated pano is still imagery within reach, so it covers and simply ages nothing.
-Both halves of `streetscape_street_analyzer` got that wrong independently (#251 finding 9, then #257), and the undated share is provider-specific by three orders of magnitude — 9.6% of audited KartaView photos against 0.010% of GSV's, so the same bug is invisible in one provider and decisive in another.
+Both halves of `streetscape_street_analyzer` got that wrong independently (#251 finding 9, then #257), and undated imagery arrives in BATCHES rather than as diffuse noise, so the per-run MAX is the number that matters, not the pooled share — both are zero through p95, but one Mapillary run is 23.3% undated against GSV's worst 0.34% and KartaView's 9.6% of audited photos.
 **Grid coverage and street coverage are different denominators and never substitute for each other** — Seattle reads 54.3% grid against 98.4% street
 — and each `--network-type` is its own series with its own denominator, never a replacement for another.
 Both providers walk the same deterministic sample points, but Mapillary reaches them through a tile census joined locally, so its cost tracks bbox **area** rather than sample count.

--- a/docs/experiments/README.md
+++ b/docs/experiments/README.md
@@ -63,10 +63,13 @@ Its transferable lesson is that a log holds **three** populations that look alik
 ### `undated-imagery-share.md`
 
 Issue #257 — how much imagery carries no usable capture date, per provider, which is the number three prose claims in the road-walk fix rested on.
-**Three orders of magnitude apart**: GSV 0.0101% of present panos (and exactly zero in 1,070 of 1,146 runs), Mapillary 0.0% across 15.3M, KartaView 9.56% of audited photos.
-Two things generalize.
-**(1) A pooled share over a concentrated distribution describes no run in it** — GSV's is zero through the 90th percentile and is carried entirely by 76 big-metro runs, so "small on average" and "absent almost everywhere, occasionally 0.3%" are different facts with different consequences for a published one-decimal column.
-**(2) An undated population is not automatically a random sample of the imagery**: every violating KartaView sequence is one 2025-11-19 bulk ingest, so its undated imagery is its *newest*, and excluding it from an age median biases the median **older** rather than merely widening its error bar.
+**Undated imagery arrives in batches, not as diffuse noise**, so the per-run maximum is the number a decision has to survive and the pooled share describes no run in the distribution: GSV pools to 0.0086% but its worst run is 0.34%, Mapillary pools to 0.150% but its worst run is **23.3%**, and KartaView is 9.56% of audited photos concentrated in one 2025-11-19 ingest.
+Three things generalize.
+**(1) An undated population is a property of an upload BATCH, not of a provider** — Mapillary's entire undated corpus is 99.96% four adjacent Denver-metro runs, and KartaView's is one 2025-11-19 Grab ingest, so a pooled per-provider rate systematically understates what any single city can hit.
+**(2) A batch is a single point in time by construction**, which makes the bias directional rather than merely noisy: KartaView's undated imagery is its *newest*, so excluding it from an age median drags the median **older** instead of widening its error bar.
+**(3) A per-provider question cannot be answered from a catalog that is well-populated for only one provider** — and this one nearly shipped wrong because of it.
+The first pass ran against a dev laptop holding 1,144 GSV cities but **three** Mapillary runs, and concluded Mapillary emits no undated imagery at all; production's 1,201 runs say 0.150%, about 17× GSV's rate.
+Hence `--catalog-label`, recorded in the metrics file: it is the only thing separating that result from its opposite.
 The catalog half is a census and the KartaView half is an API sample read from `kartaview-shotdate-audit_metrics.json`; the two frames are reported side by side and never pooled.
 Both are proxies for the road-walk share, which no walk recorded until #257 added `dated_covered_samples`.
 

--- a/docs/experiments/undated-imagery-share.md
+++ b/docs/experiments/undated-imagery-share.md
@@ -9,62 +9,80 @@ Two decisions rest on them.
 whether that is invisible noise or the largest change a city's series has ever recorded is a matter of how big the undated population is.
 **(2)** Since the fix, `covered` and `dated` are different populations, so `median_covered_age_years` is taken over a subset — and how much of a subset decides whether it can still be read as "the age of the imagery."
 
-**Answer.** Three orders of magnitude apart, so both decisions have different answers per provider.
-GSV's undated share is **0.0101%** of present panos, and for **1,070 of 1,146** runs it is exactly zero.
-KartaView's is **9.56%** of audited photos — and, unlike GSV's, it is not scattered noise but one dated bulk ingest, which makes it the provider's *newest* imagery.
+**Answer, and it is not the one the pooled averages suggest.**
+Undated imagery does not arrive as diffuse noise that a mean can describe.
+It arrives in **batches**, and we now have three independent instances of that shape: KartaView's single 2025-11-19 Grab ingest, Mapillary's Denver-metro uploads, and GSV's handful of big-baseline metros.
+So the number that matters for any decision is the **per-run maximum**, not the pooled share — they differ by three orders of magnitude within a single provider.
 
-Numbers below come from [`undated-imagery-share_metrics.json`](undated-imagery-share_metrics.json), written by `scripts/undated_imagery_share_analyze.py`.
+Numbers below come from [`undated-imagery-share_metrics.json`](undated-imagery-share_metrics.json), written by `scripts/undated_imagery_share_analyze.py` against the **makelab2 production catalog** (`catalog_label: makelab2-prod`).
 Read entirely out of the catalog and an already-committed metrics file: no network, no credentials, no collection.
 
-## Two sampling frames, never pooled
+## Read the production catalog, not a dev one — the answer inverts
 
-| | frame | undated share |
-|---|---|---|
-| **GSV** | census of 1,157 catalog grid runs, 151.9M present panos | **0.0101%** of present |
-| **Mapillary** | census of 3 catalog grid runs, 15.3M present panos | **0.0%** of present |
-| **KartaView** | API sample of 48 sequences, 59,263 photos | **9.56%** of present |
+Recording this first because it nearly shipped as a finding.
+The first pass of this measurement ran against a development laptop's catalog, which holds the full 1,144-city GSV baseline but only **three** Mapillary runs.
+It concluded that Mapillary emits no undated imagery at all and that *"small but real for Mapillary is not supported by anything we hold."*
+
+Production holds 1,201 Mapillary runs and says the opposite: **0.150%**, roughly **17× GSV's rate**.
+The original claim was right and the dev-catalog refutation was an artifact of n=3.
+A per-provider question cannot be answered from a catalog that is only well-populated for one provider, and the run counts have to be quoted next to the share for exactly that reason.
+
+## Three sampling frames, never pooled
+
+| | frame | pooled undated | runs with **any** | worst single run |
+|---|---|---|---|---|
+| **GSV** | 1,766 prod grid runs, 242.5M present panos | 0.0086% | 119 of 1,749 | **0.336%** |
+| **Mapillary** | 1,201 prod grid runs, 68.3M present panos | 0.150% | **11 of 453** | **23.3%** |
+| **KartaView** | API sample of 48 sequences, 59,263 photos | 9.56% | 10 of 48 sequences | — |
 
 The first two are a census of what we collected; the third is a sample of what the provider serves, lifted from [`kartaview-shotdate-audit_metrics.json`](kartaview-shotdate-audit_metrics.json) rather than re-probed, since that number already has a writeup and caveats of its own ([`kartaview-feasibility.md`](kartaview-feasibility.md)).
-They are not a controlled comparison and the gap between them is an order-of-magnitude claim, not a measured ratio.
-Two reasons that matters: we hold **no KartaView runs at all** (it is not a scheduler channel), and the audit's own writeup calls its sample Grab-heavy and its count a lower bound.
+They are not a controlled comparison.
+We hold no KartaView runs at all (it is not a scheduler channel), and the audit's own writeup calls its sample Grab-heavy and its count a lower bound.
 
 **And all three are proxies for the quantity actually at issue, which is the ROAD-WALK undated share.**
 No walk has ever recorded one: `street_walks` and the coverage artifact counted covered samples and nothing else, which is the gap #257 closed by adding `dated_covered_samples` per edge and `covered_samples_dated`/`dated_pct_of_covered` to the artifact's summary blocks.
 Until walks collected under that column accumulate, the grid share is the only estimate available, and it is an estimate of the right *order* rather than of the value
 — a walk samples only on-street points, where imagery is denser and plausibly better dated.
 
-## The distribution is the finding: GSV's undated imagery is not spread thin, it is absent
+## The distribution is the finding: undated imagery comes in batches
 
-Pooling GSV to 0.0101% understates how concentrated it is.
-Per run, as a share of present panos (n = 1,146 runs with any present imagery):
+Both providers are zero through the 95th percentile, and both have a long right tail.
+Per run, as a share of present panos:
 
-| min | p25 | p50 | p75 | p90 | p95 | max |
-|---|---|---|---|---|---|---|
-| 0.0% | 0.0% | 0.0% | 0.0% | 0.0% | 0.0027% | 0.323% |
+| | n | p50 | p90 | p95 | max |
+|---|---|---|---|---|---|
+| GSV | 1,749 | 0.0% | 0.0% | 0.0046% | **0.336%** |
+| Mapillary | 453 | 0.0% | 0.0% | 0.0% | **23.3%** |
 
-**1,070 of 1,146 runs carry not one undated pano.** The share is zero through the 90th percentile, and the pooled figure is carried by 76 runs — largely the big baseline metros, where Los Angeles alone contributes 2,670 of the corpus's 15,355.
-So "empty in practice for GSV" was directionally right, and is better stated as *empty in 93% of runs, and never above a third of a percent.*
+**Mapillary's entire undated population is essentially one metropolitan area.**
+Four Denver-area runs — Denver (66,441), Commerce City (32,059), Lakewood (2,378), Englewood (1,810) — account for 102,688 of the catalog's 102,733 undated Mapillary panos, or **99.96%**.
+The remaining seven runs contribute 45 panos between them.
+Note these are adjacent cities whose frozen grids overlap, and Mapillary is a *census* provider that keeps every image in the bbox, so the likeliest reading is **one contributor's upload batch counted four times** rather than four independent events.
+That is a hypothesis from the geography, not something this measurement establishes; confirming it means comparing pano ids across the four snapshots.
 
-**Mapillary's "small but real" is the claim that does not survive.**
-Across 15.3M present panos — 15.3M of them Detroit's single census — **zero** rows are `NO_DATE`.
-The mechanism is real and is in the code (`download_mapillary` maps a bogus `captured_at_ms` to `NO_DATE`), but its observed rate in our own data is 0.
-That is a claim about three runs and should not be read as a provider constant; it does mean nobody should expect a visible Mapillary phantom delta from this fix.
+**GSV's is concentrated too, just less dramatically**: zero in 1,630 of 1,749 runs, with the pooled figure carried by 119 runs, largely the big baseline metros (Los Angeles alone contributes 2,670).
 
-## Will the phantom delta be visible? Only at the extreme
+So the shape generalizes across all three providers, and it is the transferable lesson here:
+**an undated population is a property of an upload batch, not of a provider.**
+A pooled per-provider rate describes no run in the distribution and will systematically understate what any single city can hit.
+
+## Will the phantom delta be visible? For GSV rarely, for Mapillary yes
 
 `coverage_pct_by_length` is published to one decimal, so a shift under 0.05 percentage points rounds away completely.
-The relevant denominator here is undated panos over **points queried**, not over present panos, because that is the percentage-*point* shift a coverage rate takes:
+The relevant denominator is undated panos over **points queried**, not over present panos, because that is the percentage-*point* shift a coverage rate takes:
 
 | | p50 | p95 | max |
 |---|---|---|---|
-| GSV, undated as % of queried points | 0.0% | 0.0015% | **0.219%** |
+| GSV | 0.0% | 0.0028% | **0.329 pp** |
+| Mapillary | 0.0% | 0.0% | **2.73 pp** |
 
-So for at least 95% of GSV runs the delta is three orders of magnitude below the published precision and the Δ column will read exactly 0.0.
-**At the maximum it is 0.22 points, which does render** — a "+0.2" that is the fix landing, not Google driving.
-The review that prompted this measurement put the GSV maximum at 0.095% and concluded the delta was invisible everywhere;
-the catalog says 0.219%, so the weaker claim is the true one: invisible in the overwhelming majority of runs, not in all of them.
+For the overwhelming majority of runs of either provider the Δ column will read exactly 0.0.
+But the tail is not negligible: a GSV city can shift a third of a point, and **a Denver-metro Mapillary walk can shift 2.7 points** — which is not merely visible, it is larger than most real run-to-run coverage changes and would read as a substantial imagery refresh.
+That is the case the dated note in [`../street-coverage.md`](../street-coverage.md) exists for.
 
-## Why the age median is the sharper problem, and only for KartaView
+An earlier review of the fix put GSV's maximum at 0.095% and concluded the delta was invisible everywhere; the production catalog says 0.329 pp for GSV and 2.73 pp for Mapillary, so the weaker claim is the true one — invisible in the overwhelming majority of runs, not in all of them.
+
+## Why the age median is the sharper problem
 
 A phantom coverage delta is a one-time event that a dated note can explain away.
 The age median is permanent, and it is biased rather than noisy.
@@ -72,16 +90,19 @@ The age median is permanent, and it is biased rather than noisy.
 Every one of the 10 violating KartaView sequences in the audit is the same population: `date_added` **2025-11-19**, one Grab bulk ingest.
 So KartaView's undated imagery is not a random 9.56% of its photos — **it is disproportionately its newest**, and dropping it from an age median can only drag that median **older**.
 A KartaView city could refresh substantially and have its published median age move the wrong way.
+The batch shape found here for Mapillary suggests the same hazard applies wherever a batch lands, since a single upload is a single point in time by construction — whether it biases old or young depends on when that batch was captured, which is precisely what an undated batch does not tell you.
 
-This is exactly why `dated_pct_of_covered` had to go into the artifact rather than being left inferable: an age over 100% of an edge's coverage and an age over 3% of it are different measurements, and before #257 nothing recorded which one you were reading.
-For GSV the same field will read 100.0 or a hair under, which is the point — the number is only interesting where it is not.
+This is why `dated_pct_of_covered` had to go into the artifact rather than being left inferable: an age over 100% of an edge's coverage and an age over 3% of it are different measurements, and before #257 nothing recorded which one you were reading.
+For most runs of either provider the field will read 100.0, which is the point — the number is only interesting where it is not.
 
 ## Replicating
 
 ```bash
-python scripts/undated_imagery_share_analyze.py --docs-dir docs/experiments
+python scripts/undated_imagery_share_analyze.py --docs-dir docs/experiments --catalog-label makelab2-prod
 ```
 
-Reads `runs.status_ok`/`status_no_date`/`total_points` from the local catalog and `kartaview-shotdate-audit_metrics.json` from `docs/experiments/`.
-No network, no credentials, seconds to run.
-Re-run it on the production catalog when a Mapillary series longer than three runs exists, and again once KartaView walks have accumulated real `covered_samples_dated` values — at which point the proxy can be retired for the measurement itself.
+Run it **on makelab2**, against the production catalog.
+Reads `runs.status_ok`/`status_no_date`/`total_points` and `kartaview-shotdate-audit_metrics.json`; no network, no credentials, seconds to run.
+`--catalog-label` is recorded in the metrics file and is not cosmetic — it is the only thing distinguishing this result from the dev-catalog run that concluded the opposite.
+
+Re-run once KartaView walks have accumulated real `covered_samples_dated` values, at which point the grid proxy can be retired for the measurement itself.

--- a/docs/experiments/undated-imagery-share_metrics.json
+++ b/docs/experiments/undated-imagery-share_metrics.json
@@ -2,39 +2,40 @@
   "_about": {
     "experiment": "undated-imagery-share",
     "writeup": "docs/experiments/undated-imagery-share.md",
-    "generated_by": "python scripts/undated_imagery_share_analyze.py --docs-dir docs/experiments",
+    "generated_by": "python scripts/undated_imagery_share_analyze.py --docs-dir docs/experiments --catalog-label makelab2-prod",
     "issue": 257,
-    "generated_at": "2026-08-25T11:05:56+00:00",
-    "note": "Share of present imagery carrying no usable capture date, per provider. `catalog` is a census of our own GRID runs; `kartaview_audit` is a sample of KartaView's API, read from its own committed metrics file. The two are different sampling frames and are never pooled. Both are proxies for the ROAD-WALK undated share, which no walk recorded until #257 added dated_covered_samples. No data_dir is recorded: an absolute path would put one machine's layout into a committed file."
+    "catalog_label": "makelab2-prod",
+    "generated_at": "2026-08-25T12:15:38+00:00",
+    "note": "Share of present imagery carrying no usable capture date, per provider. `catalog` is a census of our own GRID runs; `kartaview_audit` is a sample of KartaView's API, read from its own committed metrics file. The two are different sampling frames and are never pooled. Both are proxies for the ROAD-WALK undated share, which no walk recorded until #257 added dated_covered_samples. No data_dir is recorded: an absolute path would put one machine's layout into a committed file -- `catalog_label` names which catalog was read instead, since a dev catalog and production give materially different answers for the same provider."
   },
   "catalog": {
     "gsv": {
-      "runs": 1157,
-      "panos_present": 151900889,
-      "panos_no_date": 15355,
-      "points_queried": 708758062,
-      "runs_with_any_no_date": 76,
-      "pooled_pct_of_present": 0.010109,
-      "pooled_pct_of_queried": 0.002166,
+      "runs": 1766,
+      "panos_present": 242499345,
+      "panos_no_date": 20968,
+      "points_queried": 996053847,
+      "runs_with_any_no_date": 119,
+      "pooled_pct_of_present": 0.008647,
+      "pooled_pct_of_queried": 0.002105,
       "per_run_pct_of_present": {
-        "n": 1146,
+        "n": 1749,
         "min": 0.0,
         "p25": 0.0,
         "p50": 0.0,
         "p75": 0.0,
         "p90": 0.0,
-        "p95": 0.002684,
-        "max": 0.32276
+        "p95": 0.00455,
+        "max": 0.335802
       },
       "per_run_pct_of_queried": {
-        "n": 1157,
+        "n": 1766,
         "min": 0.0,
         "p25": 0.0,
         "p50": 0.0,
         "p75": 0.0,
         "p90": 0.0,
-        "p95": 0.001478,
-        "max": 0.219361
+        "p95": 0.002849,
+        "max": 0.329362
       },
       "top_no_date_runs": [
         {
@@ -59,8 +60,8 @@
         },
         {
           "city_id": "chicago--illinois--united-states",
-          "run_date": "2025-01-24",
-          "no_date": 843
+          "run_date": "2026-07-30",
+          "no_date": 864
         }
       ],
       "largest_run_by_present_panos": {
@@ -70,38 +71,64 @@
       }
     },
     "mapillary": {
-      "runs": 3,
-      "panos_present": 15306443,
-      "panos_no_date": 0,
-      "points_queried": 17124160,
-      "runs_with_any_no_date": 0,
-      "pooled_pct_of_present": 0.0,
-      "pooled_pct_of_queried": 0.0,
+      "runs": 1201,
+      "panos_present": 68280653,
+      "panos_no_date": 102733,
+      "points_queried": 359372123,
+      "runs_with_any_no_date": 11,
+      "pooled_pct_of_present": 0.150457,
+      "pooled_pct_of_queried": 0.028587,
       "per_run_pct_of_present": {
-        "n": 2,
+        "n": 453,
         "min": 0.0,
         "p25": 0.0,
         "p50": 0.0,
         "p75": 0.0,
         "p90": 0.0,
         "p95": 0.0,
-        "max": 0.0
+        "max": 23.272308
       },
       "per_run_pct_of_queried": {
-        "n": 3,
+        "n": 1201,
         "min": 0.0,
         "p25": 0.0,
         "p50": 0.0,
         "p75": 0.0,
         "p90": 0.0,
         "p95": 0.0,
-        "max": 0.0
+        "max": 2.729452
       },
-      "top_no_date_runs": [],
+      "top_no_date_runs": [
+        {
+          "city_id": "denver--colorado--united-states",
+          "run_date": "2026-08-08",
+          "no_date": 66441
+        },
+        {
+          "city_id": "commerce-city--colorado--united-states",
+          "run_date": "2026-07-31",
+          "no_date": 32059
+        },
+        {
+          "city_id": "lakewood--colorado--united-states",
+          "run_date": "2026-08-24",
+          "no_date": 2378
+        },
+        {
+          "city_id": "englewood--colorado--united-states",
+          "run_date": "2026-08-11",
+          "no_date": 1810
+        },
+        {
+          "city_id": "ho-chi-minh-city--vietnam",
+          "run_date": "2026-07-23",
+          "no_date": 17
+        }
+      ],
       "largest_run_by_present_panos": {
         "city_id": "detroit--michigan--united-states",
-        "run_date": "2026-07-24",
-        "panos_present": 15305890
+        "run_date": "2026-08-17",
+        "panos_present": 15433401
       }
     }
   },

--- a/docs/street-coverage.md
+++ b/docs/street-coverage.md
@@ -161,11 +161,13 @@ A KartaView city could refresh substantially and have its published median age m
 
 ### How large the undated population actually is → [`docs/experiments/undated-imagery-share.md`](experiments/undated-imagery-share.md)
 
-The claim that this population is "large by construction for KartaView, small but real for Mapillary, empty in practice for GSV" was three prose assertions until it was measured; it is now three numbers, and one of them was wrong.
-**GSV 0.0101%** of present panos — and exactly zero in **1,070 of 1,146** runs, i.e. zero through the 90th percentile, with the pooled figure carried by 76 big-metro runs.
-**Mapillary 0.0%** across 15.3M present panos: the mechanism is in the code (a bogus `captured_at_ms` becomes `NO_DATE`) but its observed rate in our own data is zero, so "small but real" is not supported by anything we hold.
-**KartaView 9.56%** of audited photos.
+The claim that this population is "large by construction for KartaView, small but real for Mapillary, empty in practice for GSV" was three prose assertions until it was measured against the **production** catalog.
+All three hold, but the pooled rates are the wrong summary: **undated imagery arrives in batches, so the per-run MAXIMUM is what a decision has to survive.**
+GSV pools to **0.0086%** of present panos and Mapillary to **0.150%** (about 17× GSV), yet both read zero through the 95th percentile of runs — and Mapillary's worst single run is **23.3%** undated against GSV's worst **0.34%**.
+Mapillary's entire undated corpus is 99.96% four adjacent Denver-metro runs, which for a census provider whose grids overlap most likely means one contributor's upload batch counted four times.
+KartaView is **9.56%** of audited photos, all one 2025-11-19 ingest.
 Those are GRID runs standing in for walks, because no walk recorded an undated count until this change added one — an estimate of the right order, not the walk's value.
+**Measure this on makelab2, never on a dev catalog**: a laptop holding three Mapillary runs against production's 1,201 produced the opposite conclusion, that Mapillary emits no undated imagery at all.
 
 ### It changes recorded numbers for the existing GSV and Mapillary walk series, and those are not being recomputed
 
@@ -181,7 +183,8 @@ Issue #262 scopes that correctly — it recomputes affected diff rows through `w
 `{city_id}_streetwalkdiff_...csv.gz` is written **only when a diff has changes**, so a pair whose only change was the phantom delta recomputes to "no changes", writes no new file — and leaves the old, wrong one sitting in `data/` and on the public server.
 Re-diffing is therefore necessary but not sufficient: a detail file whose diff no longer has changes has to be deleted, not merely not-rewritten.
 Note also that the artifact cannot repair itself — its per-edge aggregates were already computed under the old definition, so the dropped `NO_DATE` samples are simply not in it, which rules out the cheap artifact-reading design `backfill_streetwalk_coverage.py` and `backfill_streetwalk_length.py` both use.
-Until #262 lands, the affected deltas are the FIRST walk diff of each series after 2026-08-24, and for GSV they will mostly round to 0.0 anyway (0.0015 percentage points at p95) — though not always, since the catalog's worst run would shift 0.22 points, which does render at one decimal.
+Until #262 lands, the affected deltas are the FIRST walk diff of each series after 2026-08-24.
+Most will round to 0.0 — both providers sit at zero through p95 — but the tail renders: production's worst GSV run would shift **0.33** percentage points and its worst Mapillary run **2.7**, and 2.7 points is larger than most real run-to-run coverage changes, so it will read as a substantial imagery refresh rather than as noise.
 
 ## Overpass is on the critical path of every first road walk (issue #209)
 

--- a/scripts/undated_imagery_share_analyze.py
+++ b/scripts/undated_imagery_share_analyze.py
@@ -78,16 +78,27 @@ DOCS_DIR_DEFAULT = "docs/experiments"
 KARTAVIEW_AUDIT = "kartaview-shotdate-audit_metrics.json"
 
 
-def docs_generated_by(docs_dir: str) -> str:
+def docs_generated_by(docs_dir: str, label: str) -> str:
     """The exact command that reproduces the committed metrics file.
 
     A constant rather than a literal in the JSON, so a test can assert the
     stamp names a run the repo can actually make (the grid-density precedent).
+
+    `--catalog-label` is part of it because WHICH catalog was read is the
+    single biggest determinant of these numbers and cannot be recovered from
+    them afterwards: a dev laptop holds a handful of Mapillary runs against
+    production's 1,200, which is the difference between "Mapillary never emits
+    NO_DATE" and "Mapillary emits 17x GSV's rate". A label rather than a path,
+    so no machine's directory layout lands in a committed file.
     """
-    return f"python scripts/undated_imagery_share_analyze.py --docs-dir {docs_dir}"
+    return (
+        "python scripts/undated_imagery_share_analyze.py "
+        f"--docs-dir {docs_dir} --catalog-label {label}"
+    )
 
 
-DOCS_GENERATED_BY = docs_generated_by(DOCS_DIR_DEFAULT)
+DEFAULT_LABEL = "unspecified"
+DOCS_GENERATED_BY = docs_generated_by(DOCS_DIR_DEFAULT, DEFAULT_LABEL)
 
 
 def percentiles(values: list[float]) -> dict:
@@ -219,6 +230,11 @@ def main() -> int:
         default=None,
         help=f"write {TOPIC}_metrics.json here (default: print only)",
     )
+    parser.add_argument(
+        "--catalog-label",
+        default=DEFAULT_LABEL,
+        help="which catalog this read, e.g. 'makelab2-prod' (recorded, not a path)",
+    )
     args = parser.parse_args()
 
     data_dir = args.data_dir or get_default_data_dir()
@@ -233,8 +249,11 @@ def main() -> int:
         "_about": {
             "experiment": TOPIC,
             "writeup": f"docs/experiments/{TOPIC}.md",
-            "generated_by": docs_generated_by(args.docs_dir or DOCS_DIR_DEFAULT),
+            "generated_by": docs_generated_by(
+                args.docs_dir or DOCS_DIR_DEFAULT, args.catalog_label
+            ),
             "issue": 257,
+            "catalog_label": args.catalog_label,
             "generated_at": datetime.now(UTC).isoformat(timespec="seconds"),
             "note": (
                 "Share of present imagery carrying no usable capture date, per provider. "
@@ -243,7 +262,9 @@ def main() -> int:
                 "different sampling frames and are never pooled. Both are proxies for the "
                 "ROAD-WALK undated share, which no walk recorded until #257 added "
                 "dated_covered_samples. No data_dir is recorded: an absolute path would "
-                "put one machine's layout into a committed file."
+                "put one machine's layout into a committed file -- `catalog_label` names "
+                "which catalog was read instead, since a dev catalog and production give "
+                "materially different answers for the same provider."
             ),
         },
         "catalog": catalog,

--- a/streetscape_street_analyzer/street_coverage.py
+++ b/streetscape_street_analyzer/street_coverage.py
@@ -420,12 +420,15 @@ def compute_streetwalk_coverage(
     summed into ``covered_samples_dated``/``dated_pct_of_covered`` by
     ``summarize_streetwalk_coverage``. Without it an age median over 3% of a
     KartaView edge's coverage would be indistinguishable from one over all of
-    a GSV edge's. How far apart they run is provider-specific by three orders
-    of magnitude — 9.6% of audited KartaView photos are undated by its
-    ``shot_date >= date_added`` rule against 0.010% of GSV's grid panos (see
-    ``docs/experiments/undated-imagery-share.md``) — and for KartaView the
-    undated population is not a random sample of the imagery but its NEWEST,
-    one 2025-11-19 bulk ingest, so dropping it biases the age median OLD.
+    a GSV edge's. How far apart they run is provider-specific, and undated
+    imagery arrives in BATCHES rather than as diffuse noise: GSV and Mapillary
+    both read zero through the 95th percentile of runs, yet one Mapillary run
+    is 23.3% undated against GSV's worst 0.34%, and 9.6% of audited KartaView
+    photos are undated by its ``shot_date >= date_added`` rule (see
+    ``docs/experiments/undated-imagery-share.md``). So the per-run MAXIMUM is
+    what to design against, never the pooled share. A batch is also a single
+    point in time by construction — KartaView's is one 2025-11-19 bulk ingest,
+    i.e. its NEWEST imagery, so dropping it biases that age median OLD.
 
     Args:
         edges: WGS84 LineString GeoDataFrame with ``edge_id`` (+ optional


### PR DESCRIPTION
Follow-up to https://github.com/jonfroehlich/streetscape-tracker/pull/261. Docs, one docstring, and the committed metrics — no behavior change.

## The problem

The numbers that shipped with #257 were read off a **development laptop's catalog**, which holds the full 1,144-city GSV baseline but only **three** Mapillary runs. On that evidence the writeup concluded Mapillary emits no undated imagery at all, and that *"small but real for Mapillary" is not supported by anything we hold.*

Production holds **1,201** Mapillary runs and says the opposite. The original prose claim was right; the refutation was an artifact of n=3.

Re-run on makelab2 against the production catalog. Read-only — nothing was deployed there, the checkout is at the same HEAD, and the temporary script and output were removed afterwards.

| | shipped (laptop) | **prod** |
|---|---|---|
| GSV pooled | 0.0101% | **0.0086%** |
| GSV worst run | 0.32% | **0.34%** |
| Mapillary pooled | 0.0% | **0.150%** (~17× GSV) |
| Mapillary worst run | 0.0% | **23.3%** |
| KartaView | 9.56% | 9.56% (unchanged — a committed API sample, not a catalog read) |

## The finding changed, not just the digits

The headline is no longer the cross-provider ratio. **Both providers read zero through the 95th percentile of runs, and both have a long right tail**, because undated imagery arrives in **batches** rather than as diffuse noise:

- Mapillary's entire undated corpus is **99.96% four adjacent Denver-metro runs** (Denver 66,441; Commerce City 32,059; Lakewood 2,378; Englewood 1,810 — 102,688 of 102,733). The remaining seven runs contribute 45 panos between them. These are adjacent cities whose frozen grids overlap and Mapillary is a census provider, so the likeliest reading is one contributor's upload batch counted four times — flagged in the writeup as a hypothesis from the geography, not something this measurement establishes.
- KartaView's is one 2025-11-19 Grab ingest.
- GSV's is 119 of 1,749 runs, largely the big baseline metros.

So **the per-run maximum is what a decision has to survive**; a pooled per-provider rate describes no run in the distribution. That is the transferable lesson, and it now has three independent instances.

## What it changes downstream

`docs/street-coverage.md`'s phantom-delta guidance was too reassuring. A Denver-metro Mapillary walk would shift **2.7 percentage points** — larger than most real run-to-run coverage changes, so it will read as a substantial imagery refresh rather than as rounding noise. Worth knowing before the first post-#257 walk diffs land.

## `--catalog-label`

New required-in-practice flag on the analyzer, recorded in the metrics file and in its `generated_by` stamp. Which catalog was read is the single biggest determinant of these numbers and cannot be recovered from them afterwards — which is exactly how the first pass went wrong. A label, not a path, so no machine's directory layout lands in a committed file.

## Verification

Every number in the writeup re-checked against the committed JSON. Full suite green, `ruff format --check` and `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code) — Opus 5 (1M context), claude-opus-5[1m]