### PR TITLE
State the street-coverage headline in the positive, for every provider

### DIFF
--- a/streetscape_metadata_tracker/json_summarizer.py
+++ b/streetscape_metadata_tracker/json_summarizer.py
@@ -978,8 +978,12 @@ def generate_streetwalk_manifest(conn, data_dir: str) -> dict[str, Any]:
             # the streets page can show "no data" instead of implying the
             # flat footprint was measured.
             "coverage_pct_by_length_any": row["coverage_pct_by_length_any"],
-            # street_walks has no uncovered column; derive it so the frontend
-            # headline ("X% of street-km have no imagery") needs no math.
+            # The complement of `coverage_pct_by_length`, derived here because
+            # street_walks has no uncovered column. Every headline on the site
+            # now quotes coverage in the POSITIVE ("X% of street-km has
+            # imagery"), so nothing in the frontend reads this today; it stays
+            # because it is a published manifest field, and a consumer asking
+            # "how big is the gap?" should not have to do the subtraction.
             "uncovered_pct_by_length": None if pct is None else round(100 - pct, 1),
             "edges": row["edges_total"],
             "edges_fully_covered": row["edges_fully_covered"],

--- a/tests/e2e/test_smoke.py
+++ b/tests/e2e/test_smoke.py
@@ -362,10 +362,13 @@ def test_city_page_renders_the_road_walk_street_overlay(page: Page, base_url):
     expect(panel).to_be_visible()
 
     # Headline reads the streetwalk totals through the key aliasing
-    # (edges/edges_any_coverage → segments/covered): 14.9% uncovered by length,
-    # 2 of 2 edges with some coverage.
+    # (edges/edges_any_coverage → segments/covered): 85.1% of street-km covered
+    # by length, 2 of 2 edges with some coverage. Stated in the positive — the
+    # complement (uncovered_pct_by_length, 14.9) is deliberately NOT what the
+    # panel quotes.
     headline = page.locator("#street-coverage-headline")
-    expect(headline).to_contain_text("14.9%")
+    expect(headline).to_contain_text("85.1%")
+    expect(headline).to_contain_text("has Google Street View imagery")
     expect(headline).to_contain_text("2 of 2 segments covered")
 
     # A fractional artifact opens on the graduated Coverage ramp, not Age.

--- a/www/js/__tests__/street-coverage.test.js
+++ b/www/js/__tests__/street-coverage.test.js
@@ -253,7 +253,12 @@ test("normalizeStreetArtifact: streetwalk aliases age + totals keys and flags fr
   const fc = {
     properties: {
       metadata: {
-        totals: { edges: 41, edges_any_coverage: 40, uncovered_pct_by_length: 4.4 },
+        totals: {
+          edges: 41,
+          edges_any_coverage: 40,
+          coverage_pct_by_length: 95.6,
+          uncovered_pct_by_length: 4.4,
+        },
         coverage_by_highway: {},
       },
     },
@@ -397,7 +402,12 @@ function streetwalkArtifact() {
   return {
     properties: {
       metadata: {
-        totals: { edges: 2, edges_any_coverage: 2, uncovered_pct_by_length: 1.6 },
+        totals: {
+          edges: 2,
+          edges_any_coverage: 2,
+          coverage_pct_by_length: 98.4,
+          uncovered_pct_by_length: 1.6,
+        },
         coverage_by_highway: { residential: { length_km: 1 } },
       },
     },
@@ -419,7 +429,12 @@ function gridArtifact() {
   return {
     properties: {
       metadata: {
-        totals: { segments: 2, covered: 1, uncovered_pct_by_length: 12.0 },
+        totals: {
+          segments: 2,
+          covered: 1,
+          coverage_pct_by_length: 88.0,
+          uncovered_pct_by_length: 12.0,
+        },
         coverage_by_highway: { residential: { length_km: 1 } },
       },
     },

--- a/www/js/street-coverage.js
+++ b/www/js/street-coverage.js
@@ -509,15 +509,20 @@ function buildStreetCoveragePanel(map, layer, meta, provider, options) {
   let selection = null; // {type, covered} spotlight, or null
   let gapsOnly = false; // "Highlight gaps" toggle
 
-  const uncoveredPct = totals.uncovered_pct_by_length;
+  // Stated in the positive — "98.9% of street-km has imagery", not "1.1% has
+  // none" — and the same orientation for every provider, so this number reads
+  // the same way as the coverage percentages everywhere else on the site (the
+  // overview popup, streets.html). `coverage_pct_by_length` is what both
+  // artifacts measure; `uncovered_pct_by_length` is only its complement.
+  const coveredPct = totals.coverage_pct_by_length;
   container.innerHTML = `
     <div id="street-coverage-header">
       <strong>Street coverage</strong>
     </div>
     <p id="street-coverage-headline">
-      <span class="street-headline-pct">${uncoveredPct}%</span>
-      <span class="street-headline-text">of street-km have
-      no ${providerLabel} imagery</span>
+      <span class="street-headline-pct">${coveredPct}%</span>
+      <span class="street-headline-text">of street-km
+      has ${providerLabel} imagery</span>
       <span class="street-headline-sub">
         (${totals.covered.toLocaleString()} of
         ${totals.segments.toLocaleString()} segments covered)


### PR DESCRIPTION
The per-city street-coverage panel led with the complement:

> **1.1%** of street-km have no Google Street View imagery

It now leads with the number itself:

> **98.9%** of street-km has Google Street View imagery
> *(1,234 of 1,248 segments covered)*

This was the one coverage figure on the site read in the opposite direction from all the others — the overview-map popup (`index.js`) and `streets.html` both quote coverage, not its complement. `providerLabel` comes from the `PROVIDERS` registry, so GSV, Mapillary and KartaView all get the same orientation and the same sentence.

## What changed

- **`www/js/street-coverage.js`** — the headline reads `totals.coverage_pct_by_length` instead of `totals.uncovered_pct_by_length`. That is the value both artifact builders actually measure (`summarize_coverage` for the grid `_streets.json.gz`, and the road-walk summarizer); the uncovered field was derived *from* it. So there's no second rounding, and no fallback is needed — neither builder can emit one without the other.
- **`streetscape_metadata_tracker/json_summarizer.py`** — the streetwalk manifest's derived `uncovered_pct_by_length` justified itself as "so the frontend headline needs no math", which is no longer true. The field stays (it is a published manifest field, and a consumer asking "how big is the gap?" shouldn't have to subtract), but the comment now says accurately that nothing in the frontend reads it.
- **`tests/e2e/test_smoke.py`** — the road-walk overlay test pinned `14.9%`; it now pins `85.1%` (the fixture's coverage, the complement of the same number) and the positive phrasing.
- **`www/js/__tests__/street-coverage.test.js`** — the three artifact fixtures now carry `coverage_pct_by_length` alongside the uncovered value, matching what a real artifact contains.

The "Highlight gaps" toggle, the dashed no-coverage styling and the stacked covered-vs-uncovered chart are untouched — those answer "which streets have none?", which is a different question from the headline.

## Testing

- `node --test www/js/__tests__/street-coverage.test.js` — 41/41
- `pytest tests/test_street_coverage.py tests/test_streetwalk_manifest.py` — 67/67
- `pytest tests/e2e -m e2e -k street` — 14/14, including the updated headline assertion
- `ruff check` + `ruff format --check` on the changed Python

🤖 Generated with [Claude Code](https://claude.com/claude-code) — Opus 5 (1M context), claude-opus-5[1m]
