### PR TITLE
Correct enabled_providers' rationale: no shared budget, no deadline drop (#240)

### DIFF
--- a/streetscape_metadata_tracker/scheduler.py
+++ b/streetscape_metadata_tracker/scheduler.py
@@ -310,17 +310,39 @@ class SchedulerConfig:
             self.providers = {"gsv": ProviderConfig(daily_request_budget=self.daily_request_budget)}
 
     def enabled_providers(self) -> list[str]:
-        """Enabled channel names, most expensive first.
+        """Enabled channel names in a stable canonical order, most expensive first.
 
-        Order matters: a city's channels share one night's budget, so the series
-        that can actually exhaust a budget should claim it before the cheap ones.
-        gsv (grid) leads, then gsv_streets (the other per-request channel), then
-        the two tile-census Mapillary channels.
+        Deterministic and stable is most of what this buys, and the rest is
+        narrower than it looks. Two rationales this docstring used to give are
+        wrong, and both are recorded here because each one read as established
+        for long enough to be quoted elsewhere:
 
-        Above ``max_concurrent_channels = 1`` this is the SUBMIT order into the
-        lanes, and it still governs pricing for exactly the reason above. What it
-        does NOT do there is keep a per-IP host to one talker — host affinity in
-        the launch pass does that, and it would keep doing it under any ordering.
+        It is **not** a budget mechanism. ``daily_request_budget`` is per
+        ``ProviderConfig`` and ``db.get_api_usage`` is keyed by (date, provider),
+        so a city's channels never draw on a shared pot and no ordering can let
+        one claim it ahead of another. The pre-#240 wording ("run back-to-back
+        within one night's budget") was a claim about TIMING that was true
+        sequentially; rewording it to "share one night's budget" turned it into a
+        claim about a shared RESOURCE that was never true.
+
+        It does **not** decide what a batch deadline drops, either. That check
+        lives in ``_run_city_loop`` and fires BETWEEN cities, so once a city
+        starts, every one of its channels is attempted whatever the order — the
+        deadline only clamps each child's timeout, floored at
+        ``_MIN_CLAMPED_TIMEOUT_S``. Ranking a channel last therefore does not
+        protect a night from it.
+
+        What the order genuinely decides is which channels are already LAUNCHED
+        when something stops the city mid-flight. A SIGTERM wind-down is a submit
+        gate (#206): whatever has not been launched is declined and named by
+        ``_log_stop_declined``, so order picks the survivors. Above
+        ``max_concurrent_channels = 1`` this is also the submit order into the
+        lanes, so when a city has more channels than lanes it decides which claim
+        a slot first — and at one lane it is simply the execution order.
+
+        What it does NOT do above one lane is keep a per-IP host to one talker —
+        host affinity in the launch pass does that, and it would keep doing it
+        under any ordering.
         """
         rank = {"gsv": 0, "gsv_streets": 1, "mapillary": 2, "mapillary_streets": 3}
         return sorted(

--- a/streetscape_metadata_tracker/scheduler.py
+++ b/streetscape_metadata_tracker/scheduler.py
@@ -354,6 +354,18 @@ class SchedulerConfig:
         finished, and it applies above one lane too whenever a channel waits for
         a slot instead of getting one in the first pass.
 
+        That is a rule and not a law, and its limit is worth stating because the
+        rule inverts past it: it holds only while no single channel is long
+        enough to consume the deadline by itself. One that IS starves everything
+        behind it — put it first and its siblings launch against what is left,
+        down to the floor — so for such a channel the question stops being which
+        is most expensive and becomes which can best absorb being truncated.
+        Note what does NOT change under that reading: a resumable channel loses
+        less WORK to a SIGKILL, but no channel keeps its ledger row, because
+        every ``api_usage`` write happens in the child after the download
+        returns. Ranking picks who absorbs the truncation; it never makes it
+        free.
+
         What it does NOT do above one lane is keep a per-IP host to one talker —
         host affinity in the launch pass does that, and it would keep doing it
         under any ordering.

--- a/streetscape_metadata_tracker/scheduler.py
+++ b/streetscape_metadata_tracker/scheduler.py
@@ -312,10 +312,10 @@ class SchedulerConfig:
     def enabled_providers(self) -> list[str]:
         """Enabled channel names in a stable canonical order, most expensive first.
 
-        Deterministic and stable is most of what this buys, and the rest is
-        narrower than it looks. Two rationales this docstring used to give are
-        wrong, and both are recorded here because each one read as established
-        for long enough to be quoted elsewhere:
+        There IS a mechanism behind most-expensive-first, but it is not the one
+        this docstring gave for most of its life. Two rationales it used to give
+        are wrong, and both are recorded here because each read as established
+        long enough to be quoted elsewhere:
 
         It is **not** a budget mechanism. ``daily_request_budget`` is per
         ``ProviderConfig`` and ``db.get_api_usage`` is keyed by (date, provider),
@@ -339,6 +339,20 @@ class SchedulerConfig:
         ``max_concurrent_channels = 1`` this is also the submit order into the
         lanes, so when a city has more channels than lanes it decides which claim
         a slot first — and at one lane it is simply the execution order.
+
+        And it decides how much of the deadline each child is allowed to use,
+        which is the mechanical case for putting the expensive channels first.
+        ``remaining_s`` is read fresh at every launch — one ``time.monotonic()``
+        per LAUNCHED channel — and ``city_timeout_seconds`` clamps the derived
+        timeout down to it, floored at ``_MIN_CLAMPED_TIMEOUT_S``. A channel
+        launched later sees less of the deadline, so a long one ranked late can
+        have its timeout truncated to the floor and be SIGKILLed part-way; a
+        killed child records no ``api_usage`` at all, so its already-spent
+        requests vanish from the ledger (#238). The channel that needs the most
+        wall-clock should therefore start while the most of it remains. This is
+        stark at one lane, where each channel launches only once the previous has
+        finished, and it applies above one lane too whenever a channel waits for
+        a slot instead of getting one in the first pass.
 
         What it does NOT do above one lane is keep a per-IP host to one talker —
         host affinity in the launch pass does that, and it would keep doing it

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1522,11 +1522,14 @@ def test_enabled_providers_orders_expensive_channels_first():
 
     Pinned for what the order actually decides rather than for a budget story:
     it is the submit order, so it picks which channels are already LAUNCHED when
-    a SIGTERM wind-down declines the rest (#206), and which claim a lane first
-    when a city has more channels than lanes. It decides nothing about budgets —
-    those are per-channel — and nothing about what a batch deadline drops, which
-    is a between-cities check. See `enabled_providers` for why both of those read
-    as established for a while.
+    a SIGTERM wind-down declines the rest (#206), which claim a lane first when a
+    city has more channels than lanes, and — the mechanical case for expensive
+    channels leading — how much of the batch deadline each child's timeout clamp
+    is allowed to see, since `remaining_s` is read fresh at every launch.
+
+    It decides nothing about budgets, which are per-channel, and nothing about
+    what a batch deadline DROPS, which is a between-cities check. See
+    `enabled_providers` for why both of those read as established for a while.
     """
     assert _street_cfg().enabled_providers() == [
         "gsv",

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1518,8 +1518,16 @@ def test_street_channels_parse_as_real_providers(tmp_path):
 
 
 def test_enabled_providers_orders_expensive_channels_first():
-    """A city's channels run back-to-back inside one night's budgets, so the
-    series that can actually exhaust a budget must claim it first."""
+    """The canonical order is stable, which is what other things are read against.
+
+    Pinned for what the order actually decides rather than for a budget story:
+    it is the submit order, so it picks which channels are already LAUNCHED when
+    a SIGTERM wind-down declines the rest (#206), and which claim a lane first
+    when a city has more channels than lanes. It decides nothing about budgets —
+    those are per-channel — and nothing about what a batch deadline drops, which
+    is a between-cities check. See `enabled_providers` for why both of those read
+    as established for a while.
+    """
     assert _street_cfg().enabled_providers() == [
         "gsv",
         "gsv_streets",


### PR DESCRIPTION
Docs-only follow-up to #264. No behaviour change: the `rank` dict and the pinned order are untouched, and the only edits are two docstrings.

## The claim that was wrong

`enabled_providers` said a city's channels **"share one night's budget, so the series that can actually exhaust a budget should claim it before the cheap ones."** There is no shared pot — `daily_request_budget` is per-`ProviderConfig` and `db.get_api_usage` is keyed by `(date, provider)`, so a city's channels never draw on one budget and no ordering can let one claim it ahead of another.

Traced how it got there. Pre-#240 the text read *"run back-to-back **within** one night's budget"* — a claim about **timing**, and true in sequential mode. `9d20afe` reworded it to *"**share** one night's budget"* because back-to-back had stopped being true under lanes. That swap quietly converted a timing claim into a shared-**resource** claim that was never true, and carried the trailing "should claim it before the cheap ones" along unchanged — where it now reads as the load-bearing justification for the whole rank dict.

## The second wrong claim, which replaced it

The obvious repair is "it's a deadline-priority order — rank a channel last and it's the first thing a truncated night drops." That is also false, and it is worth writing down because it is the rationale a reader reaches for next.

The batch deadline is checked in `_run_city_loop`, **between cities**. The launch pass has no deadline gate at all — only the lane cap and the SIGTERM submit gate. So once a city starts, every one of its channels is attempted whatever the order; the deadline only clamps each child's timeout, floored at `_MIN_CLAMPED_TIMEOUT_S`. Ranking a channel last does not protect a night from it.

## What the order actually decides

Three things, all verified against the launch pass:

1. **Which channels are already LAUNCHED when a wind-down stops the city.** A SIGTERM is a submit gate (#206) — whatever has not been launched is declined and named by `_log_stop_declined`. Order picks the survivors.
2. **Which claim a lane first** when a city has more channels than lanes. At one lane that is simply the execution order.
3. **How much of the deadline each child's timeout clamp is allowed to see** — and this one is the mechanical case for most-expensive-first.

The third was missed on the first pass of this PR, which concluded that stable-and-deterministic was most of what the ordering buys. That understated it. `remaining_s` is read fresh at every launch (one `time.monotonic()` per *launched* channel) and `city_timeout_seconds` clamps the derived timeout down to it, floored at `_MIN_CLAMPED_TIMEOUT_S`. A channel launched later sees less of the deadline, so a long channel ranked late can have its timeout truncated to the floor and be SIGKILLed part-way — and a killed child records **no** `api_usage` at all, so its already-spent requests vanish from the ledger (#238).

So the channel needing the most wall-clock should start while the most of it remains. Stark at one lane, where a channel launches only once the previous has finished; it applies above one lane whenever a channel waits for a slot rather than getting one in the first pass.

**The rule has a limit, and past it the rule inverts.** "Most expensive first" holds only while no single channel is long enough to consume the deadline by itself. At one lane the channels launch strictly in order, each reading a smaller `remaining_s` than the last — so a channel that long, placed first, starves everything behind it down to the floor. For such a channel the question stops being which is most expensive and becomes which can best absorb being truncated.

And resumability does not settle that either: a resumable channel loses less *work* to a SIGKILL, but no channel keeps its ledger row, because every `api_usage` write happens in the child after the download returns. Ranking picks who absorbs the truncation; it never makes it free.

**What that does and does not rehabilitate:** the old sentence's *conclusion* — expensive first — was right. Its stated *reason*, channels competing for one night's budget, is still false. A right answer for a wrong reason is still worth correcting, because the reason is what the next person reuses, and in this case four of them did.

## Why the wrong versions are recorded rather than deleted

Both are kept in the docstring as explicitly-wrong history. Each read as established long enough to be quoted elsewhere: the test docstring corrected here carried the older wording verbatim, and two further copies (a test docstring and a paragraph in `docs/census.md`) were caught on an unmerged branch, written by someone reading this text four lines above where they were working.

Proximity is what made it look settled. Deleting the sentence would leave the next person free to re-derive it.

## The pattern, since there were four versions

Every wrong version — the two corrected here and the two the follow-up commit replaces — was produced by reasoning from adjacent prose instead of reading the code that prose describes. The launch pass was ~200 lines away the whole time. Reading it settled all four questions in one pass: no deadline gate, no shared ledger, a fresh clock read per launch. The cheap check was available from the start.

🤖 Generated with [Claude Code](https://claude.com/claude-code) — Opus 5 (1M context), claude-opus-5[1m]
