### PR TITLE
Give driving.html the shared sidebar layout, and delete the alternatives (#188)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -202,7 +202,7 @@ Static vanilla JS + Leaflet + Chart.js 4 in `www/`, no build step, fetching the 
 `grid.html`/`streets.html`/`driving.html` are configuration over one shared table chassis with **no pagination or virtualization** (a new page's row count is a design constraint), and `createTableControls` (`www/js/table-controls.js`) **owns the whole query string** — two instances on one page fight over it, which is why `driving.html` renders unmatched plan areas as a summary rather than a second filtered table.
 All three share **one layout** — a sticky filter sidebar, a one-sentence lead with the rest in a closed disclosure, and per-filter histogram-sliders — and the alternatives are **deleted, not switched off**: no `layout` option, no sorted-column distribution strip, and `histogramBuckets` takes a required domain, since a self-scaling axis is right for a strip and wrong for a slider.
 But only `grid.html` and `streets.html` are pivoted to **one row per city**, providers as sub-columns (#250), so "Collected by" is a **scope, not just a row filter** — it redirects what the numeric filters read, or "coverage over 80%" silently means "some provider's".
-A `driving.html` row is a **place**, so it keeps a flat single-row header and is the only caller of that `theadHtml` branch.
+A `driving.html` row is a **place**, so it keeps a flat single-row header — the only page that renders that `theadHtml` branch **by default**, never its only caller (grid/streets reach it whenever every grouped column is unchecked, so deleting it breaks them).
 Anything fanning out over the provider registry must gate on presence in the payload — a registered provider is not a collected one.
 Mapillary attribution is required by their ToS.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -200,7 +200,9 @@ The raw feed archive lives outside `data/` (mirroring a vendor's file is not our
 Static vanilla JS + Leaflet + Chart.js 4 in `www/`, no build step, fetching the published `data/`.
 `www/js/streetscape-utils.js` holds the provider registry and `adaptCityRecord`, which flattens v1/v2/v3 aggregate records into one normalized shape.
 `grid.html`/`streets.html`/`driving.html` are configuration over one shared table chassis with **no pagination or virtualization** (a new page's row count is a design constraint), and `createTableControls` (`www/js/table-controls.js`) **owns the whole query string** — two instances on one page fight over it, which is why `driving.html` renders unmatched plan areas as a summary rather than a second filtered table.
-`grid.html` and `streets.html` are pivoted to **one row per city**, providers as sub-columns (#250), so "Collected by" is a **scope, not just a row filter** — it redirects what the numeric filters read, or "coverage over 80%" silently means "some provider's".
+All three share **one layout** — a sticky filter sidebar, a one-sentence lead with the rest in a closed disclosure, and per-filter histogram-sliders — and the alternatives are **deleted, not switched off**: no `layout` option, no sorted-column distribution strip, and `histogramBuckets` takes a required domain, since a self-scaling axis is right for a strip and wrong for a slider.
+But only `grid.html` and `streets.html` are pivoted to **one row per city**, providers as sub-columns (#250), so "Collected by" is a **scope, not just a row filter** — it redirects what the numeric filters read, or "coverage over 80%" silently means "some provider's".
+A `driving.html` row is a **place**, so it keeps a flat single-row header and is the only caller of that `theadHtml` branch.
 Anything fanning out over the provider registry must gate on presence in the payload — a registered provider is not a collected one.
 Mapillary attribution is required by their ToS.
 

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -15,8 +15,9 @@ An edit that changes a rule belongs in both files; anything written since the sp
 `city.js` streams the run's csv.gz (provider derived from the filename token; GSV rows filtered to official `© Google`, Mapillary rows all kept) and has a snapshot `<select>` filtered to the active provider's runs.
 Data is fetched from `https://makeabilitylab.cs.washington.edu/public/streetscape-tracker/data/`, populated by `sync_data_to_server.sh` (which publishes only `*.csv.gz`/`*.json.gz` — logs, the DB, and bare CSVs are excluded).
 Mapillary attribution is required by their ToS and rendered in the Leaflet attribution control.
-`grid.html`/`streets.html`/`driving.html` are **configuration over a shared chassis**, not bespoke pages: `table-utils.js` + `table-controls.js` (plus `histogram-slider.js`, loaded only by the two pivoted pages) provide sorting (nulls sink in both directions),
-diacritic-folded search, select/range/histogram-range/boolean filters, grouped two-row headers, column presets + picker, full URL round-trip and a clickable distribution strip, so a page is a column-descriptor array, a row model and a fetch.
+`grid.html`/`streets.html`/`driving.html` are **configuration over a shared chassis**, not bespoke pages: `table-utils.js` + `table-controls.js` + `histogram-slider.js` provide sorting (nulls sink in both directions),
+diacritic-folded search, select/range/histogram-range/boolean filters, grouped two-row headers, column presets + picker, a filter sidebar and full URL round-trip, so a page is a column-descriptor array, a row model and a fetch.
+All three load all three scripts and pass the same options; the chassis has no per-page layout switches left.
 Two constraints that shape what a new page may do: there is **no pagination or virtualization**
 — every keystroke re-renders all matching rows via `innerHTML`, and the largest page is `driving.html` at ~3,900 rows (`grid.html` fell from 1,501 to ~1,190 when it pivoted to one row per city)
 — and `createTableControls` **owns the whole query string**, so two instances on one page would fight over it (which is why `driving.html` renders unmatched plan areas as a summary section rather than a second table).
@@ -62,14 +63,15 @@ And this is a layout fact rather than a tidiness one: the default view carries t
 The visible leaf label is a bare provider name repeated under every metric group, so grid's default preset exposes eight sort buttons under **three** distinct accessible names, in one tab order and one rotor list.
 Reading the *table* is fine — AT associates the `scope="colgroup"` cell with the body cells during table navigation — but a controls list gets the button's accessible name and nothing else, and the disambiguating text lived only in a hover-only `title`.
 The column picker's flat checkbox list hit the identical problem one layer over, and `pickerLabel` is the string it already computes for it.
-Emitted only where a descriptor supplies one, so driving.html's header markup does not move.
+Emitted only where a descriptor supplies one, so driving.html — whose columns are ungrouped and carry no `pickerLabel` — emits no `aria-label` at all, and its header markup is unchanged.
 
 ## Histogram-slider filters replaced the distribution strip (issue #250)
 
 *Written after the split.*
 
-**Those two pages replaced the sorted-column distribution strip with per-filter histogram-sliders; driving.html keeps the strip, byte-identically.**
-The strip visualizes the ACTIVE SORT COLUMN over the CURRENTLY FILTERED rows, which made it change its own meaning twice over: re-sorting silently swapped its metric, and clicking a bar filtered the rows the strip was drawn from, so the picture collapsed under the very interaction it invited.
+**Per-filter histogram-sliders replaced the sorted-column distribution strip.**
+The strip visualized the ACTIVE SORT COLUMN over the CURRENTLY FILTERED rows, which made it change its own meaning twice over: re-sorting silently swapped its metric, and clicking a bar filtered the rows the strip was drawn from, so the picture collapsed under the very interaction it invited.
+#250 took it off the two pivoted pages and left it on driving.html; driving.html has since moved to the sidebar too, and the strip is now **deleted from the chassis** rather than switched off per page — see the section below.
 `histogram-slider.js` gives each numeric filter one histogram, on one metric, with a dual-handle brush
 — the interaction mechanics (two native range inputs on one track, thumbs clamped against each other, the band between them draggable as a window, the z-index hack that keeps the low thumb grabbable when both are pinned at the top) lifted from index.js's legend slider and generalized from integer bucket indices to continuous values.
 Three of its properties are the reason it is not just prettier.
@@ -81,9 +83,10 @@ Steps come from `sliderStepFor` (~100 arrow presses across the domain, on a 1/2/
 The min/max **number inputs stay** as the precision path and keep their `data-filter`/`data-bound` hooks verbatim — `syncControlsToState`, `handleControlChange` and the e2e selectors all read them, and the range handles deliberately carry no `data-filter` so `querySelectorAll('[data-filter=KEY]')` still returns exactly two elements.
 A bound typed on the right moves the handles on the left and the component's normalized value is read BACK as the state, so the two halves of one control cannot show different windows.
 Cost, measured in-browser against the real published aggregate (1,187 cities, 2,254 series): one filter pass **1.4 ms**, all three crossfilter histogram passes **3.6 ms**, sort + `innerHTML` of 311 matched rows **12.3 ms** — so the extra passes are ~4 ms of a ~17 ms keystroke, comfortably inside a frame.
-**What protects driving.html is enforcement, not care**: `theadHtml` emits exactly the pre-#250 single `<tr>` when no visible column carries a `group` (a test compares the two strings), and `controlsHtml`'s default `layout: "inline"` was verified byte-identical against `origin/main` over driving.js's real descriptors
-— which is why that branch carries a literal `"\n      "` where the old `${filterControls}` interpolation sat.
-Every new CSS rule is scoped under `.with-sidebar` / `.streets-main--wide` / `.th-group` / `.hist-*` / `.delta-*`, none of which driving.html emits.
+**What protected driving.html through #250 was enforcement, not care**, and the surviving half of that is still load-bearing: `theadHtml` emits exactly the pre-#250 single `<tr>` when no visible column carries a `group`, and a test compares the two strings rather than trusting the eye.
+driving.html is still the page that renders through it — its rows are places, not a pivot — so that branch has a real caller and a real browser test.
+The other half is gone with the page's old layout: `controlsHtml` carried a second `layout: "inline"` branch, verified byte-identical against `origin/main` over driving.js's real descriptors, with a literal `"\n      "` standing in for the old `${filterControls}` interpolation.
+The CSS scoping under `.with-sidebar` / `.streets-main--wide` / `.hist-*`, which is what kept driving.html's old strip untouched, is likewise now scoping that every table page opts into.
 Two things the first cut of this got wrong, both caught in review.
 **The snapped axis is the ONLY axis, and the chassis has to be handed it back.**
 `setDomain` snapped internally while `syncHistogramDomains` kept the RAW extent and passed that to `histogramBuckets`, so the bars were bucketed over `[dataMin, dataMax]` while the thumbs and `.hist-fill` were positioned over `[snappedMin, snappedMax]` — both painted across the same 100% width, i.e.
@@ -107,7 +110,7 @@ A pivoted row holds one number per provider, so "coverage over 80%" is not a com
 Measured on the live catalog, "Mapillary + ≥ 80%" returned **56 cities and not one of them had Mapillary coverage over 80** — every one matched on GSV's number, and since nothing anywhere reaches 80% on Mapillary (catalog max 47.6) the truthful answer was zero rows; the bars had the same defect, drawing GSV's spread under a Mapillary selection.
 Picking a provider now points each numeric filter at that provider's column, redraws the bars over its distribution, re-seeds the axis to its range and rewrites the wording that says whose numbers these are (the legend AND both thumbs' `aria-label`, or a screen reader announces "Minimum Grid coverage %" while the handle brushes Mapillary's column);
 "Any provider" keeps the exists-semantics with the quantifier spelled out ("any provider reaches", "freshest of any") rather than a bare "best" that never said across what.
-The mechanism is a descriptor opt-in — `fieldFor`/`labelFor`/`testFor(values)`, resolved by `resolveFilters` into the live view that `applyFilters`, `rowsExceptFilter` and the histograms all read — and **a descriptor declaring none of them passes through by IDENTITY**, which is what keeps driving.html and the plain `range` filters unaware of any of it.
+The mechanism is a descriptor opt-in — `fieldFor`/`labelFor`/`testFor(values)`, resolved by `resolveFilters` into the live view that `applyFilters`, `rowsExceptFilter` and the histograms all read — and **a descriptor declaring none of them passes through by IDENTITY**, which is what keeps driving.html's filters unaware of any of it: a driving row is a place with one GSV number, so there is nothing there to scope.
 Three decisions inside it.
 **(1) A scope change re-seeds the axis**, the single exception to the fixed-axis rule above: it is a different gesture from brushing, and a Mapillary-scoped coverage axis genuinely should not span GSV's range.
 **(2) A scope change CLEARS that filter's window** rather than carrying it across, because clamping silently rewrites the question — "≥ 80%" against a 0–47.6% axis becomes "≥ 47.6%" and returns a row where the honest answer is none.
@@ -122,15 +125,37 @@ One bug the clear path exposed is worth keeping named: three paths change a wind
 *Written after the split.*
 
 **The filter sidebar is a native `<details>`, and the one hole that leaves is closed in JS.**
-grid.html and streets.html put search/selects/columns/sliders/checkboxes in a ~280px column beside the table (page measure 1200 → 1500px) that collapses to a "Filters" disclosure at ≤900px; native semantics give keyboard and AT support for nothing.
+The table pages put search/selects/columns/sliders/checkboxes in a ~280px column beside the table (page measure 1200 → 1500px) that collapses to a "Filters" disclosure at ≤900px; native semantics give keyboard and AT support for nothing.
 Above the breakpoint the `<summary>` is `display: none` and the panel is simply a column — which means a panel collapsed on a narrow screen and then widened would be closed with its only toggle gone, stranding filters that are in the URL and cannot be seen or changed.
 `wireSidebarDisclosure` re-opens it on widening, one-way (narrowing never closes what the reader opened).
-`controlsHtml`'s `layout: "sidebar"` orders the sections search → selects → columns → numeric windows → booleans → clear, partitioning by filter TYPE with an "everything else" bucket so a type added later renders in the wrong place rather than not at all;
+`controlsHtml` orders the sections search → selects → columns → numeric windows → booleans → clear, partitioning by filter TYPE with an "everything else" bucket so a type added later renders in the wrong place rather than not at all
+— it took a `layout` option to pick between this order and driving.html's old horizontal one until that page moved here too;
 below the breakpoint the same controls become a `repeat(auto-fit, minmax(220px, 1fr))` GRID rather than a wrapping flex row, since a tall wide histogram-slider and a short narrow select interleave into a ragged block under `flex-wrap`.
 **`.table-sidebar` itself carries the card chrome and the sticky full-viewport height**, with `.table-controls` transparent inside it
 — the obvious alternative, a flex chain stretching the controls to fill, does not survive contact with `<details>`: modern Chromium gives it a `::details-content` box, so `.controls-region` is not a flex item of the disclosure at all and simply does not grow (measured: sidebar 886px, controls 637px).
-**And the pages lead with one sentence, not a screen of prose** (`.page-head` / `.page-lead` / a closed `.page-about` disclosure): these two are instruments rather than articles, and the preamble was pushing both the table and its filters below the fold.
-driving.html keeps its full `.streets-intro`, which is doing a different job — that page's verdicts do not mean anything until the plan-vs-observed contradiction has been explained.
+**And the pages lead with one sentence, not a screen of prose** (`.page-head` / `.page-lead` / a closed `.page-about` disclosure): these are instruments rather than articles, and the preamble was pushing both the table and its filters below the fold.
+driving.html held out on a full three-paragraph `.streets-intro` on the grounds that its verdicts do not mean anything until the plan-vs-observed contradiction has been explained; it now leads with one sentence like the others, with that explanation one click away rather than gone.
+`.streets-intro` had no other user and went with it.
+
+## All three table pages share one layout, and the alternatives are deleted
+
+*Written after the split.*
+
+**driving.html now renders the same sidebar, page head and histogram filters as grid.html and streets.html, and the two shapes it used to be the only caller of are gone.**
+#250 rebuilt the pivoted pages and deliberately left driving.html alone; the result was one page plus two rather than three pages over one chassis, which is the opposite of what "configuration over a shared chassis" is supposed to buy.
+What moved: `.streets-main--wide` and the `.table-layout.with-sidebar` markup, the compact `.page-head` with its closed `.page-about` disclosure, and `histogram-range` on all three numeric filters.
+What did NOT move is the pivot — a driving row is a **place** (a tracked city, or a plan area covering none), so no column declares a `group`, `theadHtml` still emits its flat single `<tr>`, and there are no Δ cells and no provider scope.
+The sidebar and the pivot were separable, and only one of them was ever about providers.
+
+**Two chassis features had no remaining caller afterwards, and were deleted rather than kept warm.**
+The sorted-column distribution strip (`renderDistributionStrip`, `formatStripSummary`, `medianOf`, `bucketCountFor`, `showDistributionStrip`, the bar-click handler and the `.strip-*` CSS) went, along with `controlsHtml`'s `layout: "inline"` branch and the `layout` option itself.
+An alternative layout nothing renders is one nothing tests either, and the strip in particular carried a live footgun: `histogramBuckets` took a `domain = null` default that scaled the axis to the values, which is exactly right for a strip describing the rows in view and exactly wrong for a slider whose handles must not move under the reader's hand — the two-axes bug above was one call site away the whole time.
+`domain` is now required, and there is one axis rule instead of two.
+
+**What was NOT deleted, and why: `type: "range"`.**
+No page declares one today, but `histogram-range`'s markup embeds `range`'s two number inputs verbatim, and the unit tests that make `histogram-range` trustworthy assert it against a plain `range` TWIN in unset/pass/parse/serialize rather than against typed expectations.
+Removing `range` would mean removing the comparison that pins them as one value shape.
+`isRangeType` has to accept both regardless.
 
 ## Site navigation + street-coverage discoverability
 

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -19,7 +19,7 @@ Mapillary attribution is required by their ToS and rendered in the Leaflet attri
 diacritic-folded search, select/range/histogram-range/boolean filters, grouped two-row headers, column presets + picker, a filter sidebar and full URL round-trip, so a page is a column-descriptor array, a row model and a fetch.
 All three load all three scripts and pass the same options; the chassis has no per-page layout switches left.
 Two constraints that shape what a new page may do: there is **no pagination or virtualization**
-— every keystroke re-renders all matching rows via `innerHTML`, and the largest page is `driving.html` at ~3,900 rows (`grid.html` fell from 1,501 to ~1,190 when it pivoted to one row per city)
+— every keystroke re-renders all matching rows via `innerHTML`, and the largest page is `driving.html` at ~3,800 rows (`grid.html` fell from 1,501 to ~1,190 when it pivoted to one row per city)
 — and `createTableControls` **owns the whole query string**, so two instances on one page would fight over it (which is why `driving.html` renders unmatched plan areas as a summary section rather than a second table).
 
 ## The two data-table pages are pivoted: one row per city (issue #250)
@@ -86,7 +86,7 @@ Cost, measured in-browser against the real published aggregate (1,187 cities, 2,
 **What protected driving.html through #250 was enforcement, not care**, and the surviving half of that is still load-bearing: `theadHtml` emits exactly the pre-#250 single `<tr>` when no visible column carries a `group`, and a test compares the two strings rather than trusting the eye.
 driving.html is still the page that renders through it — its rows are places, not a pivot — so that branch has a real caller and a real browser test.
 The other half is gone with the page's old layout: `controlsHtml` carried a second `layout: "inline"` branch, verified byte-identical against `origin/main` over driving.js's real descriptors, with a literal `"\n      "` standing in for the old `${filterControls}` interpolation.
-The CSS scoping under `.with-sidebar` / `.streets-main--wide` / `.hist-*`, which is what kept driving.html's old strip untouched, is likewise now scoping that every table page opts into.
+The CSS scoping under `.with-sidebar` / `.streets-main--wide`, which is what kept driving.html's old strip untouched, is likewise gone — every table page got it, so it became the base rule.
 Two things the first cut of this got wrong, both caught in review.
 **The snapped axis is the ONLY axis, and the chassis has to be handed it back.**
 `setDomain` snapped internally while `syncHistogramDomains` kept the RAW extent and passed that to `histogramBuckets`, so the bars were bucketed over `[dataMin, dataMax]` while the thumbs and `.hist-fill` were positioned over `[snappedMin, snappedMax]` — both painted across the same 100% width, i.e.
@@ -143,7 +143,8 @@ driving.html held out on a full three-paragraph `.streets-intro` on the grounds 
 
 **driving.html now renders the same sidebar, page head and histogram filters as grid.html and streets.html, and the two shapes it used to be the only caller of are gone.**
 #250 rebuilt the pivoted pages and deliberately left driving.html alone; the result was one page plus two rather than three pages over one chassis, which is the opposite of what "configuration over a shared chassis" is supposed to buy.
-What moved: `.streets-main--wide` and the `.table-layout.with-sidebar` markup, the compact `.page-head` with its closed `.page-about` disclosure, and `histogram-range` on all three numeric filters.
+What moved: the wide measure and the `.table-layout` markup, the compact `.page-head` with its closed `.page-about` disclosure, and `histogram-range` on all three numeric filters.
+Once all three pages carried them, the `.streets-main--wide` and `.with-sidebar` modifiers were folded into their base rules and the sidebar chrome moved into `createTableControls` — a class every caller sets is a base value wearing a class name, and its failure mode was silent (a fourth page forgetting one lands on a strip layout nothing has rendered since, with `wireSidebarDisclosure` returning null and no error anywhere).
 What did NOT move is the pivot — a driving row is a **place** (a tracked city, or a plan area covering none), so no column declares a `group`, `theadHtml` still emits its flat single `<tr>`, and there are no Δ cells and no provider scope.
 The sidebar and the pivot were separable, and only one of them was ever about providers.
 
@@ -152,10 +153,12 @@ The sorted-column distribution strip (`renderDistributionStrip`, `formatStripSum
 An alternative layout nothing renders is one nothing tests either, and the strip in particular carried a live footgun: `histogramBuckets` took a `domain = null` default that scaled the axis to the values, which is exactly right for a strip describing the rows in view and exactly wrong for a slider whose handles must not move under the reader's hand — the two-axes bug above was one call site away the whole time.
 `domain` is now required, and there is one axis rule instead of two.
 
-**What was NOT deleted, and why: `type: "range"`.**
-No page declares one today, but `histogram-range`'s markup embeds `range`'s two number inputs verbatim, and the unit tests that make `histogram-range` trustworthy assert it against a plain `range` TWIN in unset/pass/parse/serialize rather than against typed expectations.
-Removing `range` would mean removing the comparison that pins them as one value shape.
-`isRangeType` has to accept both regardless.
+**A third had none either, and the argument for keeping it did not survive review: `type: "range"`.**
+The case for keeping the bar-less flavour warm was that the tests making `histogram-range` trustworthy asserted it against a plain `range` TWIN in unset/pass/parse/serialize, so deleting `range` would delete the comparison pinning them as one value shape.
+That was wrong in a way worth recording: every one of those parity assertions dispatches through `isRangeType` FIRST, so `f(hist) === f(plain)` compared a branch against itself and could not fail.
+The twins are replaced by typed expectations (the `min~max` wire format written out, not compared), the shared test fixture now declares `histogram-range` like the real pages do, and the render branch, `.control-range` CSS and second `isRangeType` arm are deleted.
+What survives is the three per-page assertions that each numeric filter IS a `histogram-range` — more load-bearing now than before, since a descriptor left saying `range` no longer renders two number inputs, it falls off the end of `controlsHtml`'s type partition and renders as a **checkbox** for a `{min, max}` value.
+`isRangeType` itself stays as a one-arm predicate: it names why nine call sites are grouped (they reason about the value, not the widget).
 
 ## Site navigation + street-coverage discoverability
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -279,9 +279,10 @@ a scoped BOOLEAN resolving its `test` rather than only its wording, and
 — the one that catches a typo'd `base`
 — **every field a scoped filter can resolve to asserted to exist on a real row model**, for every provider in the registry, since a field that resolves to nothing filters nothing and looks like a working control.
 e2e: one row per city with a populated Δ and an absent-provider em-dash beside it, a Δ header click, the network selector's round-trip including a cold `?network=all_public` reload, a keyboard-only `ArrowRight` moving the rows AND the precision input AND the URL together, the crossfilter rule (a search redraws a slider's bars, its own brush does not),
-the sidebar beside the table at 1440px and collapsing at 600px and **re-opening on widening**, the column picker's self-contained `pickerLabel`s and the header collapsing back to ONE row when every optional column is unchecked, one test retargeted at driving.html pinning that its strip, its single-row header and its horizontal controls all survive;
+the sidebar beside the table at 1440px and collapsing at 600px and **re-opening on widening**, the column picker's self-contained `pickerLabel`s and the header collapsing back to ONE row when every optional column is unchecked;
 every per-provider cell of a row opening THAT provider's series while the Δ cells open nothing and a provider with no run here stays plain;
-and the layout asks themselves as outcomes rather than word counts — the table's first row and the search box both above the fold at 1440×900, the long prose present but closed, and the sidebar sticky, painted, and taller than 85% of the viewport;
+and the layout asks themselves as outcomes rather than word counts — the table's first row and the search box both above the fold at 1440×900, the long prose present but closed, and the sidebar sticky, painted, and taller than 85% of the viewport
+— all four of those layout tests parametrized over **all three** table pages once driving.html joined the sidebar (see below), so a page cannot quietly opt out of the shape;
 and the scope end to end in a browser
 — the unscoped legend naming its quantifier, a scope change clearing the window from all three of its carriers at once (rows, URL, precision input), the axis re-seeding to the scoped provider's range, both labels following it, a scoped window returning no rows where best-across would have returned a city whose own Mapillary number contradicts the filter,
 and a `?provider=&age=` link surviving a cold load rather than being cleared on arrival.
@@ -295,7 +296,26 @@ The two column/model seam tests (`every sortable column key exists on a row mode
 Six domains, including the three measured ones, a domain spanning zero, a sub-unit one and a degenerate one, each asserted to contain the data, to land on a whole number of steps (which is what makes both ends reachable at all), to overshoot by less than one step, and to agree with the `min`/`max`/`step` attributes the browser actually snaps against
 — the property, rather than one fixture's incidental span.
 Beside it: that `setDomain` hands back the SNAPPED axis rather than echoing its argument (an echo is exactly the two-axes bug), that a re-seeded axis re-normalizes the window it is holding, and that `destroy()` really aborts the one signal every listener was attached with — which is also what stops that method being untested API surface.
-Three smaller pins: a grouped leaf's header button carrying `pickerLabel` as `aria-label` **while a descriptor without one emits no `aria-label` at all** (driving.html's markup must not move);
+Three smaller pins: a grouped leaf's header button carrying `pickerLabel` as `aria-label` **while a descriptor without one emits no `aria-label` at all** (driving.html declares none, and its header markup must not move);
 `walkChangeCellHtml` rendering an exact zero unsigned and grey, matching `deltaCellHtml` one column over, while still signing a real direction;
 and `updateStreetsCaption` formatting its counts at a scale where the separator shows, since the fixture's own counts are single digits and would pass either way.
 And that aggregate records with no `city_id` stay DISTINCT rows with a warning rather than collapsing into one shared "Unknown" — latent, since the published v3 aggregate always carries one, which is exactly why it needed a test rather than a reader's trust.
+
+## driving.html joined the sidebar, and the alternatives lost their tests with their callers
+
+**The four shared layout e2e tests are now parametrized over grid.html, streets.html AND driving.html**, which is the whole assertion: the pages are one shape, and a page that drifts off it fails a test another page wrote.
+They cover the sidebar beside the table and collapsing at 600px, its sticky full-viewport height, the first-screen budget, and the strip's absence.
+driving.html is the tightest case on that last budget — it renders the archive-provenance callout above the layout as well as the page head — which is exactly why it is worth having in the parametrize list rather than exempted from it.
+
+**One test stayed page-specific, and its subject changed:** `test_driving_takes_the_sidebar_without_taking_the_pivot`.
+driving.html shares the chassis, the sidebar and the histograms but NOT the pivot — its rows are places, so no column declares a `group` — which makes it the only page exercising `theadHtml`'s flat single-`<tr>` branch in a real browser, and the only place a Δ-cell count of zero means anything.
+It replaced `test_distribution_strip_survives_on_the_driving_page`, whose premise (the strip was removed from two pages, not from the chassis) stopped being true.
+
+**Tests were deleted only where their subject was**, and it is worth being explicit about which:
+`bucketCountFor`, `medianOf`, `formatStripSummary` and the three `renderDistributionStrip` cases went with the strip itself.
+The `histogramBuckets` cases were rewritten rather than dropped — the helper survives, but its axis is now the caller's in every case, so the self-scaling assertions became fixed-domain ones and the "without a domain, nothing moves" test had nothing left to say.
+`controlsHtml`'s inline-order test went with the `layout` option; the sidebar-order test lost its `layout: "sidebar"` argument and kept every assertion, and it is still worth reading for the reason its fixture declares filters in a DIFFERENT order than they render in.
+
+**Added:** `DRIVING_FILTERS: numeric filters are histogram sliders over real row fields`, the contract grid.js and streets.js already carried.
+It asserts the field exists on **both** driving row kinds — a tracked city and a plan area — because the axis is seeded from the full row set, and a field present only on cities would read `undefined` off every untracked area without failing anything.
+A descriptor that silently stayed `type: "range"` still renders two working number inputs, so the defect it guards against looks deliberate rather than broken.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -301,21 +301,38 @@ Three smaller pins: a grouped leaf's header button carrying `pickerLabel` as `ar
 and `updateStreetsCaption` formatting its counts at a scale where the separator shows, since the fixture's own counts are single digits and would pass either way.
 And that aggregate records with no `city_id` stay DISTINCT rows with a warning rather than collapsing into one shared "Unknown" — latent, since the published v3 aggregate always carries one, which is exactly why it needed a test rather than a reader's trust.
 
-## driving.html joined the sidebar, and the alternatives lost their tests with their callers
+### driving.html joined the sidebar (issue #188 follow-up)
 
-**The four shared layout e2e tests are now parametrized over grid.html, streets.html AND driving.html**, which is the whole assertion: the pages are one shape, and a page that drifts off it fails a test another page wrote.
-They cover the sidebar beside the table and collapsing at 600px, its sticky full-viewport height, the first-screen budget, and the strip's absence.
-driving.html is the tightest case on that last budget — it renders the archive-provenance callout above the layout as well as the page head — which is exactly why it is worth having in the parametrize list rather than exempted from it.
+**The four shared layout e2e tests are parametrized over all three table pages** — that parametrization is described with the rest of the #250 e2e list above, and this is the entry that says WHY driving.html is in it: the pages are one shape, and a page that drifts off it now fails a test another page wrote.
+driving.html is the tightest case on the first-screen budget, since it renders the archive-provenance callout above the layout as well as the page head, which is exactly why it is worth having in the list rather than exempted from it.
 
 **One test stayed page-specific, and its subject changed:** `test_driving_takes_the_sidebar_without_taking_the_pivot`.
-driving.html shares the chassis, the sidebar and the histograms but NOT the pivot — its rows are places, so no column declares a `group` — which makes it the only page exercising `theadHtml`'s flat single-`<tr>` branch in a real browser, and the only place a Δ-cell count of zero means anything.
-It replaced `test_distribution_strip_survives_on_the_driving_page`, whose premise (the strip was removed from two pages, not from the chassis) stopped being true.
+driving.html shares the chassis, the sidebar and the histograms but NOT the pivot — its rows are places, so no column declares a `group` — which makes it the only page rendering `theadHtml`'s flat single-`<tr>` branch **by default** in a real browser, and the only place a Δ-cell count of zero means anything.
+That branch is a data-shape rule (`!visible.some((column) => column.group)`), not a driving.html feature, so it is emphatically not driving.html's to own: `test_unchecking_every_optional_column_actually_empties_the_table` already watches grid.html collapse to the same single `<tr>` with zero `th.th-group` once every grouped column is unchecked.
+Saying "only caller" here would invite a later PR to delete the branch along with a pivoted driving.html, and break grid/streets in a state only the advisory e2e job covers.
+It replaced `test_distribution_strip_survives_on_the_driving_page`, whose premise (the strip was removed from two pages, not from the chassis) stopped being true — and the replacement's **header-click assertions had to be rewritten to be positive ones**.
+The strip was what made a driving.html header click observable, because it retargeted itself at the newly sorted column; with the strip gone site-wide, asserting its absence after a click says nothing about the click, and inert header buttons passed.
+It now asserts `aria-sort` moving to the clicked column and off the old one, the `?sort=`/`?dir=` pair in the URL, and the first row actually changing between the two directions.
 
 **Tests were deleted only where their subject was**, and it is worth being explicit about which:
 `bucketCountFor`, `medianOf`, `formatStripSummary` and the three `renderDistributionStrip` cases went with the strip itself.
 The `histogramBuckets` cases were rewritten rather than dropped — the helper survives, but its axis is now the caller's in every case, so the self-scaling assertions became fixed-domain ones and the "without a domain, nothing moves" test had nothing left to say.
 `controlsHtml`'s inline-order test went with the `layout` option; the sidebar-order test lost its `layout: "sidebar"` argument and kept every assertion, and it is still worth reading for the reason its fixture declares filters in a DIFFERENT order than they render in.
+`controlsHtml: renders no sorted-column distribution strip` went too, for the opposite reason to the rest: its subject was already gone, and a `doesNotMatch(/distribution-strip/)` against a file that no longer contains the string cannot fail.
+So did the two `histogram-range` PARITY tests, which asserted `f(hist) === f(plainRange)` at every value-shaped call site — every one of those sites dispatches through `isRangeType` first, so both arguments took the same branch and the comparison was vacuous.
+Their content survives as typed expectations (the `min~max` wire format written out rather than compared), and the shared fixture in `table-controls.test.js` now declares `histogram-range`, the only numeric-window type left.
 
 **Added:** `DRIVING_FILTERS: numeric filters are histogram sliders over real row fields`, the contract grid.js and streets.js already carried.
 It asserts the field exists on **both** driving row kinds — a tracked city and a plan area — because the axis is seeded from the full row set, and a field present only on cities would read `undefined` off every untracked area without failing anything.
-A descriptor that silently stayed `type: "range"` still renders two working number inputs, so the defect it guards against looks deliberate rather than broken.
+It also pins each filter's `unit` and `digits`, which `histogram-slider.js` is the only reader of and which the plain `range` renderer these three came from never read: without them a thumb on the 0–12 yrs axis announces "0", "0", "1" for 0.2/0.4/0.6 while the column renders `0.2 yrs`, and every bucket tooltip reads "0–0: 12 rows".
+The type half of that assertion got MORE load-bearing when `type: "range"` was deleted: a descriptor left saying `range` no longer renders two working number inputs, it falls off the end of `controlsHtml`'s type partition and renders as a **checkbox** for a `{min, max}` value.
+
+**Added:** `test_a_page_with_nothing_published_shows_no_empty_sidebar`, parametrized over each page and the artifact that page cannot render without.
+The empty state is a real state of a real deployment — driving.html before its first `fetch-driving-plan`, streets.html before the first road walk, plus a transient 404 on any of the three — and the sidebar being an unconditional `position: sticky` full-viewport-height white card meant a viewport-tall empty panel beside a one-line "nothing published yet", with an `aria-label`led landmark holding nothing.
+It asserts the **attribute**, `hidden`, and the computed `display: none` separately, and both halves were confirmed to fail on their own: an unrendered layout has no content, so it collapses to zero height and Playwright's `to_be_hidden()` passes either way, and `display: grid` is an author declaration that beats the UA stylesheet's `[hidden]` rule unless `.table-layout[hidden]` says otherwise.
+The reveal lives in `createTableControls` rather than in the three pages, because every empty/error path returns before reaching it — so the page that is added next cannot forget it.
+
+Two more chassis-level pins came with the same work.
+`foldSearchTerms` is asserted to agree with `matchesSearch` on the same queries, because folding the query once per pass instead of once per row is only an optimization if the two spellings cannot diverge.
+And the per-row search haystack cache is asserted to be keyed by the **field list**, not just the row object — a cache ignoring the field list would serve one caller's haystack to a caller asking about different columns, which is a wrong answer rather than a slow one.
+

--- a/tests/e2e/test_smoke.py
+++ b/tests/e2e/test_smoke.py
@@ -1316,16 +1316,21 @@ def test_driving_takes_the_sidebar_without_taking_the_pivot(page: Page, base_url
     """driving.html shares the chassis, the filter sidebar and the histogram
     filters with grid/streets — but NOT the pivot. Its rows are places, not
     cities-with-a-column-per-provider, so no column declares a `group` and the
-    header stays a single <tr>. That makes this the only page exercising
-    theadHtml's flat branch in a real browser, which is why the assertion lives
-    here rather than being folded into the shared parametrized tests above."""
+    header stays a single <tr>. That makes this the only page whose DEFAULT
+    render exercises theadHtml's flat branch, which is why the assertion lives
+    here rather than being folded into the shared parametrized tests above.
+
+    Not the branch's only caller, though: it keys off the visible columns, so
+    grid.html reaches it too once every grouped column is unchecked (see
+    test_unchecking_every_optional_column_actually_empties_the_table). Deleting
+    the branch with a future pivoted driving.html would break those pages."""
     errors = _capture_errors(page)
     page.goto(f"{base_url}/driving.html")
     expect(page.locator("#driving-table-wrap")).to_be_visible()
 
-    # Shared: the sidebar and a real histogram on the coverage filter.
+    # Shared: the sidebar. (The coverage histogram itself is covered for all
+    # three pages by test_the_table_pages_replaced_the_strip_with_per_filter_histograms.)
     expect(page.locator(".table-sidebar")).to_have_count(1)
-    expect(page.locator('.control-histogram[data-histogram="cov"]')).to_have_count(1)
 
     # Not shared: the pivot's grouped header, and no Δ cells to go with it —
     # a difference between providers is only a question a pivoted row can ask.
@@ -1333,11 +1338,29 @@ def test_driving_takes_the_sidebar_without_taking_the_pivot(page: Page, base_url
     expect(page.locator("#driving-thead tr")).to_have_count(1)
     expect(page.locator("#driving-tbody td.delta-cell")).to_have_count(0)
 
-    # Re-sorting is still just a sort: the strip that used to repoint itself at
-    # the newly sorted column is gone from the whole site.
+    # Re-sorting is still just a sort — and the assertions have to be POSITIVE
+    # ones. The strip this replaced was what made a driving.html header click
+    # observable (it retargeted itself at the newly sorted column); with the
+    # strip gone site-wide, asserting its absence after a click says nothing
+    # about the click, and inert header buttons would pass.
+    rows = page.locator("#driving-tbody tr")
+    expect(page.locator('th[data-key="label"]')).to_have_attribute("aria-sort", "ascending")
     page.locator('th[data-key="coveragePct"] button').click()
-    expect(page.locator("#distribution-strip")).to_have_count(0)
-    expect(page.locator(".strip-bar")).to_have_count(0)
+    expect(page.locator('th[data-key="coveragePct"]')).to_have_attribute("aria-sort", "descending")
+    expect(page.locator('th[data-key="label"]')).to_have_attribute("aria-sort", "none")
+    assert "sort=coveragePct" in page.url and "dir=desc" in page.url
+
+    # ...and the ROWS moved, not just the header glyph: the leading row's own
+    # coverage figure has to reverse with the direction. Read off the cell
+    # rather than matching city names, so the assertion survives a fixture that
+    # gains a city.
+    def leading_coverage():
+        return float(rows.first.locator(".coverage-value").first.inner_text().rstrip("%"))
+
+    most_covered = leading_coverage()
+    page.locator('th[data-key="coveragePct"] button').click()
+    expect(page.locator('th[data-key="coveragePct"]')).to_have_attribute("aria-sort", "ascending")
+    assert leading_coverage() < most_covered
 
     assert errors == []
 
@@ -1457,6 +1480,67 @@ def test_filter_sidebar_sits_beside_the_table_and_collapses_on_narrow_screens(
     expect(page.locator(".sidebar-disclosure > summary")).to_be_hidden()
 
     assert errors == []
+
+
+@pytest.mark.parametrize(
+    "path,artifact",
+    [
+        ("grid.html", "cities.json.gz"),
+        ("streets.html", "streetwalks.json.gz"),
+        ("driving.html", "driving_plan.json.gz"),
+    ],
+)
+def test_a_page_with_nothing_published_shows_no_empty_sidebar(page: Page, base_url, path, artifact):
+    """Fail the page's own artifact and it must render the status line ALONE.
+
+    Not a defensive branch: every one of these is a real state of a real
+    deployment — driving.html before its first `scheduler fetch-driving-plan`,
+    streets.html before the first road walk, plus a transient 404 on any of
+    them. The sidebar is a `position: sticky` full-viewport-height white card,
+    so an unconditional one meant a viewport-tall empty panel beside a
+    one-line "nothing published yet" message, and an empty `aria-label`led
+    landmark for anyone navigating by landmark.
+
+    The fix is in the chassis rather than in the three pages: `.table-layout`
+    is authored `hidden` and only `createTableControls` clears it, and every
+    empty/error path returns before reaching it."""
+    errors = _capture_errors(page)
+
+    def fail_artifact(route):
+        route.fulfill(status=404, body=b"nothing published")
+
+    page.route(f"**/streetscape-tracker/data/{artifact}", fail_artifact)
+    page.set_viewport_size({"width": 1440, "height": 900})
+    page.goto(f"{base_url}/{path}")
+
+    status = page.locator(".table-status")
+    expect(status).to_be_visible()
+    expect(status).not_to_have_text("")
+    # No sidebar, no landmark, no filters.
+    expect(page.locator(".table-sidebar")).to_have_count(0)
+    expect(page.locator('aside[aria-label="Search and filters"]')).to_have_count(0)
+    expect(page.locator("#table-search")).to_have_count(0)
+    expect(page.locator("tbody tr")).to_have_count(0)
+
+    # The page head is still there: this is an empty state, not a broken page.
+    expect(page.locator(".page-head h1")).to_be_visible()
+
+    # The `hidden` attribute specifically, asserted on the attribute rather
+    # than through to_be_hidden(): an unrendered layout has no content, so it
+    # collapses to zero height and Playwright calls it hidden either way. What
+    # must hold is that it is DECLARED hidden and stays that way — otherwise a
+    # later page that authors trailing content inside .table-content (as
+    # driving.html does, with its revision history and limits sections) gets a
+    # 20px-gap grid column and a sticky sidebar slot around it.
+    assert page.locator(".table-layout").get_attribute("hidden") is not None
+    assert (
+        page.evaluate("() => getComputedStyle(document.querySelector('.table-layout')).display")
+        == "none"
+    ), "the [hidden] attribute lost to the layout's own display: grid"
+
+    # A 404 on driving_plan.json.gz is logged by driving.js on purpose, and
+    # streets.html's cities.json.gz path warns; neither is a page error.
+    assert [e for e in errors if "404" not in e and "Error loading" not in e] == []
 
 
 def test_driving_page_joins_the_plan_against_observed_imagery(page: Page, base_url):

--- a/tests/e2e/test_smoke.py
+++ b/tests/e2e/test_smoke.py
@@ -1134,15 +1134,14 @@ def test_unchecking_every_optional_column_actually_empties_the_table(page: Page,
     assert errors == []
 
 
-@pytest.mark.parametrize("path", ["grid.html", "streets.html"])
-def test_the_pivoted_pages_replaced_the_strip_with_per_filter_histograms(
-    page: Page, base_url, path
-):
-    """Issue #250. The sorted-column strip is gone from these two pages: it
-    visualized whichever column happened to be sorted, over the FILTERED rows,
-    so it silently swapped its metric on a header click and collapsed under the
-    very bar-click it invited. Each numeric filter now owns one histogram, on
-    one metric, on a fixed axis."""
+@pytest.mark.parametrize("path", ["grid.html", "streets.html", "driving.html"])
+def test_the_table_pages_replaced_the_strip_with_per_filter_histograms(page: Page, base_url, path):
+    """Issue #250, extended to driving.html. The sorted-column strip is gone
+    from the site: it visualized whichever column happened to be sorted, over
+    the FILTERED rows, so it silently swapped its metric on a header click and
+    collapsed under the very bar-click it invited. Each numeric filter now owns
+    one histogram, on one metric, on a fixed axis — and every table page keys
+    its coverage filter `cov`, which is why one body covers all three."""
     errors = _capture_errors(page)
     page.goto(f"{base_url}/{path}")
     expect(page.locator("tbody tr").first).to_be_visible()
@@ -1313,41 +1312,44 @@ def test_a_scoped_window_survives_a_url_restore(page: Page, base_url):
     assert errors == []
 
 
-def test_distribution_strip_survives_on_the_driving_page(page: Page, base_url):
-    """The strip was removed from the two pivoted pages, NOT from the chassis.
-    driving.html keeps it, and keeps the behaviour it always had: a histogram
-    of the ACTIVE SORT COLUMN over the CURRENTLY FILTERED rows, with the
-    summary sentence as its accessible equivalent."""
+def test_driving_takes_the_sidebar_without_taking_the_pivot(page: Page, base_url):
+    """driving.html shares the chassis, the filter sidebar and the histogram
+    filters with grid/streets — but NOT the pivot. Its rows are places, not
+    cities-with-a-column-per-provider, so no column declares a `group` and the
+    header stays a single <tr>. That makes this the only page exercising
+    theadHtml's flat branch in a real browser, which is why the assertion lives
+    here rather than being folded into the shared parametrized tests above."""
     errors = _capture_errors(page)
     page.goto(f"{base_url}/driving.html")
+    expect(page.locator("#driving-table-wrap")).to_be_visible()
 
-    summary = page.locator("#distribution-strip .strip-summary")
-    expect(summary).to_be_visible()
+    # Shared: the sidebar and a real histogram on the coverage filter.
+    expect(page.locator(".table-sidebar")).to_have_count(1)
+    expect(page.locator('.control-histogram[data-histogram="cov"]')).to_have_count(1)
 
-    # Re-sorting repoints the strip at the newly sorted column (coveragePct is
-    # in driving.html's default Overview preset, so it is on screen).
-    page.locator('th[data-key="coveragePct"] button').click()
-    # Case-insensitive: the summary lowercases the column label in its
-    # "No <label> values" form, which is what a fixture with few tracked
-    # cities in view actually produces.
-    expect(summary).to_contain_text(re.compile(r"grid coverage", re.I))
-
-    # ...and driving.html renders none of the pivot's furniture.
-    expect(page.locator(".control-histogram")).to_have_count(0)
-    expect(page.locator(".table-sidebar")).to_have_count(0)
+    # Not shared: the pivot's grouped header, and no Δ cells to go with it —
+    # a difference between providers is only a question a pivoted row can ask.
     expect(page.locator("thead th.th-group")).to_have_count(0)
     expect(page.locator("#driving-thead tr")).to_have_count(1)
+    expect(page.locator("#driving-tbody td.delta-cell")).to_have_count(0)
+
+    # Re-sorting is still just a sort: the strip that used to repoint itself at
+    # the newly sorted column is gone from the whole site.
+    page.locator('th[data-key="coveragePct"] button').click()
+    expect(page.locator("#distribution-strip")).to_have_count(0)
+    expect(page.locator(".strip-bar")).to_have_count(0)
 
     assert errors == []
 
 
-@pytest.mark.parametrize("path", ["grid.html", "streets.html"])
+@pytest.mark.parametrize("path", ["grid.html", "streets.html", "driving.html"])
 def test_the_table_and_its_filters_are_on_the_first_screen(page: Page, base_url, path):
-    """These two pages are instruments, not articles. A screen of preamble
-    pushed both the table and the filter sidebar below the fold, so the lead is
-    now one sentence and the rest lives in a closed disclosure. The assertion is
-    the outcome, not the word count: the table's first row and the search box
-    both have to be visible without scrolling."""
+    """These pages are instruments, not articles. A screen of preamble pushed
+    both the table and the filter sidebar below the fold, so the lead is now one
+    sentence and the rest lives in a closed disclosure. The assertion is the
+    outcome, not the word count: the table's first row and the search box both
+    have to be visible without scrolling. driving.html is the tightest case —
+    it also renders the archive-provenance callout above the layout."""
     errors = _capture_errors(page)
     page.set_viewport_size({"width": 1440, "height": 900})
     page.goto(f"{base_url}/{path}")
@@ -1374,7 +1376,7 @@ def test_the_table_and_its_filters_are_on_the_first_screen(page: Page, base_url,
     assert errors == []
 
 
-@pytest.mark.parametrize("path", ["grid.html", "streets.html"])
+@pytest.mark.parametrize("path", ["grid.html", "streets.html", "driving.html"])
 def test_the_filter_sidebar_spans_the_full_viewport_height(page: Page, base_url, path):
     """ "Always there" means it does not scroll away, and "full extent" means it
     is a column rather than a short card with grey below it. Both come from the
@@ -1409,7 +1411,7 @@ def test_the_filter_sidebar_spans_the_full_viewport_height(page: Page, base_url,
     assert errors == []
 
 
-@pytest.mark.parametrize("path", ["grid.html", "streets.html"])
+@pytest.mark.parametrize("path", ["grid.html", "streets.html", "driving.html"])
 def test_filter_sidebar_sits_beside_the_table_and_collapses_on_narrow_screens(
     page: Page, base_url, path
 ):

--- a/www/css/data-table.css
+++ b/www/css/data-table.css
@@ -1,12 +1,13 @@
 /**
  * data-table.css
  * Shared styles for the sortable data-table pages: grid.html (per-city
- * grid-run stats) and streets.html (published road walks).
+ * grid-run stats), streets.html (published road walks) and driving.html
+ * (Google's plan joined against observed imagery).
  *
  * Moved wholesale from streets.css when the Grid page was added; the
  * `streets-*` class names predate the move and are kept verbatim because
  * the row templates in table-utils.js/streets.js and the e2e selectors
- * emit them — both pages simply share them.
+ * emit them — all three pages simply share them.
  *
  * Unlike index.html / city.html these pages are normal scrolling documents,
  * not a full-bleed map with floating panels — so they clear the fixed
@@ -19,8 +20,8 @@
   line-height: 1.5;
 }
 
-/* Wide enough that the table's nowrap columns fit without scrolling at
-   desktop widths; the intro keeps its own reading measure below. */
+/* The base measure. Every table page overrides it with .streets-main--wide
+   below; this is what a table page WITHOUT the filter sidebar would get. */
 .streets-main {
   max-width: 1200px;
   margin: 0 auto;
@@ -30,15 +31,6 @@
 .streets-main h1 {
   margin: 0 0 12px;
   font-size: 24px;
-}
-
-.streets-intro {
-  max-width: 68ch;
-  margin-bottom: 24px;
-}
-
-.streets-intro p {
-  margin: 0 0 10px;
 }
 
 .streets-caveat {
@@ -274,9 +266,8 @@
 }
 
 /* ── Exploration controls (issue #188) ─────────────────────────────────────
-   Search, filters, the column preset/picker and the distribution strip. The
-   whole region is rendered by table-controls.js; nothing here is authored in
-   the HTML. */
+   Search, filters and the column preset/picker. The whole region is rendered
+   by table-controls.js; nothing here is authored in the HTML. */
 
 .controls-region {
   margin-bottom: 16px;
@@ -431,9 +422,10 @@
 }
 
 /* ── Kayak-style filter sidebar (issue #250) ──────────────────────────────
-   grid.html and streets.html only: every rule below is scoped under
-   .with-sidebar or .streets-main--wide, and driving.html carries neither
-   class, so its horizontal control strip is untouched.
+   Every rule below is scoped under .with-sidebar or .streets-main--wide. That
+   scoping was originally what kept driving.html on its old horizontal control
+   strip; driving.html now carries both classes too, so all three table pages
+   share this column.
 
    The sidebar is a native <details>. Above the breakpoint its <summary> is
    hidden and the panel is simply an always-open column; below it, the summary
@@ -442,8 +434,10 @@
    panel closed with its toggle hidden — is closed in JS by
    wireSidebarDisclosure. */
 
-/* Wider measure than the 1200px single-column pages: a pivoted table carries
-   one sub-column per provider, and the sidebar takes 280px of the width. */
+/* Wider measure than the 1200px base: the sidebar takes 280px of the width,
+   and a pivoted table carries one sub-column per provider on top of that. The
+   arithmetic is deliberate — 1500 − 280 − 20 leaves the table the same 1200px
+   the pages had before the sidebar, so no preset had to be re-sized. */
 .streets-main--wide {
   max-width: 1500px;
   /* Tighter than the prose pages': the point of the compact head below is to
@@ -453,15 +447,15 @@
 }
 
 /* ── Compact page head ────────────────────────────────────────────────────
-   These two pages are instruments, not articles: the table and the filter
-   sidebar are what the reader came for, and a screen of preamble above them
-   pushed both below the fold. The lead is one sentence saying what the page
-   measures and how it differs from its sibling; everything else — how to read
-   the pivot, the census-vs-sample caveat, the crossfilter rule — moves into a
-   disclosure that is one click away and costs no vertical space closed.
-   driving.html keeps its full prose intro (.streets-intro), which is doing a
-   different job: that page's whole point needs explaining before its verdicts
-   mean anything. */
+   These pages are instruments, not articles: the table and the filter sidebar
+   are what the reader came for, and a screen of preamble above them pushed
+   both below the fold. The lead is one sentence saying what the page measures;
+   everything else — how to read the pivot, the census-vs-sample caveat, the
+   crossfilter rule, driving.html's "a closed plan row is not evidence" — moves
+   into a disclosure that is one click away and costs no vertical space closed.
+   driving.html held out longest on a three-paragraph intro, on the grounds
+   that its verdicts need explaining; the explanation is one click away here
+   rather than gone. */
 
 .page-head {
   margin-bottom: 14px;
@@ -650,12 +644,12 @@
 
 /* ── Histogram-slider filter (issue #250) ─────────────────────────────────
    A mini histogram with a dual-handle brush over it, used in place of a bare
-   min/max pair on grid.html and streets.html. Only pages whose filters declare
-   `type: "histogram-range"` emit this markup, so driving.html never matches.
+   min/max pair. Only filters declaring `type: "histogram-range"` emit this
+   markup; a plain `range` still renders as two number inputs.
 
-   The bars reuse the distribution strip's look (one flat hue, no legend, no
-   axis furniture) because they encode the same thing — row counts — and a
-   second visual language for one quantity would imply a second meaning.
+   One flat hue, no legend, no axis furniture: a single series encoding row
+   counts. Deliberately NOT painted with coverageColor, which would imply the
+   bar height meant coverage.
 
    The slider itself is lifted from index.css's .legend-slider family: two
    native range inputs stacked on one custom track, the inputs ignoring pointer
@@ -700,7 +694,7 @@
 .hist-bar {
   flex: 1;
   min-width: 1px;
-  background: #6c8ba0; /* the strip's hue — 3.6:1 on white, above the 3:1 floor */
+  background: #6c8ba0; /* 3.6:1 on the white surface — above the 3:1 floor */
   border-radius: 2px 2px 0 0;
 }
 
@@ -818,69 +812,4 @@
 .hist-bounds input:focus-visible {
   outline: 2px solid #1a73e8;
   outline-offset: 1px;
-}
-
-/* ── Distribution strip ────────────────────────────────────────────────────
-   A histogram of the ACTIVE SORT COLUMN over the CURRENTLY FILTERED rows, so
-   it describes what you have selected rather than the whole table. Single
-   series, so: one flat hue, no legend, no axis furniture. Deliberately not
-   painted with coverageColor — these bars encode row counts, and reusing the
-   coverage ramp would imply the height meant coverage. */
-
-.distribution-strip {
-  margin-top: 10px;
-  padding: 10px 14px;
-  background: #fff;
-  border-radius: 6px;
-  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.15);
-}
-
-.strip-bars {
-  display: flex;
-  align-items: flex-end;
-  gap: 2px; /* the surface gap that keeps adjacent bars readable as separate */
-  height: 40px;
-}
-
-.strip-bar {
-  flex: 1;
-  min-width: 2px;
-  background: #6c8ba0; /* 3.6:1 on the white surface — above the 3:1 floor */
-  border-radius: 2px 2px 0 0; /* rounded data-end, anchored to the baseline */
-  /* Reset browser <button> chrome (border/padding/font/background) — a bar is
-     a <button> exactly when its bucket is clickable (renderDistributionStrip
-     emits a plain, non-interactive <span> otherwise), and these are no-ops on
-     a <span>, so one rule covers both without a tag selector. */
-  display: block;
-  border: 0;
-  padding: 0;
-  font: inherit;
-  appearance: none;
-}
-
-/* Only a <button> (a clickable bucket) gets pointer affordance and
-   interaction states; the plain <span> case has nothing to hover into. */
-button.strip-bar {
-  cursor: pointer;
-}
-
-button.strip-bar:hover {
-  background: #557089;
-}
-
-button.strip-bar:focus-visible {
-  outline: 2px solid #1a73e8;
-  outline-offset: 1px;
-}
-
-.strip-summary {
-  margin: 6px 0 0;
-  color: #555;
-  font-size: 12px;
-}
-
-@media (prefers-reduced-motion: no-preference) {
-  .strip-bar {
-    transition: height 120ms ease-out;
-  }
 }

--- a/www/css/data-table.css
+++ b/www/css/data-table.css
@@ -20,12 +20,21 @@
   line-height: 1.5;
 }
 
-/* The base measure. Every table page overrides it with .streets-main--wide
-   below; this is what a table page WITHOUT the filter sidebar would get. */
+/* The measure for every page loading this stylesheet — grid, streets and
+   driving, all three of which carry the sidebar. There is no narrower variant:
+   a `--wide` modifier lived here while driving.html was still on a horizontal
+   control strip, and once all three shared the sidebar it was a modifier every
+   caller set, which is a base value wearing a class name.
+
+   The width is deliberate arithmetic: the sidebar takes 280px, and 1500 − 280
+   − 20 leaves the table the same 1200px the pages had before the sidebar, so
+   no column preset had to be re-sized. The padding is tighter than the prose
+   pages' because the point of the compact page head is to put the table and
+   its filters on the first screen. */
 .streets-main {
-  max-width: 1200px;
+  max-width: 1500px;
   margin: 0 auto;
-  padding: 64px 20px 60px; /* 44px header + breathing room */
+  padding: 56px 20px 24px; /* 44px header + breathing room */
 }
 
 .streets-main h1 {
@@ -270,18 +279,21 @@
    by table-controls.js; nothing here is authored in the HTML. */
 
 .controls-region {
-  margin-bottom: 16px;
+  margin-bottom: 0;
 }
 
+/* ONE column of controls, and transparent: the sidebar that holds it paints
+   the card (see .table-sidebar for why the chrome lives there rather than
+   here). Both go the other way below the breakpoint, where the controls stack
+   above the table instead — that is the only place the horizontal card still
+   exists. */
 .table-controls {
   display: flex;
-  flex-wrap: wrap;
-  align-items: flex-end;
-  gap: 10px 16px;
+  flex-direction: column;
+  align-items: stretch;
+  flex-wrap: nowrap;
+  gap: 12px;
   padding: 12px 14px;
-  background: #fff;
-  border-radius: 6px;
-  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.15);
 }
 
 .control {
@@ -308,26 +320,16 @@
   color: #222;
 }
 
+/* Fills the sidebar column rather than carrying a fixed measure of its own. */
 .control-search input {
-  min-width: 220px;
+  min-width: 0;
+  width: 100%;
 }
 
-/* Two bounds on one line; each input stays wide enough for a 4-digit figure
-   plus the spinner the browser adds to number inputs. */
-.control-range {
-  flex-direction: row;
-  align-items: center;
-  flex-wrap: wrap;
-  gap: 4px;
-}
-
-.control-range .control-legend {
-  flex-basis: 100%;
-}
-
-.control-range input {
-  width: 78px;
-}
+/* There was a `.control-range` block here — the bar-less numeric filter's two
+   number inputs on one line — referenced by nothing but that filter's render
+   branch. It went with the branch; every numeric window is a histogram-slider
+   now, and .hist-bounds below lays the same two inputs out. */
 
 .control-dash {
   color: #999;
@@ -338,8 +340,7 @@
   flex-direction: row;
   align-items: center;
   gap: 6px;
-  align-self: flex-end;
-  padding-bottom: 5px;
+  align-self: flex-start;
 }
 
 .control-check label {
@@ -350,8 +351,7 @@
 .col-picker {
   position: relative; /* the open panel positions against this, not the page */
   font-size: 13px;
-  align-self: flex-end;
-  padding-bottom: 4px;
+  align-self: flex-start;
 }
 
 .col-picker summary {
@@ -360,23 +360,24 @@
   font-weight: bold;
 }
 
-/* Floated over the table rather than pushing it down, so opening the picker
-   does not reflow the rows you are reading. */
+/* In the sidebar the panel PUSHES the controls below it down rather than
+   floating over anything: it is clipped by the sidebar's own overflow, and
+   nothing is being read underneath it there — the table is in the next column.
+   Below the breakpoint the controls sit directly above the table and it floats
+   instead, which is where the shadow and the stacking context come back. */
 .col-picker .col-panel {
-  position: absolute;
-  z-index: 5;
-  left: 0;
+  position: static;
   margin-top: 6px;
   padding: 10px 12px;
   border: 1px solid #ddd;
   border-radius: 6px;
   background: #fff;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
 }
 
+/* One column of checkboxes: a 280px sidebar has no room for two. */
 .col-picker .col-panel fieldset {
   display: grid;
-  grid-template-columns: repeat(2, minmax(140px, 1fr));
+  grid-template-columns: 1fr;
   gap: 2px 14px;
   margin: 0 0 8px;
   padding: 0;
@@ -403,7 +404,7 @@
 }
 
 .controls-clear {
-  align-self: flex-end;
+  align-self: flex-start;
 }
 
 .controls-clear:hover,
@@ -422,29 +423,20 @@
 }
 
 /* ── Kayak-style filter sidebar (issue #250) ──────────────────────────────
-   Every rule below is scoped under .with-sidebar or .streets-main--wide. That
-   scoping was originally what kept driving.html on its old horizontal control
-   strip; driving.html now carries both classes too, so all three table pages
-   share this column.
+   The rules below were scoped under a .with-sidebar modifier while
+   driving.html was still on its old horizontal control strip and grid/streets
+   were not. All three pages share this column now, and .with-sidebar was on
+   every one of them, so the modifier is gone: a class every caller sets is a
+   base rule with an extra way to get it wrong, and the way it went wrong was
+   silent — a fourth table page forgetting it would land on a strip layout
+   nothing has rendered since, with no error anywhere.
 
-   The sidebar is a native <details>. Above the breakpoint its <summary> is
-   hidden and the panel is simply an always-open column; below it, the summary
-   becomes the "Filters" toggle. That is keyboard and AT semantics for free,
-   and the one hole it leaves — collapsed narrow, then widened, leaving the
-   panel closed with its toggle hidden — is closed in JS by
-   wireSidebarDisclosure. */
-
-/* Wider measure than the 1200px base: the sidebar takes 280px of the width,
-   and a pivoted table carries one sub-column per provider on top of that. The
-   arithmetic is deliberate — 1500 − 280 − 20 leaves the table the same 1200px
-   the pages had before the sidebar, so no preset had to be re-sized. */
-.streets-main--wide {
-  max-width: 1500px;
-  /* Tighter than the prose pages': the point of the compact head below is to
-     put the table and its filters on the first screen. */
-  padding-top: 56px;
-  padding-bottom: 24px;
-}
+   The sidebar is a native <details>, built by table-controls.js rather than
+   authored per page. Above the breakpoint its <summary> is hidden and the
+   panel is simply an always-open column; below it, the summary becomes the
+   "Filters" toggle. That is keyboard and AT semantics for free, and the one
+   hole it leaves — collapsed narrow, then widened, leaving the panel closed
+   with its toggle hidden — is closed in JS by wireSidebarDisclosure. */
 
 /* ── Compact page head ────────────────────────────────────────────────────
    These pages are instruments, not articles: the table and the filter sidebar
@@ -496,13 +488,22 @@
   margin: 0 0 8px;
 }
 
-.table-layout.with-sidebar {
+.table-layout {
   display: grid;
   grid-template-columns: 280px minmax(0, 1fr);
   gap: 20px;
   /* Without this the sidebar stretches to the table's height and cannot be
      sticky (a stretched grid item has nothing to stick within). */
   align-items: start;
+}
+
+/* The pages author this element `hidden` and table-controls.js clears the
+   attribute on the first successful render, so an empty or failed load shows
+   the status line alone rather than a viewport-tall empty sidebar card. This
+   rule is what makes that work: `display: grid` above is an author declaration
+   and would otherwise beat the UA stylesheet's `[hidden] { display: none }`. */
+.table-layout[hidden] {
+  display: none;
 }
 
 /* Always there, and the full height of the viewport once the head scrolls
@@ -516,7 +517,7 @@
    gives it a `::details-content` box, so .controls-region is not a flex item
    of the disclosure at all and simply does not grow. Painting the container is
    both shorter and immune to that. */
-.with-sidebar .table-sidebar {
+.table-sidebar {
   position: sticky;
   top: 52px; /* clears the 44px fixed .site-header, plus breathing room */
   height: calc(100vh - 64px);
@@ -527,76 +528,36 @@
   box-shadow: 0 1px 4px rgba(0, 0, 0, 0.15);
 }
 
-.with-sidebar .table-controls {
-  background: none;
-  border-radius: 0;
-  box-shadow: none;
-}
-
-.with-sidebar .sidebar-disclosure > summary {
+.sidebar-disclosure > summary {
   display: none; /* the panel is simply present at this width */
 }
 
-.with-sidebar .controls-region {
-  margin-bottom: 0;
-}
-
-/* One column of controls rather than a wrapping row. */
-.with-sidebar .table-controls {
-  flex-direction: column;
-  align-items: stretch;
-  flex-wrap: nowrap;
-  gap: 12px;
-}
-
-.with-sidebar .control-search input {
-  min-width: 0;
-  width: 100%;
-}
-
-.with-sidebar .control-check,
-.with-sidebar .col-picker {
-  align-self: flex-start;
-  padding-bottom: 0;
-}
-
-.with-sidebar .controls-clear {
-  align-self: flex-start;
-}
-
-/* The floating picker panel is clipped by the sidebar's own overflow, so in
-   this layout it pushes the controls below it down instead of overlaying the
-   table. Nothing is being read underneath it here — the table is elsewhere. */
-.with-sidebar .col-picker .col-panel {
-  position: static;
-  margin-top: 6px;
-  box-shadow: none;
-}
-
-.with-sidebar .col-picker .col-panel fieldset {
-  grid-template-columns: 1fr;
-}
-
 @media (max-width: 900px) {
-  .table-layout.with-sidebar {
+  .table-layout {
     grid-template-columns: minmax(0, 1fr);
   }
 
-  .with-sidebar .table-sidebar {
+  /* A full-height sticky column makes no sense stacked above the table, and
+     the card chrome goes back onto the controls with it: the sidebar becomes
+     a plain block, and .table-controls the card again. */
+  .table-sidebar {
     position: static;
     height: auto;
     overflow: visible;
-  }
-
-  /* A full-height column makes no sense stacked above the table: the card
-     chrome goes back onto the controls, and the container back to plain. */
-  .with-sidebar .table-sidebar {
     background: none;
     border-radius: 0;
     box-shadow: none;
   }
 
-  .with-sidebar .table-controls {
+  /* Back to using the full width — but as a GRID rather than a wrapping flex
+     row. A histogram-slider is a tall, wide item and a select is a short
+     narrow one, and flex-wrap interleaves them into a ragged block where a
+     slider's number inputs end up beside an unrelated control's label. */
+  .table-controls {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    align-items: end;
+    gap: 12px 16px;
     background: #fff;
     border-radius: 6px;
     box-shadow: 0 1px 4px rgba(0, 0, 0, 0.15);
@@ -604,7 +565,7 @@
 
   /* Below the breakpoint the disclosure is real: the filters collapse behind
      a "Filters" summary so the table is not pushed off the first screen. */
-  .with-sidebar .sidebar-disclosure > summary {
+  .sidebar-disclosure > summary {
     display: list-item;
     cursor: pointer;
     padding: 8px 12px;
@@ -616,28 +577,21 @@
     color: #1a6b1d;
   }
 
-  .with-sidebar .sidebar-disclosure > summary:focus-visible {
+  .sidebar-disclosure > summary:focus-visible {
     outline: 2px solid #1a73e8;
     outline-offset: 1px;
   }
 
-  /* Back to using the full width — but as a GRID rather than a wrapping flex
-     row. A histogram-slider is a tall, wide item and a select is a short
-     narrow one, and flex-wrap interleaves them into a ragged block where a
-     slider's number inputs end up beside an unrelated control's label. */
-  .with-sidebar .table-controls {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-    align-items: end;
-    gap: 12px 16px;
-  }
-
-  .with-sidebar .col-picker .col-panel {
+  /* Floating again: here the controls sit directly above the table, so a panel
+     that pushed them down would shove the rows off the screen. */
+  .col-picker .col-panel {
     position: absolute;
+    z-index: 5;
+    left: 0;
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
   }
 
-  .with-sidebar .col-picker .col-panel fieldset {
+  .col-picker .col-panel fieldset {
     grid-template-columns: repeat(2, minmax(140px, 1fr));
   }
 }

--- a/www/css/driving.css
+++ b/www/css/driving.css
@@ -1,7 +1,7 @@
 /* driving.css — styles unique to the Driving page (driving.html).
  *
- * The page reuses data-table.css for the table, controls and distribution
- * strip; only the verdict pills, the archive-provenance block and the
+ * The page reuses data-table.css for the table, the filter sidebar and the
+ * controls in it; only the verdict pills, the archive-provenance block and the
  * unwatched-areas summary are page-specific.
  *
  * Colour note: the four tones below are the same family the rest of the site

--- a/www/driving.html
+++ b/www/driving.html
@@ -38,91 +38,120 @@
        target="_blank" rel="noopener">About &#8599;</a>
   </header>
 
-  <main class="streets-main">
-    <h1>Driving plan vs. observed imagery</h1>
-
-    <div class="streets-intro">
-      <p>
-        Google publishes where it plans to drive next, at a single URL it
-        <strong>overwrites in place</strong> — so every revision is lost unless
-        someone keeps a dated copy. This tracker does. This page reads that
-        archived plan together with the imagery we have actually measured, and
-        reports where the two agree and where they do not.
+  <main class="streets-main streets-main--wide">
+    <div class="page-head">
+      <h1>Driving plan vs. observed imagery</h1>
+      <p class="page-lead">
+        Google publishes where it plans to drive next at a single URL it
+        <strong>overwrites in place</strong> — this page reads our dated archive
+        of that plan against the imagery we have actually measured, and reports
+        where the two agree and where they do not.
       </p>
-      <p>
-        Every row is a <strong>place</strong>: either a city this project
-        collects, or a region named in Google's plan that it does not — so the
-        <em>Tracked</em> column tells you both whether imagery is coming and
-        whether anyone here is watching for it. The
-        <em>Capture history</em> column shows the years a place's official
-        Google imagery was actually taken, which is where repeat drives show up
-        that a single median age hides.
-      </p>
-      <p class="streets-caveat">
-        <strong>A closed or absent plan entry is not evidence that an area was
-        not driven.</strong> Google's Israeli entries all read
-        <em>publish&nbsp;=&nbsp;No</em> with 2018–19 windows, while our own runs
-        record captures in September and October 2023 — Google drove Israel four
-        years after the feed said the campaign had closed, and never revised it.
-        Rows like that are labelled <em>Driven, unplanned</em>, and they are the
-        clearest measure of how much the plan under-reports. Treat the plan as
-        advisory, never as a contract.
-      </p>
+      <details class="page-about">
+        <summary>How to read this table</summary>
+        <div class="page-about-body">
+          <p>
+            Every row is a <strong>place</strong>: either a city this project
+            collects, or a region named in Google's plan that it does not — so
+            the <em>Tracked</em> column tells you both whether imagery is coming
+            and whether anyone here is watching for it. The
+            <em>Capture history</em> column shows the years a place's official
+            Google imagery was actually taken, which is where repeat drives show
+            up that a single median age hides.
+          </p>
+          <p>
+            <strong>A closed or absent plan entry is not evidence that an area
+            was not driven.</strong> Google's Israeli entries all read
+            <em>publish&nbsp;=&nbsp;No</em> with 2018–19 windows, while our own
+            runs record captures in September and October 2023 — Google drove
+            Israel four years after the feed said the campaign had closed, and
+            never revised it. Rows like that are labelled <em>Driven,
+            unplanned</em>, and they are the clearest measure of how much the
+            plan under-reports. Treat the plan as advisory, never as a contract.
+          </p>
+          <p>
+            Each numeric filter in the sidebar carries a histogram of where the
+            rows actually sit, drawn over everything the <em>other</em> controls
+            have selected, so brushing one range never redraws its own picture.
+            The address bar always carries the view you are looking at so it can
+            be shared.
+          </p>
+        </div>
+      </details>
     </div>
 
     <!-- Archive provenance + Google's own disclaimer, rendered by driving.js
          from the artifact's `plan` block. This is the page's principal caveat
-         (the archive is young), so it sits above the table, not below it. -->
+         (the archive is young), so it sits above the table, not below it — and
+         above the .table-layout rather than inside its table column, so the
+         sidebar and the table still start on the same row. -->
     <div id="driving-provenance" class="driving-provenance" hidden></div>
 
     <div id="driving-status" class="table-status" role="status" aria-live="polite">
       Loading the driving plan…
     </div>
 
-    <!-- Search, filters, column preset/picker and the distribution strip are
-         rendered into this container by table-controls.js once the data has
-         loaded. -->
-    <div id="driving-controls" class="controls-region"></div>
+    <!-- Sidebar + table, the shape grid.html and streets.html use; see that
+         file for the <details> rationale. This page is NOT pivoted — one row
+         per place, no provider sub-columns — but it filters through the same
+         chassis, so it gets the same filter column. -->
+    <div class="table-layout with-sidebar">
+      <aside class="table-sidebar" aria-label="Search and filters">
+        <details class="sidebar-disclosure" open>
+          <summary>Filters</summary>
+          <!-- Search, filters and the column preset/picker are rendered into
+               this container by table-controls.js once the data has loaded. -->
+          <div id="driving-controls" class="controls-region"></div>
+        </details>
+      </aside>
 
-    <div id="driving-table-wrap" class="streets-table-wrap" hidden>
-      <table class="streets-table">
-        <caption id="driving-caption"></caption>
-        <!-- Header cells are rendered by table-utils.js from the page's column
-             descriptors (DRIVING_COLUMNS), not authored here: column presets
-             change the visible set at runtime, so the header and the body have
-             to come from one list or they drift. -->
-        <thead id="driving-thead"></thead>
-        <tbody id="driving-tbody"></tbody>
-      </table>
+      <div class="table-content">
+        <div id="driving-table-wrap" class="streets-table-wrap" hidden>
+          <table class="streets-table">
+            <caption id="driving-caption"></caption>
+            <!-- Header cells are rendered by table-utils.js from the page's
+                 column descriptors (DRIVING_COLUMNS), not authored here: column
+                 presets change the visible set at runtime, so the header and
+                 the body have to come from one list or they drift. -->
+            <thead id="driving-thead"></thead>
+            <tbody id="driving-tbody"></tbody>
+          </table>
+        </div>
+
+        <!-- Both trailing sections live INSIDE the table column rather than
+             below the layout, so the sticky sidebar stays beside them and the
+             filters remain reachable while the revision history is being read.
+
+             What Google actually changed between archived snapshots, rendered
+             by driving.js from the artifact's `revisions`. This is the
+             archive's own reason to exist: the feed is overwritten in place, so
+             these edits are observable only because they were captured at the
+             time. -->
+        <section id="driving-revisions" class="driving-revisions" hidden></section>
+
+        <!-- The limits of "the past". Deliberately placed HERE rather than in
+             the page head: it is a caveat about historical depth, so it belongs
+             beside the history, and stacking a third caveat above the table
+             pushed the data itself below the fold. -->
+        <section class="driving-limits">
+          <h2>What this page cannot tell you</h2>
+          <p class="streets-caveat">
+            The capture history is built from dates attached to imagery that is
+            <em>currently</em> published, so a drive whose panoramas have since
+            been replaced leaves no trace in it. Recovering the full per-panorama
+            capture history — every past drive-through and its month — is
+            possible through an unpublished Google endpoint, but that harvester
+            has not been run for any city yet.
+          </p>
+          <p class="streets-caveat">
+            The plan archive itself only begins in July 2026. For any drive
+            before that, this page can report that the plan is silent or stale,
+            never that the drive was genuinely unplanned — the record simply
+            does not go back far enough.
+          </p>
+        </section>
+      </div>
     </div>
-
-    <!-- What Google actually changed between archived snapshots. Rendered by
-         driving.js from the artifact's `revisions`. This is the archive's own
-         reason to exist: the feed is overwritten in place, so these edits are
-         observable only because they were captured at the time. -->
-    <section id="driving-revisions" class="driving-revisions" hidden></section>
-
-    <!-- The limits of "the past". Deliberately placed HERE rather than in the
-         intro: it is a caveat about historical depth, so it belongs beside the
-         history, and stacking a third caveat above the table pushed the data
-         itself below the fold. -->
-    <section class="driving-limits">
-      <h2>What this page cannot tell you</h2>
-      <p class="streets-caveat">
-        The capture history is built from dates attached to imagery that is
-        <em>currently</em> published, so a drive whose panoramas have since
-        been replaced leaves no trace in it. Recovering the full per-panorama
-        capture history — every past drive-through and its month — is possible
-        through an unpublished Google endpoint, but that harvester has not been
-        run for any city yet.
-      </p>
-      <p class="streets-caveat">
-        The plan archive itself only begins in July 2026. For any drive before
-        that, this page can report that the plan is silent or stale, never that
-        the drive was genuinely unplanned — the record simply does not go back
-        far enough.
-      </p>
-    </section>
   </main>
 
   <!-- Scripts (order matters: libs → shared utils → page logic) -->
@@ -131,6 +160,7 @@
           crossorigin="anonymous"></script>
   <script src="js/streetscape-utils.js"></script>
   <script src="js/table-utils.js"></script>
+  <script src="js/histogram-slider.js"></script>
   <script src="js/table-controls.js"></script>
   <script src="js/driving.js"></script>
 </body>

--- a/www/driving.html
+++ b/www/driving.html
@@ -38,7 +38,7 @@
        target="_blank" rel="noopener">About &#8599;</a>
   </header>
 
-  <main class="streets-main streets-main--wide">
+  <main class="streets-main">
     <div class="page-head">
       <h1>Driving plan vs. observed imagery</h1>
       <p class="page-lead">
@@ -92,18 +92,17 @@
     </div>
 
     <!-- Sidebar + table, the shape grid.html and streets.html use; see that
-         file for the <details> rationale. This page is NOT pivoted — one row
-         per place, no provider sub-columns — but it filters through the same
-         chassis, so it gets the same filter column. -->
-    <div class="table-layout with-sidebar">
-      <aside class="table-sidebar" aria-label="Search and filters">
-        <details class="sidebar-disclosure" open>
-          <summary>Filters</summary>
-          <!-- Search, filters and the column preset/picker are rendered into
-               this container by table-controls.js once the data has loaded. -->
-          <div id="driving-controls" class="controls-region"></div>
-        </details>
-      </aside>
+         file for the `hidden` and <details> rationale. This page is NOT
+         pivoted — one row per place, no provider sub-columns — but it filters
+         through the same chassis, so it gets the same filter column.
+
+         The `hidden` matters most here: a deployment that has never run
+         `scheduler fetch-driving-plan`, or a transient 404 of
+         driving_plan.json.gz, is the ordinary way this page renders no rows. -->
+    <div class="table-layout" hidden>
+      <!-- Search, filters and the column preset/picker are rendered into this
+           container by table-controls.js once the data has loaded. -->
+      <div id="driving-controls" class="controls-region"></div>
 
       <div class="table-content">
         <div id="driving-table-wrap" class="streets-table-wrap" hidden>

--- a/www/eslint.config.js
+++ b/www/eslint.config.js
@@ -93,9 +93,8 @@ const tableGlobals = {
 
 // Symbols histogram-slider.js DEFINES (issue #250). Loaded between
 // table-utils.js (whose formatCellNumber it consumes) and table-controls.js,
-// which instantiates the component. Only grid.html and streets.html load it —
-// driving.html has no histogram-range filter, so table-controls.js reaches
-// these names only when one exists.
+// which instantiates the component. All three table pages load it — every
+// numeric filter on the site is a histogram-range.
 const histogramSliderGlobals = {
   HISTOGRAM_SLIDER_BUCKETS: "readonly",
   sliderStepFor: "readonly",
@@ -107,7 +106,7 @@ const histogramSliderGlobals = {
 };
 
 // Symbols table-controls.js DEFINES and the table pages CONSUME (issue
-// #188). Loaded after table-utils.js, whose formatCellNumber it consumes.
+// #188). Loaded after histogram-slider.js, which it instantiates.
 const tableControlGlobals = {
   foldForSearch: "readonly",
   matchesSearch: "readonly",
@@ -122,9 +121,6 @@ const tableControlGlobals = {
   parseTableState: "readonly",
   serializeTableState: "readonly",
   histogramBuckets: "readonly",
-  medianOf: "readonly",
-  formatStripSummary: "readonly",
-  renderDistributionStrip: "readonly",
   controlsHtml: "readonly",
   createTableControls: "readonly",
   syncSidebarDisclosure: "readonly",
@@ -200,8 +196,8 @@ module.exports = [
     rules: browserRules,
   },
   {
-    // The exploration chassis (issue #188): consumes table-utils.js's
-    // formatCellNumber and defines the tableControlGlobals. Node export shim
+    // The exploration chassis (issue #188): consumes histogram-slider.js's
+    // component and defines the tableControlGlobals. Node export shim
     // (`module`) for the unit tests.
     files: ["js/table-controls.js"],
     languageOptions: {
@@ -219,10 +215,10 @@ module.exports = [
     rules: browserRules,
   },
   {
-    // The two table pages (issues #99/#155 and the grid table): consume the
-    // streetscape-utils.js, table-utils.js and table-controls.js globals and,
-    // like the files above, carry a Node export shim (`module`) so their pure
-    // helpers can be unit-tested.
+    // The three table pages (issues #99/#155, the grid table and the driving
+    // join): consume the streetscape-utils.js, table-utils.js and
+    // table-controls.js globals and, like the files above, carry a Node export
+    // shim (`module`) so their pure helpers can be unit-tested.
     files: ["js/streets.js", "js/grid.js", "js/driving.js"],
     languageOptions: {
       ecmaVersion: 2022,

--- a/www/eslint.config.js
+++ b/www/eslint.config.js
@@ -120,7 +120,9 @@ const tableControlGlobals = {
   defaultFilterValues: "readonly",
   parseTableState: "readonly",
   serializeTableState: "readonly",
-  histogramBuckets: "readonly",
+  // No `histogramBuckets`: it is table-controls.js's own, used only inside the
+  // file and `require`d by the unit tests. Declaring it here said a page
+  // script reads it, and none does.
   controlsHtml: "readonly",
   createTableControls: "readonly",
   syncSidebarDisclosure: "readonly",
@@ -199,6 +201,13 @@ module.exports = [
     // The exploration chassis (issue #188): consumes histogram-slider.js's
     // component and defines the tableControlGlobals. Node export shim
     // (`module`) for the unit tests.
+    //
+    // Deliberately NOT given tableGlobals: this file's last table-utils.js
+    // dependency (formatCellNumber) went to histogram-slider.js, and `no-undef`
+    // is the only thing enforcing the load order the docblock claims. Left
+    // spread here, a new table-utils use would slip in silently — and
+    // table-controls.js is loaded before table-utils.js on no page today, but
+    // nothing but this list would notice if one changed.
     files: ["js/table-controls.js"],
     languageOptions: {
       ecmaVersion: 2022,
@@ -207,7 +216,6 @@ module.exports = [
         ...globals.browser,
         ...vendorGlobals,
         ...sharedGlobals,
-        ...tableGlobals,
         ...histogramSliderGlobals,
         module: "readonly",
       },

--- a/www/grid.html
+++ b/www/grid.html
@@ -37,7 +37,7 @@
        target="_blank" rel="noopener">About &#8599;</a>
   </header>
 
-  <main class="streets-main streets-main--wide">
+  <main class="streets-main">
     <div class="page-head">
       <h1>Grid coverage</h1>
       <p class="page-lead">
@@ -79,22 +79,26 @@
       Loading city collections…
     </div>
 
-    <!-- Sidebar + table (issue #250). The <details> is what makes the sidebar
-         collapsible below 900px with keyboard/AT semantics for free; above
-         that breakpoint its <summary> is hidden by CSS and the panel is simply
-         an always-open column. table-controls.js re-opens it on widening, so a
-         panel collapsed on a narrow screen can never end up hidden with its
-         only toggle gone. -->
-    <div class="table-layout with-sidebar">
-      <aside class="table-sidebar" aria-label="Search and filters">
-        <details class="sidebar-disclosure" open>
-          <summary>Filters</summary>
-          <!-- Search, filters and the column preset/picker are rendered into
-               this container by table-controls.js once the data has loaded
-               (issue #188). -->
-          <div id="grid-controls" class="controls-region"></div>
-        </details>
-      </aside>
+    <!-- Sidebar + table (issue #250).
+
+         `hidden` until the first successful render: createTableControls clears
+         it, and every empty/error path returns before that, so a deployment
+         with nothing published shows the status line alone rather than a
+         viewport-tall empty sidebar card (and an empty landmark to AT).
+
+         The sidebar CHROME — the <aside> landmark, the collapsible <details>
+         and its "Filters" summary — is emitted by table-controls.js around
+         this container, not authored here, so the three pages cannot drift
+         apart on it. The <details> is what makes the sidebar collapsible
+         below 900px with keyboard/AT semantics for free; above that breakpoint
+         its <summary> is hidden by CSS and the panel is simply an always-open
+         column, and table-controls.js re-opens it on widening so a panel
+         collapsed on a narrow screen can never end up hidden with its only
+         toggle gone. -->
+    <div class="table-layout" hidden>
+      <!-- Search, filters and the column preset/picker are rendered into this
+           container by table-controls.js once the data has loaded (#188). -->
+      <div id="grid-controls" class="controls-region"></div>
 
       <div class="table-content">
         <div id="grid-table-wrap" class="streets-table-wrap" hidden>

--- a/www/js/__tests__/driving.test.js
+++ b/www/js/__tests__/driving.test.js
@@ -416,6 +416,25 @@ test("every plan-status filter value is one the row models can actually produce"
   }
 });
 
+test("DRIVING_FILTERS: numeric filters are histogram sliders over real row fields", () => {
+  // The same contract grid.js and streets.js carry. A `range` descriptor still
+  // renders (two number inputs, no picture), so a filter that silently stayed
+  // plain would look deliberate rather than broken — and on THIS page the bars
+  // are load-bearing: most rows are plan areas we do not track, whose observed
+  // fields are all null, so the histogram is what says how few of the ~3,800
+  // rows a coverage window can match at all.
+  const row = drivingRowModel(ADDIS, TODAY);
+  const area = planAreaRowModel(CHUBUT, TODAY);
+  for (const filter of DRIVING_FILTERS) {
+    if (!filter.field) continue;
+    assert.equal(filter.type, "histogram-range", `${filter.key} is not a histogram filter`);
+    assert.ok(filter.field in row, `filter ${filter.key} reads a missing field ${filter.field}`);
+    // Both row KINDS have to carry the field, or a domain seeded from the full
+    // row set would read `undefined` off every untracked area.
+    assert.ok(filter.field in area, `filter ${filter.key} is absent from a plan-area row`);
+  }
+});
+
 test("planAreaRowModel: names the row by the districts it covers", () => {
   // Google's feed carries TEN separate Accra records — different districts,
   // different windows. Labelling them all "Accra, Ghana" made ten distinct

--- a/www/js/__tests__/driving.test.js
+++ b/www/js/__tests__/driving.test.js
@@ -417,12 +417,16 @@ test("every plan-status filter value is one the row models can actually produce"
 });
 
 test("DRIVING_FILTERS: numeric filters are histogram sliders over real row fields", () => {
-  // The same contract grid.js and streets.js carry. A `range` descriptor still
-  // renders (two number inputs, no picture), so a filter that silently stayed
-  // plain would look deliberate rather than broken — and on THIS page the bars
-  // are load-bearing: most rows are plan areas we do not track, whose observed
-  // fields are all null, so the histogram is what says how few of the ~3,800
-  // rows a coverage window can match at all.
+  // The same contract grid.js and streets.js carry, and it got MORE
+  // load-bearing when the bar-less `range` type was deleted: `histogram-range`
+  // is now the only numeric window, so a descriptor left saying `range` no
+  // longer renders two number inputs — it falls off the end of controlsHtml's
+  // partition and renders as a CHECKBOX, silently, on a filter whose value
+  // shape is `{min, max}`.
+  //
+  // On THIS page the bars are load-bearing besides: most rows are plan areas we
+  // do not track, whose observed fields are all null, so the histogram is what
+  // says how few of the ~3,800 rows a coverage window can match at all.
   const row = drivingRowModel(ADDIS, TODAY);
   const area = planAreaRowModel(CHUBUT, TODAY);
   for (const filter of DRIVING_FILTERS) {
@@ -432,7 +436,26 @@ test("DRIVING_FILTERS: numeric filters are histogram sliders over real row field
     // Both row KINDS have to carry the field, or a domain seeded from the full
     // row set would read `undefined` off every untracked area.
     assert.ok(filter.field in area, `filter ${filter.key} is absent from a plan-area row`);
+    // `unit`/`digits` are not cosmetic here: histogram-slider.js is the ONLY
+    // reader of them, and it is the control that speaks to assistive tech.
+    // The `aria-valuetext` it builds is `formatCellNumber(v, digits ?? 0) +
+    // (unit ?? "")`, so an undeclared pair makes a thumb on the 0-12 yrs axis
+    // (0.2 steps) announce "0", "0", "1" while the column renders "0.2 yrs",
+    // and makes every bucket tooltip read "0-0: 12 rows". The plain `range`
+    // renderer these three came from never read either field, so nothing
+    // caught the omission when they were switched over.
+    assert.equal(typeof filter.digits, "number", `filter ${filter.key} declares no digits`);
+    assert.equal(typeof filter.unit, "string", `filter ${filter.key} declares no unit`);
   }
+});
+
+test("DRIVING_FILTERS: each numeric axis is announced in its own units", () => {
+  const units = new Map(
+    DRIVING_FILTERS.filter((f) => f.field).map((f) => [f.key, [f.unit, f.digits]])
+  );
+  assert.deepEqual(units.get("cov"), ["%", 1]);
+  assert.deepEqual(units.get("street"), ["%", 1]);
+  assert.deepEqual(units.get("since"), [" yrs", 1]);
 });
 
 test("planAreaRowModel: names the row by the districts it covers", () => {

--- a/www/js/__tests__/grid.test.js
+++ b/www/js/__tests__/grid.test.js
@@ -576,6 +576,10 @@ test("GRID_FILTERS: numeric filters read best-across-providers, and are histogra
   assert.equal(byKey.cov.field, "pctBest");
   assert.equal(byKey.age.field, "medianAgeBest");
   assert.equal(byKey.dcov.field, "deltaPct");
+  // `histogram-range` is the only numeric-window type now that the bar-less
+  // `range` is deleted, so this is not a style check: a descriptor left saying
+  // `range` falls off the end of controlsHtml's partition and renders as a
+  // CHECKBOX for a `{min, max}` value.
   for (const key of ["cov", "age", "dcov"]) {
     assert.equal(byKey[key].type, "histogram-range", `${key} is not a histogram filter`);
   }

--- a/www/js/__tests__/streets.test.js
+++ b/www/js/__tests__/streets.test.js
@@ -705,6 +705,10 @@ test("STREET_FILTERS: 'Has Δ' asks whether ANY provider walked this row twice",
 });
 
 test("STREET_FILTERS: numeric filters are histogram sliders over real row fields", () => {
+  // `histogram-range` is the only numeric-window type now that the bar-less
+  // `range` is deleted, so this is not a style check: a descriptor left saying
+  // `range` falls off the end of controlsHtml's partition and renders as a
+  // CHECKBOX for a `{min, max}` value.
   const row = rowsFor(SEATTLE_GSV_WALK, SEATTLE_MAPILLARY_WALK)[0];
   for (const filter of STREET_FILTERS) {
     if (!filter.field) continue;

--- a/www/js/__tests__/table-controls.test.js
+++ b/www/js/__tests__/table-controls.test.js
@@ -1,21 +1,20 @@
 // Offline unit tests for the exploration chassis in table-controls.js
-// (issue #188): search, structured filters, column presets, URL round-trip,
-// and the distribution strip's bucketing.
+// (issue #188): search, structured filters, column presets and URL round-trip.
 //
 // Run with `npm test` (Node's built-in test runner) — no network, no jsdom.
-// In the browser this module reads formatCellNumber from table-utils.js; here
-// we stub it. The DOM wiring in createTableControls is covered by the browser
-// e2e smoke test instead (tests/e2e/test_smoke.py).
+// The DOM wiring in createTableControls is covered by the browser e2e smoke
+// test instead (tests/e2e/test_smoke.py). No global stubs are needed: the
+// module's only cross-file dependency is histogram-slider.js, reached solely
+// through createTableControls' DOM path, which nothing here exercises.
 
 const test = require("node:test");
 const assert = require("node:assert/strict");
 
-global.formatCellNumber = (v, digits = 0) =>
-  v == null ? "—" : v.toFixed(digits);
-
 const {
   foldForSearch,
+  foldSearchTerms,
   matchesSearch,
+  matchesSearchTerms,
   isRangeType,
   isFilterUnset,
   rowPassesFilter,
@@ -57,6 +56,35 @@ test("matchesSearch: a blank or whitespace query matches everything", () => {
   assert.ok(matchesSearch(row, SEARCH_FIELDS, "   "));
 });
 
+test("foldSearchTerms: the query is folded to terms once, for the whole pass", () => {
+  // applyFilters calls this once and hands the terms to matchesSearchTerms per
+  // row, rather than re-folding the query ~19,000 times per keystroke on
+  // driving.html. The two spellings must agree, or the split would be a
+  // behaviour change dressed as an optimization.
+  assert.deepEqual(foldSearchTerms("  SÃO   paulo "), ["sao", "paulo"]);
+  assert.deepEqual(foldSearchTerms("   "), []);
+  const row = { label: "São Paulo, Brazil", providerLabel: "Mapillary" };
+  for (const query of ["sao paulo", "SÃO", "  ", "sao google"]) {
+    assert.equal(
+      matchesSearchTerms(row, SEARCH_FIELDS, foldSearchTerms(query)),
+      matchesSearch(row, SEARCH_FIELDS, query),
+      `disagreed on ${JSON.stringify(query)}`
+    );
+  }
+});
+
+test("the per-row haystack cache is keyed by the FIELD LIST, not just the row", () => {
+  // The cache lives on the row object for the life of the row model. Two
+  // callers on one page always search the same fields, but a cache that
+  // ignored the field list would serve streets.html's haystack to a caller
+  // asking about a different column set — a silent wrong ANSWER, not a slow
+  // one, so the key is asserted rather than assumed.
+  const row = { label: "Seattle", providerLabel: "Mapillary" };
+  assert.ok(matchesSearch(row, ["label", "providerLabel"], "mapillary"));
+  assert.ok(!matchesSearch(row, ["label"], "mapillary"));
+  assert.ok(matchesSearch(row, ["label", "providerLabel"], "mapillary"));
+});
+
 // --- filters ----------------------------------------------------------------
 
 const FILTERS = [
@@ -70,7 +98,11 @@ const FILTERS = [
     ],
     test: (row, value) => row.provider === value,
   },
-  { key: "cov", label: "Coverage", type: "range", field: "pct", min: 0, max: 100 },
+  // `histogram-range` is the ONLY numeric-window type — there was a bar-less
+  // `range` twin, and this fixture was it. Every value-shaped assertion below
+  // (unset, pass, URL round-trip, section order) now runs against the type the
+  // pages actually declare.
+  { key: "cov", label: "Coverage", type: "histogram-range", field: "pct", min: 0, max: 100 },
   { key: "changed", label: "Has Δ", type: "boolean", test: (row) => row.delta != null },
 ];
 
@@ -308,43 +340,28 @@ test("controlsHtml: the picker offers every column except the always-on ones", (
 
 // --- histogram-range parity (issue #250) ------------------------------------
 //
-// `histogram-range` renders differently and behaves identically: same value
-// shape, same URL wire format. Every place that reasons about the VALUE has to
-// treat the two as one, so each is asserted against its `range` twin rather
-// than against a hand-copied expectation.
-
+// A second numeric window, for the cases that need two on one page.
 const HIST_FILTERS = [
-  { key: "cov", label: "Coverage", type: "histogram-range", field: "pct", min: 0, max: 100 },
+  FILTERS[1],
   { key: "age", label: "Median age", type: "histogram-range", field: "age", min: 0 },
 ];
 
-test("isRangeType: both numeric-window flavours, nothing else", () => {
-  assert.ok(isRangeType({ type: "range" }));
+test("isRangeType: histogram-range and nothing else", () => {
+  // ONE numeric-window type. There was a bar-less `range` twin, and there were
+  // "parity" tests asserting f(range) === f(histogram) at every value-shaped
+  // call site — which proved nothing, because every one of those sites
+  // dispatches through THIS predicate first, so the two arguments took the
+  // same branch. The typed assertions the twins wrapped are the real content
+  // and live on above, against the histogram-range fixture.
   assert.ok(isRangeType({ type: "histogram-range" }));
+  assert.ok(!isRangeType({ type: "range" }));
   assert.ok(!isRangeType({ type: "select" }));
   assert.ok(!isRangeType({ type: "boolean" }));
 });
 
-test("histogram-range is unset/pass-tested exactly like range", () => {
-  const hist = HIST_FILTERS[0];
-  const plain = FILTERS[1];
-  for (const value of [{ min: null, max: null }, { min: 10, max: null }, null, ""]) {
-    assert.equal(
-      isFilterUnset(hist, value),
-      isFilterUnset(plain, value),
-      `unset disagreed on ${JSON.stringify(value)}`
-    );
-  }
-  for (const row of [{ pct: 90 }, { pct: 10 }, { pct: null }]) {
-    assert.equal(
-      rowPassesFilter(hist, row, { min: 50, max: 100 }),
-      rowPassesFilter(plain, row, { min: 50, max: 100 }),
-      `pass disagreed on ${JSON.stringify(row)}`
-    );
-  }
-});
-
-test("histogram-range round-trips through the URL in the plain range's format", () => {
+test("a numeric window's URL format is `min~max`, exactly", () => {
+  // Typed rather than compared against a twin: this IS the wire format, and a
+  // shared link written by an older deployment has to keep parsing.
   const state = {
     query: "",
     preset: "overview",
@@ -352,16 +369,20 @@ test("histogram-range round-trips through the URL in the plain range's format", 
     sort: null,
     values: { cov: { min: 10, max: 90 } },
   };
-  const qs = serializeTableState(state, { filters: HIST_FILTERS, defaultPreset: "overview" });
-  // Byte-for-byte what the plain `range` twin writes (URLSearchParams
-  // percent-encodes the "~", which is why this is compared rather than typed).
+  // URLSearchParams percent-encodes the "~", which is why the expectation
+  // reads `%7E` rather than the character the parser splits on.
   assert.equal(
-    qs,
-    serializeTableState(state, { filters: [FILTERS[1]], defaultPreset: "overview" })
+    serializeTableState(state, { filters: HIST_FILTERS, defaultPreset: "overview" }),
+    "cov=10%7E90"
   );
-  assert.deepEqual(parseTableState(qs, { filters: HIST_FILTERS }).values.cov, { min: 10, max: 90 });
+  assert.deepEqual(parseTableState("cov=10~90", { filters: HIST_FILTERS }).values.cov, {
+    min: 10,
+    max: 90,
+  });
+  // A window on one filter says nothing about the other.
+  assert.equal(parseTableState("cov=10~90", { filters: HIST_FILTERS }).values.age, undefined);
 
-  // One-sided and malformed degrade the same way a plain range does.
+  // One-sided keeps the bound it was given; unparseable is simply not set.
   assert.deepEqual(parseTableState("cov=50~", { filters: HIST_FILTERS }).values.cov, {
     min: 50,
     max: null,
@@ -497,18 +518,16 @@ test("controlsHtml: a defaulted select drops the blank 'any' option", () => {
   );
 });
 
-// --- strip opt-out + pickerLabel --------------------------------------------
+// --- pickerLabel ------------------------------------------------------------
 
-test("controlsHtml: renders no sorted-column distribution strip", () => {
-  // Every numeric filter now owns a histogram on a FIXED axis. A second
-  // histogram of whichever column happened to be sorted was a different answer
-  // to the same question — it swapped its metric on a header click and
-  // collapsed under the very bar-click it invited — so it is gone from the
-  // chassis, not merely switched off per page.
-  const html = controlsHtml({ filters: FILTERS, presets: PRESETS, columns: COLUMNS });
-  assert.doesNotMatch(html, /distribution-strip/);
-  assert.doesNotMatch(html, /strip-bar/);
-});
+// There WAS a `controlsHtml: renders no sorted-column distribution strip` test
+// here, asserting the output matched neither /distribution-strip/ nor
+// /strip-bar/. It went with the strip: once those strings appear nowhere in
+// table-controls.js, a test for their absence from its output cannot fail, and
+// a vacuous test reads like coverage. The strip's real replacement — one
+// fixed-axis histogram per numeric filter — is pinned by the histogram-range
+// cases above and, in a browser, by
+// test_the_table_pages_replaced_the_strip_with_per_filter_histograms.
 
 test("controlsHtml: the picker prefers pickerLabel over the leaf label", () => {
   // A pivot's leaf label is a provider name repeated under every metric group

--- a/www/js/__tests__/table-controls.test.js
+++ b/www/js/__tests__/table-controls.test.js
@@ -26,11 +26,7 @@ const {
   defaultFilterValues,
   parseTableState,
   serializeTableState,
-  bucketCountFor,
   histogramBuckets,
-  medianOf,
-  formatStripSummary,
-  renderDistributionStrip,
   controlsHtml,
   syncSidebarDisclosure,
   wireSidebarDisclosure,
@@ -253,24 +249,15 @@ test("parseTableState: an empty query string yields defaults, not undefined", ()
   assert.deepEqual(parsed, { query: "", preset: null, cols: null, sort: null, values: {} });
 });
 
-// --- distribution strip -----------------------------------------------------
-
-test("bucketCountFor: scales with N and clamps at both ends", () => {
-  // A heavily filtered view must not render two lone bars across 24 empty
-  // buckets, and a full table must not render bars thinner than their gaps.
-  assert.equal(bucketCountFor(1), 1);
-  assert.equal(bucketCountFor(2), 2);
-  assert.equal(bucketCountFor(283), 17); // production's walk count
-  assert.equal(bucketCountFor(1501), 24); // production's grid-series count, capped
-});
-
-test("histogramBuckets: bucket count adapts to N when not given one", () => {
-  assert.equal(histogramBuckets([1, 2]).buckets.length, 2);
-  assert.equal(histogramBuckets(Array.from({ length: 100 }, (_, i) => i)).buckets.length, 10);
-});
+// --- histogramBuckets --------------------------------------------------------
+//
+// The axis is always the CALLER's. This helper fed two consumers until the
+// sorted-column distribution strip was retired: the strip scaled itself to the
+// rows in view, the histogram-slider must not, and the self-scaling default
+// went with the strip rather than being left as an option nothing picks.
 
 test("histogramBuckets: drops nulls and puts the maximum in the last bucket", () => {
-  const stats = histogramBuckets([0, 50, 100, null, undefined], 4);
+  const stats = histogramBuckets([0, 50, 100, null, undefined], 4, { min: 0, max: 100 });
   assert.equal(stats.count, 3);
   assert.equal(stats.min, 0);
   assert.equal(stats.max, 100);
@@ -280,68 +267,18 @@ test("histogramBuckets: drops nulls and puts the maximum in the last bucket", ()
   assert.equal(stats.buckets.reduce((n, b) => n + b.count, 0), 3);
 });
 
-test("histogramBuckets: a single distinct value yields one bucket, not a zero-width range", () => {
-  const stats = histogramBuckets([7, 7, 7], 10);
+test("histogramBuckets: a single-point domain yields one bucket, not a zero-width range", () => {
+  const stats = histogramBuckets([7, 7, 7], 10, { min: 7, max: 7 });
   assert.equal(stats.buckets.length, 1);
   assert.deepEqual(stats.buckets[0], { from: 7, to: 7, count: 3 });
 });
 
 test("histogramBuckets: nothing measurable yields null, not an empty chart", () => {
-  assert.equal(histogramBuckets([]), null);
-  assert.equal(histogramBuckets([null, undefined]), null);
+  const domain = { min: 0, max: 100 };
+  assert.equal(histogramBuckets([], 4, domain), null);
+  assert.equal(histogramBuckets([null, undefined], 4, domain), null);
   // NaN/Infinity are not measurements either.
-  assert.equal(histogramBuckets([NaN, Infinity]), null);
-});
-
-test("medianOf: averages the middle pair on an even count, ignores nulls", () => {
-  assert.equal(medianOf([1, 2, 3]), 2);
-  assert.equal(medianOf([1, 2, 3, 4]), 2.5);
-  assert.equal(medianOf([3, null, 1]), 2);
-  assert.equal(medianOf([]), null);
-});
-
-test("formatStripSummary: carries min/median/max as text for screen readers", () => {
-  const column = { key: "pct", label: "Grid coverage", type: "number", unit: "%", digits: 1 };
-  const summary = formatStripSummary(column, [10, 20, 90]);
-  assert.match(summary, /Grid coverage across 3 rows/);
-  assert.match(summary, /min 10\.0%/);
-  assert.match(summary, /median 20\.0%/);
-  assert.match(summary, /max 90\.0%/);
-});
-
-test("formatStripSummary: says so plainly when the filtered view has no values", () => {
-  const column = { key: "pct", label: "Grid coverage", type: "number" };
-  assert.match(formatStripSummary(column, [null, null]), /No grid coverage values/);
-});
-
-// --- renderDistributionStrip (clickable bars) --------------------------------
-
-const STRIP_EL = () => ({ innerHTML: "" });
-const STRIP_COLUMN = { key: "pct", label: "Coverage", type: "number", unit: "%", digits: 1 };
-
-test("renderDistributionStrip: plain, non-interactive spans when the caller passes no filter", () => {
-  const el = STRIP_EL();
-  renderDistributionStrip(el, STRIP_COLUMN, [10, 50, 90]);
-  assert.match(el.innerHTML, /<div class="strip-bars" aria-hidden="true">/);
-  assert.match(el.innerHTML, /<span class="strip-bar"/);
-  assert.doesNotMatch(el.innerHTML, /<button/);
-});
-
-test("renderDistributionStrip: clickable buttons carrying rounded bounds when a matching filter exists", () => {
-  const el = STRIP_EL();
-  renderDistributionStrip(el, STRIP_COLUMN, [10, 50, 90], true);
-  // No aria-hidden on the container once its bars are real, focusable buttons.
-  assert.doesNotMatch(el.innerHTML, /aria-hidden="true"/);
-  assert.match(el.innerHTML, /<button type="button" class="strip-bar" data-from="[\d.]+" data-to="[\d.]+"/);
-  assert.match(el.innerHTML, /click to filter to this range/);
-});
-
-test("renderDistributionStrip: a non-numeric or empty column never renders buttons, even if asked", () => {
-  // clickable=true from a stale sort state must not produce a strip with
-  // nothing behind it to filter.
-  const el = STRIP_EL();
-  renderDistributionStrip(el, { key: "label", label: "City", type: "text" }, [], true);
-  assert.doesNotMatch(el.innerHTML, /<button/);
+  assert.equal(histogramBuckets([NaN, Infinity], 4, domain), null);
 });
 
 // --- controls markup --------------------------------------------------------
@@ -475,9 +412,10 @@ test("rowsExceptFilter: the free-text query still narrows the bars", () => {
 
 // --- histogramBuckets: fixed domain -----------------------------------------
 
-test("histogramBuckets: a domain override fixes the axis instead of tracking the values", () => {
+test("histogramBuckets: the axis is the caller's, never the values' own extent", () => {
   // The slider's axis must not rescale under a brush — bars shrink, the axis
-  // stays. Without the override these three values would span 10–30.
+  // stays. Left to themselves these three values would span 10–30, which would
+  // move the handles' meaning out from under the reader's hand.
   const stats = histogramBuckets([10, 20, 30], 4, { min: 0, max: 100 });
   assert.equal(stats.min, 0);
   assert.equal(stats.max, 100);
@@ -485,8 +423,6 @@ test("histogramBuckets: a domain override fixes the axis instead of tracking the
   assert.deepEqual(stats.buckets.map((b) => b.count), [2, 1, 0, 0]);
   assert.equal(stats.buckets[0].from, 0);
   assert.equal(stats.buckets[3].to, 100);
-  // Without the override the same values would span 10-30 instead.
-  assert.equal(histogramBuckets([10, 20, 30], 4).max, 30);
 });
 
 test("histogramBuckets: values outside a fixed domain clamp into the end buckets", () => {
@@ -498,13 +434,6 @@ test("histogramBuckets: values outside a fixed domain clamp into the end buckets
   // on the boundary and belongs to the upper bucket, as it always has.
   assert.deepEqual(stats.buckets.map((b) => b.count), [1, 2]);
   assert.equal(stats.count, 3);
-});
-
-test("histogramBuckets: without a domain, nothing about the existing behaviour moves", () => {
-  const stats = histogramBuckets([0, 50, 100], 4);
-  assert.equal(stats.min, 0);
-  assert.equal(stats.max, 100);
-  assert.equal(histogramBuckets([], 4, { min: 0, max: 100 }), null);
 });
 
 // --- select defaultValue (issue #250) ---------------------------------------
@@ -570,18 +499,15 @@ test("controlsHtml: a defaulted select drops the blank 'any' option", () => {
 
 // --- strip opt-out + pickerLabel --------------------------------------------
 
-test("controlsHtml: showDistributionStrip=false omits the strip container entirely", () => {
-  // The pivoted pages replace it with per-filter histograms; leaving an empty
-  // container would still paint a card-shaped box under the controls.
-  const off = controlsHtml({
-    filters: FILTERS,
-    presets: PRESETS,
-    columns: COLUMNS,
-    showDistributionStrip: false,
-  });
-  assert.doesNotMatch(off, /distribution-strip/);
-  // driving.html passes nothing and keeps it.
-  assert.match(controlsHtml({ filters: FILTERS, presets: PRESETS, columns: COLUMNS }), /id="distribution-strip"/);
+test("controlsHtml: renders no sorted-column distribution strip", () => {
+  // Every numeric filter now owns a histogram on a FIXED axis. A second
+  // histogram of whichever column happened to be sorted was a different answer
+  // to the same question — it swapped its metric on a header click and
+  // collapsed under the very bar-click it invited — so it is gone from the
+  // chassis, not merely switched off per page.
+  const html = controlsHtml({ filters: FILTERS, presets: PRESETS, columns: COLUMNS });
+  assert.doesNotMatch(html, /distribution-strip/);
+  assert.doesNotMatch(html, /strip-bar/);
 });
 
 test("controlsHtml: the picker prefers pickerLabel over the leaf label", () => {
@@ -617,25 +543,14 @@ function landmarks(html) {
   };
 }
 
-test("controlsHtml: the inline layout keeps descriptor order, filters before the column controls", () => {
-  // driving.html renders through this branch, and its controls have always
-  // been "search, every filter in the order the page declared them, columns,
-  // clear". Reordering them would be a visible change to a page #250 does not
-  // touch.
-  const at = landmarks(controlsHtml({ filters: ORDER_FILTERS, presets: PRESETS, columns: COLUMNS }));
-  assert.ok(at.search < at.range, "search must lead");
-  assert.ok(at.range < at.boolean, "descriptor order: range before boolean");
-  assert.ok(at.boolean < at.select, "descriptor order: boolean before select");
-  assert.ok(at.select < at.columns, "every filter precedes the column controls");
-  assert.ok(at.columns < at.clear, "Clear all is last");
-});
-
-test("controlsHtml: the sidebar layout partitions by type, columns between selects and ranges", () => {
+test("controlsHtml: sections partition by type, columns between selects and ranges", () => {
   // In a 280px column the reading order IS the layout: cheap categorical
   // narrowings first, then the column controls, then the tall histogram
-  // brushes, then the checkboxes.
+  // brushes, then the checkboxes. Note the descriptors arrive in a DIFFERENT
+  // order (range, boolean, select) — the page's declaration order is not the
+  // rendering order, which is the whole point of partitioning.
   const at = landmarks(
-    controlsHtml({ filters: ORDER_FILTERS, presets: PRESETS, columns: COLUMNS, layout: "sidebar" })
+    controlsHtml({ filters: ORDER_FILTERS, presets: PRESETS, columns: COLUMNS })
   );
   assert.ok(at.search < at.select, "search leads");
   assert.ok(at.select < at.columns, "selects come before the column controls");
@@ -644,15 +559,14 @@ test("controlsHtml: the sidebar layout partitions by type, columns between selec
   assert.ok(at.boolean < at.clear, "Clear all is last");
 });
 
-test("controlsHtml: the sidebar layout renders EVERY filter, including an unknown type", () => {
-  // The partition is by type, so a type added later must land somewhere rather
-  // than being silently dropped from one of the two layouts.
+test("controlsHtml: EVERY filter renders, including an unknown type", () => {
+  // The partition is by type, so a type added later must land somewhere — in
+  // the wrong PLACE rather than not at all.
   const odd = { key: "future", label: "Future", type: "something-new" };
   const html = controlsHtml({
     filters: [...ORDER_FILTERS, odd],
     presets: PRESETS,
     columns: COLUMNS,
-    layout: "sidebar",
   });
   for (const key of ["provider", "cov", "changed", "future"]) {
     assert.match(html, new RegExp(`data-filter="${key}"`), `${key} is missing from the sidebar`);
@@ -691,8 +605,9 @@ test("syncSidebarDisclosure: narrowing never closes what the reader opened", () 
 });
 
 test("wireSidebarDisclosure: a no-op without a sidebar, matchMedia, or a document", () => {
-  // driving.html has no .sidebar-disclosure, and Node has no window at all —
-  // this is called unconditionally on DOMContentLoaded, so both must be safe.
+  // Node has no window at all, and any page loading table-controls.js without
+  // a sidebar has no .sidebar-disclosure — this is called unconditionally on
+  // DOMContentLoaded, so both must be safe.
   assert.equal(wireSidebarDisclosure({ querySelector: () => null }), null);
   assert.equal(wireSidebarDisclosure(), null);
 });

--- a/www/js/driving.js
+++ b/www/js/driving.js
@@ -27,7 +27,15 @@
  * STREETSCAPE_DATA_BASE_URL, fetchGzippedJson, escapeHtml — from
  * table-utils.js: sortRowsBy, formatCellNumber, coverageCellHtml,
  * rowHtmlFromColumns, createSortableTable — and from table-controls.js:
- * createTableControls.
+ * createTableControls. histogram-slider.js is loaded for the numeric filters,
+ * but only table-controls.js talks to it.
+ *
+ * The page renders through the same chassis as grid.html and streets.html and
+ * now shares their layout too: a sticky filter sidebar, a one-sentence lead
+ * with the explanation in a disclosure, and histogram-slider filters. What it
+ * does NOT share is the pivot — those two carry one row per city with a
+ * sub-column per provider, this one carries one row per place and a flat
+ * single-row header, so no column here declares a `group`.
  */
 
 /**
@@ -542,10 +550,15 @@ const DRIVING_FILTERS = [
     ],
     test: (row, value) => (row.planStatus ?? "None") === value,
   },
+  // The three numeric windows are histogram-sliders, like grid.html's and
+  // streets.html's. On this page the picture is doing more work than there:
+  // most rows are plan areas we do not track, whose observed fields are all
+  // null, so the bars are the only thing that says how few of the ~3,800 rows
+  // a coverage window can possibly match before you brush one.
   {
     key: "cov",
     label: "Grid coverage %",
-    type: "range",
+    type: "histogram-range",
     field: "coveragePct",
     min: 0,
     max: 100,
@@ -553,7 +566,7 @@ const DRIVING_FILTERS = [
   {
     key: "street",
     label: "Street coverage %",
-    type: "range",
+    type: "histogram-range",
     field: "streetPct",
     min: 0,
     max: 100,
@@ -561,8 +574,10 @@ const DRIVING_FILTERS = [
   {
     key: "since",
     label: "Years since capture",
-    type: "range",
+    type: "histogram-range",
     field: "yearsSinceCapture",
+    // No declared max: how stale the stalest place is, is a property of the
+    // data rather than of the metric, so the axis takes it from the rows.
     min: 0,
   },
   {

--- a/www/js/driving.js
+++ b/www/js/driving.js
@@ -562,6 +562,8 @@ const DRIVING_FILTERS = [
     field: "coveragePct",
     min: 0,
     max: 100,
+    unit: "%",
+    digits: 1,
   },
   {
     key: "street",
@@ -570,6 +572,8 @@ const DRIVING_FILTERS = [
     field: "streetPct",
     min: 0,
     max: 100,
+    unit: "%",
+    digits: 1,
   },
   {
     key: "since",
@@ -579,6 +583,8 @@ const DRIVING_FILTERS = [
     // No declared max: how stale the stalest place is, is a property of the
     // data rather than of the metric, so the axis takes it from the rows.
     min: 0,
+    unit: " yrs",
+    digits: 1,
   },
   {
     key: "enabled",

--- a/www/js/grid.js
+++ b/www/js/grid.js
@@ -693,11 +693,6 @@ function renderGridRuns(rawCities) {
     presets: buildGridPresets(columns),
     filters: buildGridFilters(providers),
     searchFields: GRID_SEARCH_FIELDS,
-    // The sidebar carries per-filter histograms on fixed axes; a second
-    // histogram of whichever column happens to be sorted would be a different
-    // answer to the same question, changing its metric on every header click.
-    layout: "sidebar",
-    showDistributionStrip: false,
     onChange: (shown, all) => updateGridCaption(shown, all, generatedAt),
   });
   gridControls.setRows(rows);

--- a/www/js/histogram-slider.js
+++ b/www/js/histogram-slider.js
@@ -1,6 +1,9 @@
 /**
  * histogram-slider.js — a mini histogram with a dual-handle range brush, used
- * as the numeric filter control on the pivoted data-table pages (issue #250).
+ * as THE numeric filter control on every data-table page (issue #250). Not
+ * only the pivoted ones: driving.html is deliberately unpivoted (its rows are
+ * places, not cities-with-a-column-per-provider) and loads three of these, and
+ * the bar-less alternative it used to render is deleted.
  *
  * WHY this replaces the min/max number inputs as the primary control, and why
  * it replaces the distribution strip rather than joining it:
@@ -36,7 +39,13 @@
  * Depends on globals from table-utils.js (loaded first): formatCellNumber.
  */
 
-/** How many bars a histogram-slider draws. Matches the strip's cap. */
+/**
+ * How many bars a histogram-slider draws.
+ *
+ * Inherited from the sorted-column distribution strip this replaced, which
+ * capped itself here; the strip is gone, and the figure survives on its own
+ * merits — 24 bars is about as fine as a 280px sidebar column resolves.
+ */
 const HISTOGRAM_SLIDER_BUCKETS = 24;
 
 /**

--- a/www/js/streets.js
+++ b/www/js/streets.js
@@ -852,8 +852,6 @@ function renderStreetWalks(manifest, rawCities) {
     presets: buildStreetPresets(columns),
     filters: buildStreetFilters(providers),
     searchFields: STREET_SEARCH_FIELDS,
-    layout: "sidebar",
-    showDistributionStrip: false,
     onChange: (shown, all, state) => updateStreetsCaption(shown, all, manifest, state),
   });
   streetsControls.setRows(rows);

--- a/www/js/table-controls.js
+++ b/www/js/table-controls.js
@@ -1,14 +1,15 @@
 /**
  * table-controls.js — the exploration chassis for the data-table pages
- * (grid.html and streets.html), issue #188.
+ * (grid.html, streets.html and driving.html), issue #188.
  *
- * The tables outgrew "sortable list": grid.html renders 1,501 rows and
- * streets.html 283, and the questions being asked of them are comparative
- * ("where does Mapillary beat GSV?", "which cities have imagery where people
- * actually walk?") rather than lookup-by-name. This module adds the machinery
- * that makes a large table explorable — text search, structured filters,
- * column presets, and a distribution strip for the sorted column — and keeps
- * the whole view in the URL so a finding can be linked to.
+ * The tables outgrew "sortable list": driving.html renders ~3,800 rows,
+ * grid.html ~1,190 and streets.html 283, and the questions being asked of them
+ * are comparative ("where does Mapillary beat GSV?", "which cities have
+ * imagery where people actually walk?") rather than lookup-by-name. This
+ * module adds the machinery that makes a large table explorable — text search,
+ * structured filters, column presets and per-filter histograms, rendered into
+ * a sidebar beside the table — and keeps the whole view in the URL so a
+ * finding can be linked to.
  *
  * Deliberately NOT an export tool. `cities.json.gz` and `streetwalks.json.gz`
  * are already published as public gzipped JSON at fixed URLs, so a CSV of the
@@ -16,11 +17,12 @@
  * analysis pulls from the catalog instead.
  *
  * Page-agnostic: everything specific to a page arrives as descriptors
- * (`columns`, `presets`, `filters`) from grid.js / streets.js. The pure
- * functions here are exported for the offline unit tests; only
+ * (`columns`, `presets`, `filters`) from grid.js / streets.js / driving.js.
+ * The pure functions here are exported for the offline unit tests; only
  * `createTableControls` touches the DOM.
  *
- * Depends on globals from table-utils.js (loaded first): formatCellNumber.
+ * Depends on globals from histogram-slider.js (loaded first):
+ * createHistogramSlider, HISTOGRAM_SLIDER_BUCKETS.
  */
 
 // ── Text search ───────────────────────────────────────────────
@@ -350,50 +352,38 @@ function serializeTableState(state, { filters, defaultPreset }) {
   return params.toString();
 }
 
-// ── Distribution strip ────────────────────────────────────────
+// ── Histogram bucketing ───────────────────────────────────────
 
 /**
- * How many buckets to cut a set of N values into.
- *
- * The square-root rule, clamped. A fixed bucket count is wrong at both ends of
- * this table's range: at N=2 (a heavily filtered view) 24 buckets strand two
- * lone bars at opposite edges of an otherwise empty strip, and past ~600 the
- * bars are thinner than the gaps between them. Production sits at 283 walks
- * and 1,501 grid series, both of which land on the 24 cap.
- *
- * @param {number} n - Count of measurable values.
- * @returns {number}
- */
-function bucketCountFor(n) {
-  return Math.min(24, Math.max(1, Math.ceil(Math.sqrt(n))));
-}
-
-/**
- * Bucket numeric values into a histogram.
+ * Bucket numeric values into a histogram, over an axis the CALLER fixes.
  *
  * Nulls are dropped rather than bucketed as zero (see rowPassesFilter). A
  * single distinct value yields one full-width bucket instead of a degenerate
  * zero-width range.
  *
+ * The axis is never taken from the values themselves. A histogram-slider's
+ * axis has to stay put while the reader brushes it, or the handles' meaning
+ * moves out from under their hand — and the bars have to be bucketed over the
+ * SNAPPED domain the component hands back, not the raw extent, or the two are
+ * painted across the same 100% width on two different scales (measured at
+ * 1.05% of the track on a 0–85.1 coverage axis). The sorted-column
+ * distribution strip did scale itself to the rows in view, which is why this
+ * carried a self-scaling default until that strip was retired; it does not,
+ * now, because nothing left on the site wants one.
+ *
  * @param {Array<?number>} values
- * @param {number} [bucketCount] - Defaults to bucketCountFor(N).
- * @param {?{min: number, max: number}} [domain] - Fixed axis (issue #250). By
- *   default the extent is taken from `values`, which is right for the
- *   distribution strip (it describes the rows in view) and WRONG for a
- *   histogram-slider, whose axis must stay put while the reader brushes it:
- *   a self-scaling axis would move the handles' meaning out from under them.
- *   Values outside the domain are clamped into the end buckets rather than
- *   dropped, so a stale domain under-draws rather than losing rows.
+ * @param {number} bucketCount
+ * @param {{min: number, max: number}} domain - The fixed axis. Values outside
+ *   it are clamped into the end buckets rather than dropped, so a stale domain
+ *   under-draws rather than losing rows.
  * @returns {{buckets: {from: number, to: number, count: number}[],
  *            min: number, max: number, count: number}|null}
  *   Null when nothing is measurable.
  */
-function histogramBuckets(values, bucketCount, domain = null) {
+function histogramBuckets(values, bucketCount, domain) {
   const nums = values.filter((v) => typeof v === "number" && Number.isFinite(v));
   if (nums.length === 0) return null;
-  bucketCount = bucketCount ?? bucketCountFor(nums.length);
-  const min = domain ? domain.min : Math.min(...nums);
-  const max = domain ? domain.max : Math.max(...nums);
+  const { min, max } = domain;
   if (min === max) {
     return { buckets: [{ from: min, to: max, count: nums.length }], min, max, count: nums.length };
   }
@@ -413,101 +403,7 @@ function histogramBuckets(values, bucketCount, domain = null) {
   return { buckets, min, max, count: nums.length };
 }
 
-/** Median of a numeric array (the strip's text summary). */
-function medianOf(values) {
-  const nums = values
-    .filter((v) => typeof v === "number" && Number.isFinite(v))
-    .sort((a, b) => a - b);
-  if (nums.length === 0) return null;
-  const mid = Math.floor(nums.length / 2);
-  return nums.length % 2 ? nums[mid] : (nums[mid - 1] + nums[mid]) / 2;
-}
-
-/**
- * Text equivalent of the distribution strip.
- *
- * The bars are decorative (`aria-hidden`); this sentence carries the same
- * information for a screen reader and doubles as the visible caption.
- *
- * @param {Object} column - The active sort column descriptor.
- * @param {Array<?number>} values
- * @returns {string}
- */
-function formatStripSummary(column, values) {
-  const stats = histogramBuckets(values);
-  if (!stats) return `No ${column.label.toLowerCase()} values in the current view.`;
-  const unit = column.unit ?? "";
-  const fmt = (v) => `${formatCellNumber(v, column.digits ?? 1)}${unit}`;
-  return (
-    `${column.label} across ${formatCellNumber(stats.count)} rows: ` +
-    `min ${fmt(stats.min)}, median ${fmt(medianOf(values))}, max ${fmt(stats.max)}.`
-  );
-}
-
 // ── DOM wiring ────────────────────────────────────────────────
-
-/**
- * Render the distribution strip into a container.
- *
- * A single-series magnitude chart, so: one flat hue for every bar (bar colour
- * carries no second meaning), no legend, no axis furniture. The bars are
- * deliberately NOT painted with `coverageColor` — these encode row counts, and
- * reusing the coverage ramp here would imply the height meant coverage.
- *
- * When the active sort column has a matching range filter, each bucket
- * becomes a real `<button>` carrying its bounds in `data-from`/`data-to` —
- * `createTableControls` delegates a click listener to the container (bars are
- * rebuilt on every repaint, so a per-bar listener would need re-binding every
- * time; delegation on the container survives the innerHTML replacement, the
- * same reason the header's sort click is delegated to the `<thead>`). Without
- * a matching filter the bars stay plain, `aria-hidden` `<span>`s exactly as
- * before — there is nothing a click on them could narrow.
- *
- * @param {Element} el - Container.
- * @param {Object} column - Active sort column descriptor.
- * @param {Array<?number>} values
- * @param {boolean} [clickable] - Whether the active sort column has a range
- *   filter a bar click can set.
- */
-function renderDistributionStrip(el, column, values, clickable = false) {
-  const stats = histogramBuckets(values);
-  const summary = formatStripSummary(column, values);
-  if (!stats || column.type !== "number") {
-    el.innerHTML = `<p class="strip-summary">${
-      column.type === "number" ? summary : "Sort by a numeric column to see its distribution."
-    }</p>`;
-    return;
-  }
-  const tallest = Math.max(...stats.buckets.map((b) => b.count));
-  const unit = column.unit ?? "";
-  const digits = column.digits ?? 1;
-  // Bucket bounds are rounded to the column's own display precision before
-  // being used anywhere — as the label text AND as the value a click writes
-  // into the filter — so a bar's tooltip and the range it actually selects
-  // always agree (rather than a label reading "58.7%" while the click quietly
-  // filters to the unrounded 58.6987…%).
-  const roundToDigits = (v) => Math.round(v * 10 ** digits) / 10 ** digits;
-  const bars = stats.buckets
-    .map((bucket) => {
-      const height = tallest === 0 ? 0 : Math.round((bucket.count / tallest) * 100);
-      const from = roundToDigits(bucket.from);
-      const to = roundToDigits(bucket.to);
-      const label =
-        `${formatCellNumber(from, digits)}${unit}–${formatCellNumber(to, digits)}${unit}: ` +
-        `${formatCellNumber(bucket.count)} row${bucket.count === 1 ? "" : "s"}` +
-        (clickable ? " — click to filter to this range" : "");
-      // min-height keeps a non-empty bucket visible instead of rounding it away.
-      const heightPct = bucket.count > 0 ? Math.max(height, 2) : 0;
-      return clickable
-        ? `<button type="button" class="strip-bar" data-from="${from}" data-to="${to}"
-                   title="${label}" aria-label="${label}" style="height:${heightPct}%"></button>`
-        : `<span class="strip-bar" title="${label}" style="height:${heightPct}%"></span>`;
-    })
-    .join("");
-  el.innerHTML =
-    `<div class="strip-bars"${clickable ? "" : ' aria-hidden="true"'}>${bars}</div>` +
-    `<p class="strip-summary">${summary}</p>`;
-}
 
 /**
  * Build the controls markup for a page.
@@ -518,33 +414,25 @@ function renderDistributionStrip(el, column, values, clickable = false) {
  * `<fieldset>` — so the whole region is keyboard-reachable and announced
  * without any ARIA of its own.
  *
- * Two section orders, picked by `layout`:
+ * One section order, for the one place these controls are rendered: a ~280px
+ * sidebar beside the table. Search, selects, the column controls, numeric
+ * windows, booleans, Clear all (issue #250). In a column that narrow the
+ * reading order IS the layout, so the cheap categorical narrowings come first
+ * and the tall histogram brushes sit below the column controls rather than
+ * pushing them off the bottom.
  *
- *  * `"inline"` (default) — search, then every filter in descriptor order,
- *    then the column controls, then Clear all. This is the horizontal strip
- *    driving.html has always rendered, and it is emitted byte-identically.
- *  * `"sidebar"` — search, selects, the column controls, numeric windows, then
- *    booleans, then Clear all (issue #250). In a 280px column the reading
- *    order IS the layout, so the cheap categorical narrowings come first and
- *    the tall histogram brushes sit below the column controls rather than
- *    pushing them off the bottom.
+ * There was a second, horizontal order for driving.html until that page moved
+ * to the sidebar too; it is gone rather than kept warm, since an alternative
+ * layout nothing renders is one nothing tests either.
  *
- * The sidebar order partitions by filter TYPE, so it also carries an
- * "everything else" bucket: a filter type added later must still be rendered
- * somewhere rather than silently vanishing from one of the two layouts.
+ * The order partitions by filter TYPE, so it also carries an "everything else"
+ * bucket: a filter type added later must still be rendered somewhere rather
+ * than silently vanishing.
  *
- * @param {Object} cfg - {filters, presets, columns, searchPlaceholder,
- *   showDistributionStrip, layout}.
+ * @param {Object} cfg - {filters, presets, columns, searchPlaceholder}.
  * @returns {string} HTML.
  */
-function controlsHtml({
-  filters,
-  presets,
-  columns,
-  searchPlaceholder,
-  showDistributionStrip = true,
-  layout = "inline",
-}) {
+function controlsHtml({ filters, presets, columns, searchPlaceholder }) {
   const renderFilter = (filter) => {
       if (filter.type === "select") {
         // A select with a declared default has no "any" reading (issue #250:
@@ -658,47 +546,36 @@ function controlsHtml({
   const clearControl = `
       <button type="button" class="controls-clear">Clear all</button>`;
 
-  let body;
-  if (layout === "sidebar") {
-    // Partition, don't hand-list: `rest` catches any filter type not named
-    // here, so a type added later renders in the wrong PLACE rather than not
-    // at all. The order is search -> selects -> columns -> numeric windows ->
-    // booleans -> clear.
-    const selects = filters.filter((f) => f.type === "select");
-    const ranges = filters.filter(isRangeType);
-    const booleans = filters.filter((f) => f.type === "boolean");
-    const placed = new Set([...selects, ...ranges, ...booleans]);
-    const rest = filters.filter((f) => !placed.has(f));
-    const render = (list) => list.map(renderFilter).join("");
-    body =
-      searchControl +
-      render(selects) +
-      columnControls +
-      render(ranges) +
-      render(booleans) +
-      render(rest) +
-      clearControl;
-  } else {
-    // The literal indent the old `${filterControls}` interpolation sat on. It
-    // is here so this branch stays BYTE-identical to the pre-#250 markup —
-    // driving.html renders through it, and a test compares the two strings
-    // rather than trusting the eye.
-    body =
-      searchControl + "\n      " + filters.map(renderFilter).join("") + columnControls + clearControl;
-  }
+  // Partition, don't hand-list: `rest` catches any filter type not named here,
+  // so a type added later renders in the wrong PLACE rather than not at all.
+  // The order is search -> selects -> columns -> numeric windows -> booleans
+  // -> clear.
+  const selects = filters.filter((f) => f.type === "select");
+  const ranges = filters.filter(isRangeType);
+  const booleans = filters.filter((f) => f.type === "boolean");
+  const placed = new Set([...selects, ...ranges, ...booleans]);
+  const rest = filters.filter((f) => !placed.has(f));
+  const render = (list) => list.map(renderFilter).join("");
+  const body =
+    searchControl +
+    render(selects) +
+    columnControls +
+    render(ranges) +
+    render(booleans) +
+    render(rest) +
+    clearControl;
 
   return `
     <div class="table-controls">${body}
-    </div>
-    ${showDistributionStrip ? `<div class="distribution-strip" id="distribution-strip"></div>` : ""}`;
+    </div>`;
 }
 
 /**
  * Wire the controls region to a sortable table.
  *
  * Owns the filter/search/preset state, pushes the narrowed rows into the
- * table, keeps the URL in step, and repaints the distribution strip whenever
- * the active sort column or the filtered set changes.
+ * table, keeps the URL in step, and redraws each filter's histogram whenever
+ * the filtered set changes.
  *
  * The URL is written with `replaceState`, not `pushState`: exploring a table is
  * a continuous adjustment, and one history entry per keystroke would make the
@@ -716,15 +593,6 @@ function controlsHtml({
  *   caption/result count. The third argument is what lets a caption name a
  *   filter's active value (streets.html's network) without reaching into the
  *   DOM for it.
- * @param {"inline"|"sidebar"} [cfg.layout="inline"] - Control section order;
- *   see controlsHtml. The pivoted pages pass "sidebar"; driving.js does not,
- *   and its markup is unchanged.
- * @param {boolean} [cfg.showDistributionStrip=true] - Render the sorted-column
- *   distribution strip. The pivoted pages (issue #250) turn it off: their
- *   numeric filters are histogram-sliders, which draw a PER-FILTER histogram
- *   on a fixed axis, so a second histogram of whichever column happens to be
- *   sorted — one that silently swapped its metric on every header click — is
- *   two conflicting answers to one question. driving.html keeps it.
  * @returns {{setRows: Function, getFilteredRows: Function}}
  */
 /**
@@ -755,16 +623,14 @@ function createTableControls({
   searchFields,
   searchPlaceholder,
   onChange,
-  showDistributionStrip = true,
-  layout = "inline",
 }) {
   const defaultPreset = presets[0].id;
   let allRows = [];
   let filtered = [];
   // No `sort` field here: the sort is owned entirely by `table` (the
   // createSortableTable controller), read via `table.getSort()` wherever it's
-  // needed (updateUrl, repaintStrip). Duplicating it into this state object
-  // would just be a second, driftable copy of the same fact.
+  // needed (updateUrl). Duplicating it into this state object would just be a
+  // second, driftable copy of the same fact.
   const state = {
     query: "",
     preset: defaultPreset,
@@ -772,20 +638,9 @@ function createTableControls({
     values: defaultFilterValues(filters),
   };
 
-  rootEl.innerHTML = controlsHtml({
-    filters,
-    presets,
-    columns,
-    searchPlaceholder,
-    showDistributionStrip,
-    layout,
-  });
+  rootEl.innerHTML = controlsHtml({ filters, presets, columns, searchPlaceholder });
   const searchEl = rootEl.querySelector("#table-search");
   const presetEl = rootEl.querySelector("#table-preset");
-  // Null when the page opted out — every strip site below guards on the
-  // element rather than re-reading the flag, so there is one condition to get
-  // right instead of five.
-  const stripEl = rootEl.querySelector("#distribution-strip");
 
   // ── Histogram-sliders (issue #250) ──
   // One per `histogram-range` filter, each with a FIXED axis seeded once from
@@ -972,9 +827,9 @@ function createTableControls({
         else el.value = value ?? "";
       }
     }
-    // Adopt WITHOUT reporting: this runs when the URL, "Clear all" or a strip
-    // click is the source of the value, and echoing it back through onInput
-    // would be circular.
+    // Adopt WITHOUT reporting: this runs when the URL or "Clear all" is the
+    // source of the value, and echoing it back through onInput would be
+    // circular.
     for (const [key, entry] of histograms) entry.slider.setValue(state.values[key]);
     for (const filter of resolved) if (filter.labelFor) relabelControl(filter);
     const visibleKeys = new Set(
@@ -991,26 +846,7 @@ function createTableControls({
     history.replaceState(null, "", qs ? `?${qs}` : location.pathname);
   }
 
-  /** The range filter a click on the strip's bars would set, if any. */
-  function rangeFilterFor(column) {
-    return filters.find((f) => isRangeType(f) && f.field === column.key);
-  }
-
-  function repaintStrip() {
-    if (!stripEl) return;
-    const sort = table.getSort();
-    const column = columns.find((c) => c.key === sort.key);
-    if (column) {
-      renderDistributionStrip(
-        stripEl,
-        column,
-        filtered.map((r) => r[column.key]),
-        Boolean(rangeFilterFor(column))
-      );
-    }
-  }
-
-  /** Re-filter, repaint the table, the strip, and the URL. */
+  /** Re-filter, repaint the table, the histograms, and the URL. */
   function apply() {
     // A scope change lands here through the same path as any other control, so
     // this is where the resolved filters catch up before anything reads them.
@@ -1022,7 +858,6 @@ function createTableControls({
       searchFields,
     });
     table.setRows(filtered);
-    repaintStrip();
     repaintHistograms();
     updateUrl();
     onChange?.(filtered, allRows, { values: { ...state.values }, preset: state.preset });
@@ -1048,7 +883,6 @@ function createTableControls({
     state.cols = null; // an explicit preset choice discards a picker deviation
     applyColumns();
     syncControlsToState();
-    repaintStrip();
     updateUrl();
   });
 
@@ -1071,7 +905,6 @@ function createTableControls({
         .filter((b) => b.checked)
         .map((b) => b.dataset.column);
       applyColumns();
-      repaintStrip();
       updateUrl();
       return;
     }
@@ -1140,35 +973,10 @@ function createTableControls({
     rangeTimer = setTimeout(() => handleControlChange(event.target), 150);
   });
 
-  // Distribution strip: a bar click sets the range filter matching the
-  // ACTIVE SORT COLUMN to that bucket's bounds (renderDistributionStrip only
-  // emits <button>s, rather than the plain aria-hidden <span>s, when such a
-  // filter exists — so a stray click elsewhere in the strip's whitespace is
-  // simply not on a `.strip-bar[data-from]` and no-ops here). Delegated on
-  // the container rather than bound per-bar: repaintStrip replaces the strip's
-  // innerHTML on every sort/filter change, which would silently drop a
-  // per-button listener the same way an un-delegated header click would (see
-  // createSortableTable's own listener for that exact regression).
-  stripEl?.addEventListener("click", (event) => {
-    const bar = event.target.closest?.(".strip-bar[data-from]");
-    if (!bar) return;
-    const sort = table.getSort();
-    const column = columns.find((c) => c.key === sort.key);
-    const filter = column && rangeFilterFor(column);
-    if (!filter) return;
-    state.values[filter.key] = {
-      min: Number.parseFloat(bar.dataset.from),
-      max: Number.parseFloat(bar.dataset.to),
-    };
-    syncControlsToState();
-    apply();
-  });
-
   rootEl.querySelector(".col-reset").addEventListener("click", () => {
     state.cols = null;
     applyColumns();
     syncControlsToState();
-    repaintStrip();
     updateUrl();
   });
 
@@ -1183,9 +991,11 @@ function createTableControls({
   });
 
   // A header click re-sorts inside the table controller, which knows nothing
-  // about the URL or the strip — so listen on the same thead and follow up.
+  // about the URL — so listen on the same thead and follow up. The histograms
+  // are deliberately NOT redrawn here: which column is sorted does not change
+  // which rows are selected, and a picture that repainted on a sort would be
+  // claiming otherwise.
   table.onSortChange?.(() => {
-    repaintStrip();
     updateUrl();
   });
 
@@ -1287,11 +1097,7 @@ if (typeof module !== "undefined" && module.exports) {
     defaultFilterValues,
     parseTableState,
     serializeTableState,
-    bucketCountFor,
     histogramBuckets,
-    medianOf,
-    formatStripSummary,
-    renderDistributionStrip,
     controlsHtml,
     createTableControls,
     syncSidebarDisclosure,

--- a/www/js/table-controls.js
+++ b/www/js/table-controls.js
@@ -48,6 +48,51 @@ function foldForSearch(value) {
 }
 
 /**
+ * Fold a raw query into its search terms: whitespace-separated, blanks
+ * dropped, each folded by foldForSearch.
+ *
+ * Split out so applyFilters can fold the query ONCE per pass instead of once
+ * per row. It matters because of how many passes there are: every `apply()`
+ * runs applyFilters for the table plus one `rowsExceptFilter` per histogram
+ * (three on driving.html, four on grid.html), so driving.html's ~3,800 rows
+ * meant ~19,000 NFD folds of the same three-character query per keystroke.
+ *
+ * @param {string} query - Raw query text.
+ * @returns {string[]} Folded terms; empty for a blank query.
+ */
+function foldSearchTerms(query) {
+  return foldForSearch(query).split(/\s+/).filter(Boolean);
+}
+
+/**
+ * Each row's searched fields, folded and joined — computed once per row.
+ *
+ * Keyed on the row OBJECT, so the cache lives exactly as long as the row
+ * models do and a reload drops it with them. It assumes the SEARCHED fields
+ * are immutable once a row model is built, which is true of all three pages
+ * (driving.js's mergeStreetCoverage does mutate rows, but it writes observed
+ * coverage, not any of DRIVING_SEARCH_FIELDS, and it runs before the rows
+ * reach the chassis at all).
+ *
+ * @type {WeakMap<Object, {fields: string, text: string}>}
+ */
+const searchHaystacks = new WeakMap();
+
+/**
+ * @param {Object} row - A row model.
+ * @param {string[]} fields - Row fields to search.
+ * @returns {string} The folded, joined haystack for that row.
+ */
+function searchHaystackFor(row, fields) {
+  const fieldKey = fields.join(",");
+  const cached = searchHaystacks.get(row);
+  if (cached !== undefined && cached.fields === fieldKey) return cached.text;
+  const text = fields.map((f) => foldForSearch(row[f])).join(" ");
+  searchHaystacks.set(row, { fields: fieldKey, text });
+  return text;
+}
+
+/**
  * Does a row match a free-text query?
  *
  * Every whitespace-separated term must appear in at least one of the row's
@@ -60,31 +105,54 @@ function foldForSearch(value) {
  * @returns {boolean}
  */
 function matchesSearch(row, fields, query) {
-  const terms = foldForSearch(query).split(/\s+/).filter(Boolean);
+  return matchesSearchTerms(row, fields, foldSearchTerms(query));
+}
+
+/**
+ * matchesSearch with the query already folded — the hot path.
+ *
+ * @param {Object} row - A row model.
+ * @param {string[]} fields - Row fields to search.
+ * @param {string[]} terms - Folded terms from foldSearchTerms; empty matches
+ *   everything.
+ * @returns {boolean}
+ */
+function matchesSearchTerms(row, fields, terms) {
   if (terms.length === 0) return true;
-  const haystack = fields.map((f) => foldForSearch(row[f])).join(" ");
+  const haystack = searchHaystackFor(row, fields);
   return terms.every((term) => haystack.includes(term));
 }
 
 // ── Structured filters ────────────────────────────────────────
 
 /**
- * Is this a numeric-window filter?
+ * Is this a numeric-window filter — a `{min, max}` value, either nullable,
+ * serialized as `"min~max"`?
  *
- * `range` (two number inputs) and `histogram-range` (issue #250: a mini
- * histogram plus a dual-handle slider, WITH the same two number inputs kept
- * for precision and keyboard/AT parity) differ only in what they render. The
- * value shape is identical — `{min, max}`, either nullable — and so is the URL
- * wire format, `"min~max"`. Every place that reasons about the VALUE therefore
- * has to accept both, which is what this predicate is for: a missed site would
- * make a histogram filter silently unserializable or un-parseable rather than
- * failing loudly.
+ * There were TWO flavours once (issue #188 follow-up): a bar-less `range` (the two
+ * number inputs) and `histogram-range` (issue #250: a mini histogram plus a
+ * dual-handle slider, keeping those same inputs for precision and keyboard/AT
+ * parity). They differed only in what they RENDERED, so this predicate existed
+ * to keep every value-shaped call site accepting both.
+ *
+ * `range` is gone, along with its render branch, its `.control-range` CSS and
+ * the twinned tests. driving.html was its last caller and moved to
+ * `histogram-range` here; keeping a second flavour warm for a hypothetical
+ * caller would have kept warm a code path nothing renders, and the "parity"
+ * tests that appeared to protect it proved nothing — every one of them
+ * dispatched through THIS predicate first, so `f(range) === f(histogram)` was
+ * comparing a branch against itself.
+ *
+ * The predicate itself stays, rather than inlining `type === "histogram-range"`
+ * at nine call sites: it names WHY those sites are grouped (they reason about
+ * the value, not the widget), and it is where the next numeric widget would be
+ * admitted.
  *
  * @param {Object} filter - Filter descriptor.
  * @returns {boolean}
  */
 function isRangeType(filter) {
-  return filter.type === "range" || filter.type === "histogram-range";
+  return filter.type === "histogram-range";
 }
 
 /**
@@ -132,6 +200,12 @@ function rowPassesFilter(filter, row, value) {
 /**
  * Narrow rows by the free-text query and every set filter.
  *
+ * The query is folded ONCE here, not once per row, and each row's haystack is
+ * folded once for the life of the row model (searchHaystackFor) — worth doing
+ * because this function runs 4-5 times per keystroke on the largest table (the
+ * table itself plus one `rowsExceptFilter` per histogram) behind a 150 ms
+ * debounce.
+ *
  * @param {Object[]} rows - All row models.
  * @param {Object} cfg
  * @param {Object[]} cfg.filters - Filter descriptors.
@@ -141,9 +215,10 @@ function rowPassesFilter(filter, row, value) {
  * @returns {Object[]} A new filtered array (input untouched).
  */
 function applyFilters(rows, { filters, values, query, searchFields }) {
+  const terms = foldSearchTerms(query ?? "");
   return rows.filter(
     (row) =>
-      matchesSearch(row, searchFields, query ?? "") &&
+      matchesSearchTerms(row, searchFields, terms) &&
       filters.every((filter) => rowPassesFilter(filter, row, values[filter.key]))
   );
 }
@@ -163,9 +238,10 @@ function applyFilters(rows, { filters, values, query, searchFields }) {
  *
  * A descriptor opts in with `fieldFor(values)` / `labelFor(values)` /
  * `testFor(values)`; everything else passes through untouched, which is what
- * keeps driving.html and the plain `range` filters unaware of any of this. The
- * result is a SHALLOW COPY, so the originals stay the page's static
- * descriptors and nothing accumulates state across renders.
+ * keeps the unpivoted page (driving.html, whose rows are places rather than
+ * cities-with-a-column-per-provider) unaware of any of this. The result is a
+ * SHALLOW COPY, so the originals stay the page's static descriptors and
+ * nothing accumulates state across renders.
  *
  * @param {Object[]} filters - Filter descriptors.
  * @param {Object} values - Current {filterKey: value}.
@@ -451,12 +527,11 @@ function controlsHtml({ filters, presets, columns, searchPlaceholder }) {
             <select id="f-${filter.key}" data-filter="${filter.key}">${options}</select>
           </div>`;
       }
-      // The two numeric-window flavours share their number inputs verbatim —
-      // same `data-filter`/`data-bound` hooks, same aria-labels — because
-      // those are what syncControlsToState, handleControlChange and the e2e
-      // selectors read. `histogram-range` only ADDS the bars + brush above
-      // them (issue #250); the precision path is unchanged, which is also what
-      // keeps the control fully usable by keyboard and by AT.
+      // The number inputs are the PRECISION path under the brush, and they are
+      // what syncControlsToState, handleControlChange and the e2e selectors
+      // read (`data-filter`/`data-bound`). They were shared verbatim with a
+      // second, bar-less `range` flavour until that flavour lost its last
+      // caller; see isRangeType for why it is gone rather than kept warm.
       const boundInputs = () => `<input type="number" data-filter="${filter.key}" data-bound="min"
                    aria-label="Minimum ${filter.label}" placeholder="min"
                    ${filter.min != null ? `min="${filter.min}"` : ""}
@@ -466,13 +541,6 @@ function controlsHtml({ filters, presets, columns, searchPlaceholder }) {
                    aria-label="Maximum ${filter.label}" placeholder="max"
                    ${filter.min != null ? `min="${filter.min}"` : ""}
                    ${filter.max != null ? `max="${filter.max}"` : ""}>`;
-      if (filter.type === "range") {
-        return `
-          <div class="control control-range" role="group" aria-labelledby="f-${filter.key}-legend">
-            <span class="control-legend" id="f-${filter.key}-legend">${filter.label}</span>
-            ${boundInputs()}
-          </div>`;
-      }
       if (filter.type === "histogram-range") {
         // The bars are decorative (aria-hidden): the two range thumbs carry a
         // live aria-valuetext and the number inputs carry the exact figures,
@@ -614,6 +682,55 @@ function defaultFilterValues(filters) {
   return values;
 }
 
+/**
+ * Wrap the controls container in the sidebar chrome, and reveal the layout.
+ *
+ * The `<aside>` landmark, the collapsible `<details>` and its "Filters"
+ * summary used to be hand-copied into all three page HTMLs. That made a
+ * wrapper change — the summary text, the `aria-label`, the `open` default — a
+ * three-file edit whose failure mode was silent: miss one page and
+ * `wireSidebarDisclosure` simply returns null there, so its filters stay
+ * collapsed after a widen with no toggle to reopen them.
+ *
+ * Revealing the layout is the same argument from the other side. The pages
+ * author `.table-layout` as `hidden`, and every empty-state and error path
+ * returns BEFORE createTableControls — so a deployment with nothing published
+ * (driving.html before its first `fetch-driving-plan`, streets.html before the
+ * first road walk) used to render a viewport-tall empty white sidebar beside
+ * its status line, and an empty landmark to assistive tech. Clearing the
+ * attribute here rather than per page means the reveal cannot be forgotten by
+ * whichever page is added next.
+ *
+ * @param {Element} rootEl - The `#<page>-controls` container authored in HTML.
+ * @returns {?Element} The layout element, if there was one.
+ */
+function mountSidebar(rootEl) {
+  if (typeof document === "undefined") return null;
+  const layoutEl = rootEl.closest(".table-layout");
+  if (rootEl.closest(".table-sidebar")) {
+    // Already wrapped — a page that calls createTableControls twice.
+    layoutEl?.removeAttribute("hidden");
+    return layoutEl;
+  }
+  const asideEl = document.createElement("aside");
+  asideEl.className = "table-sidebar";
+  asideEl.setAttribute("aria-label", "Search and filters");
+  const detailsEl = document.createElement("details");
+  detailsEl.className = "sidebar-disclosure";
+  detailsEl.open = true;
+  const summaryEl = document.createElement("summary");
+  summaryEl.textContent = "Filters";
+  detailsEl.append(summaryEl);
+  asideEl.append(detailsEl);
+  // Put the aside exactly where the container was, then adopt the container
+  // into it: `rootEl` keeps its identity, so everything downstream that reads
+  // or listens on it is unaffected.
+  rootEl.replaceWith(asideEl);
+  detailsEl.append(rootEl);
+  layoutEl?.removeAttribute("hidden");
+  return layoutEl;
+}
+
 function createTableControls({
   rootEl,
   table,
@@ -638,7 +755,11 @@ function createTableControls({
     values: defaultFilterValues(filters),
   };
 
+  const layoutEl = mountSidebar(rootEl);
   rootEl.innerHTML = controlsHtml({ filters, presets, columns, searchPlaceholder });
+  // Wired here rather than on DOMContentLoaded: the disclosure it needs does
+  // not exist until mountSidebar has run.
+  wireSidebarDisclosure(layoutEl ?? undefined);
   const searchEl = rootEl.querySelector("#table-search");
   const presetEl = rootEl.querySelector("#table-preset");
 
@@ -692,7 +813,7 @@ function createTableControls({
         // and a typed bound can never disagree about the current window.
         writeRangeInputs(filter.key, range);
         // Debounced on the SAME timer as a typed bound: a drag emits on every
-        // pointer move, and on grid.html that is 1,501 rows re-filtered and
+        // pointer move, and on driving.html that is ~3,800 rows re-filtered and
         // re-rendered per frame.
         clearTimeout(rangeTimer);
         rangeTimer = setTimeout(apply, 150);
@@ -758,7 +879,8 @@ function createTableControls({
    * Never over `filtered`: feeding a slider its own output makes the picture
    * collapse under the brush that drew it (and dragging back out cannot
    * restore bars that are no longer there). Costs one extra filter pass per
-   * histogram — three passes over ~1,500 rows on the widest page.
+   * histogram: four extra passes over grid.html's ~1,190 rows, three over
+   * driving.html's ~3,800.
    */
   function repaintHistograms() {
     for (const [key, entry] of histograms) {
@@ -870,7 +992,7 @@ function createTableControls({
   // ── DOM → state ──
   let searchTimer = null;
   searchEl.addEventListener("input", () => {
-    // Debounced: 1,501 rows re-filter and re-render on every keystroke.
+    // Debounced: ~3,800 rows re-filter and re-render on every keystroke.
     clearTimeout(searchTimer);
     searchTimer = setTimeout(() => {
       state.query = searchEl.value;
@@ -965,7 +1087,7 @@ function createTableControls({
   rootEl.addEventListener("input", (event) => {
     if (!event.target.dataset?.bound) return;
     // Debounced for the same reason the search box is: a range bound applies
-    // on every keystroke (see above), and on grid.html that is up to 1,501
+    // on every keystroke (see above), and on driving.html that is up to ~3,800
     // rows re-filtered and re-rendered per digit typed. handleControlChange
     // re-reads the input's live value when the timer fires, so only the
     // settled figure is ever applied.
@@ -1057,8 +1179,11 @@ function syncSidebarDisclosure(detailsEl, isWide) {
 }
 
 /**
- * Wire syncSidebarDisclosure to a media query. A no-op on a page with no
- * sidebar (driving.html) and in Node, so it is safe to call unconditionally.
+ * Wire syncSidebarDisclosure to a media query. A no-op before the sidebar is
+ * mounted, on a page that has none, and in Node — so it is safe to call
+ * unconditionally. createTableControls calls it once mountSidebar has built
+ * the disclosure; there is no DOMContentLoaded hook, because at that point the
+ * data has not loaded and the sidebar does not exist yet.
  *
  * @param {Document|Element} [root]
  * @param {string} [query] - Must mirror the `max-width: 900px` breakpoint in
@@ -1077,16 +1202,14 @@ function wireSidebarDisclosure(root, query = "(min-width: 901px)") {
   return mq;
 }
 
-if (typeof document !== "undefined") {
-  document.addEventListener("DOMContentLoaded", () => wireSidebarDisclosure());
-}
-
 // Node/CommonJS export shim for the unit tests. No-op in the browser, where
 // these are plain globals loaded via <script>.
 if (typeof module !== "undefined" && module.exports) {
   module.exports = {
     foldForSearch,
+    foldSearchTerms,
     matchesSearch,
+    matchesSearchTerms,
     isRangeType,
     isFilterUnset,
     rowPassesFilter,

--- a/www/js/table-utils.js
+++ b/www/js/table-utils.js
@@ -539,9 +539,8 @@ function createSortableTable({ columns, defaultSort, theadEl, tbodyEl, tieKey = 
   /**
    * Subscribe to sort changes made through the header.
    *
-   * The table controller deliberately knows nothing about the URL or the
-   * distribution strip; table-controls.js registers here to keep both in step
-   * with a header click.
+   * The table controller deliberately knows nothing about the URL;
+   * table-controls.js registers here to keep it in step with a header click.
    *
    * @param {(sort: {key: string, dir: string}) => void} fn
    */

--- a/www/streets.html
+++ b/www/streets.html
@@ -37,7 +37,7 @@
        target="_blank" rel="noopener">About &#8599;</a>
   </header>
 
-  <main class="streets-main streets-main--wide">
+  <main class="streets-main">
     <div class="page-head">
       <h1>Street-level coverage</h1>
       <p class="page-lead">
@@ -88,18 +88,13 @@
       Loading street-level collections…
     </div>
 
-    <!-- Sidebar + table (issue #250); see grid.html for the <details>
-         rationale — the two pages share one shape and one stylesheet. -->
-    <div class="table-layout with-sidebar">
-      <aside class="table-sidebar" aria-label="Search and filters">
-        <details class="sidebar-disclosure" open>
-          <summary>Filters</summary>
-          <!-- Search, filters and the column preset/picker are rendered into
-               this container by table-controls.js once the data has loaded
-               (issue #188). -->
-          <div id="streets-controls" class="controls-region"></div>
-        </details>
-      </aside>
+    <!-- Sidebar + table (issue #250); see grid.html for the `hidden` and
+         <details> rationale — all three table pages share one shape, one
+         stylesheet and one chassis-emitted sidebar. -->
+    <div class="table-layout" hidden>
+      <!-- Search, filters and the column preset/picker are rendered into this
+           container by table-controls.js once the data has loaded (#188). -->
+      <div id="streets-controls" class="controls-region"></div>
 
       <div class="table-content">
         <div id="streets-table-wrap" class="streets-table-wrap" hidden>


### PR DESCRIPTION
`driving.html` was the one table page #250 left alone, so the site ended up as **one page plus two** rather than three pages over one chassis — which is the opposite of what "configuration over a shared chassis" is supposed to buy. This gives it the same shape as `grid.html` and `streets.html`, and deletes the two alternatives it was the last caller of.

## What moved

- `.streets-main--wide` + the `.table-layout.with-sidebar` markup — a sticky ~280px filter sidebar beside the table, collapsing to a `<details>` at ≤900px.
- The compact `.page-head` / `.page-lead` with the three-paragraph explanation in a closed `.page-about` disclosure. The plan-vs-observed contradiction still has to be explained before this page's verdicts mean anything — it's now one click away rather than gone, and the table and its filters are above the fold.
- `histogram-range` on all three numeric filters. The picture does more work here than on the other two: most rows are plan areas we don't track, whose observed fields are all null, so the bars are the only thing that says how few of the ~3,800 rows a coverage window can possibly match.

## What did NOT move: the pivot

A driving row is a **place** (a tracked city, or a plan area covering none), not a city with a provider series. So no column declares a `group`, `theadHtml` still emits its flat single `<tr>`, and there are no Δ cells and no provider scope. The sidebar and the pivot were separable, and only one of them was ever about providers.

That also means driving.html is the only page whose **default** render exercises `theadHtml`'s flat-header branch, which is why that branch still has a real caller and a real browser test. It is emphatically not its only caller: the branch keys off the visible columns, so grid.html reaches it too once every grouped column is unchecked.

## Two chassis features deleted rather than kept warm

**The sorted-column distribution strip** — `renderDistributionStrip`, `formatStripSummary`, `medianOf`, `bucketCountFor`, `showDistributionStrip`, the bar-click handler and the `.strip-*` CSS.

It carried a live footgun worth naming: `histogramBuckets` took a `domain = null` default that scaled the axis to the values. That is exactly right for a strip describing the rows in view, and exactly wrong for a slider whose handles must not move under the reader's hand — the two-axes bug #250 already fixed once was one call site away the whole time. **`domain` is now required, so there is one axis rule instead of two.**

**`controlsHtml`'s `layout: "inline"` branch and the `layout` option.** An alternative layout nothing renders is one nothing tests either.

## A third deleted after review: `type: "range"`

The first cut of this PR kept the bar-less flavour warm, on the grounds that the tests making `histogram-range` trustworthy asserted it against a plain `range` **twin** in unset/pass/parse/serialize, so deleting `range` would delete the comparison pinning them as one value shape.

That argument was wrong, and wrong in a way worth recording: every one of those parity assertions dispatches through `isRangeType` **first**, so `f(hist) === f(plain)` compared a branch against itself and could not fail. The twins are replaced by typed expectations (the `min~max` wire format written out rather than compared), the shared test fixture now declares `histogram-range` like the real pages do, and the render branch, `.control-range` CSS and second `isRangeType` arm are gone.

What survives is the three per-page assertions that each numeric filter **is** a `histogram-range` — more load-bearing now than before, since a descriptor left saying `range` no longer renders two working number inputs: it falls off the end of `controlsHtml`'s type partition and renders as a **checkbox** for a `{min, max}` value.

## Tests

- **The four shared layout e2e tests are now parametrized over all three pages** — that parametrize list *is* the assertion: a page that drifts off the shape fails a test another page wrote. driving.html is the tightest case on the first-screen budget (it renders the archive-provenance callout above the layout as well as the page head), which is why it belongs in the list rather than exempted from it.
- `test_distribution_strip_survives_on_the_driving_page` → `test_driving_takes_the_sidebar_without_taking_the_pivot`. The old test's premise — the strip left two pages, not the chassis — stopped being true.
- Deleted only where the subject was: `bucketCountFor`, `medianOf`, `formatStripSummary` and the three `renderDistributionStrip` cases. The `histogramBuckets` cases were **rewritten, not dropped** — the helper survives, its axis is just the caller's now.
- Added `DRIVING_FILTERS: numeric filters are histogram sliders over real row fields`, the contract grid.js and streets.js already carried. It asserts the field exists on **both** driving row kinds, because a field present only on tracked cities would read `undefined` off every plan area without failing anything — plus each filter's `unit`/`digits`, which `histogram-slider.js` is the only reader of.
- Added `test_a_page_with_nothing_published_shows_no_empty_sidebar`, parametrized over each page and the artifact it cannot render without.

## Review round (10 findings)

A deep review of `ee40b64` found **10 findings under a fully green suite** — the same pattern as #256 and #290. All ten are addressed in `6557ad8`; the review is [here](https://github.com/jonfroehlich/streetscape-tracker/pull/281#issuecomment-5479086676).

**Correctness (gated the merge):**

1. **`DRIVING_FILTERS` lost `unit`/`digits`** in the `range` → `histogram-range` switch — an a11y regression, since `histogram-slider.js` is their only reader and it is the control that speaks to AT. Without them a thumb on the 0–12 yrs axis (0.2 steps) announces "0", "0", "1" while the column renders `0.2 yrs`, and every bucket tooltip reads "0–0: 12 rows". The old `range` renderer never read either field, so nothing caught it; the node test now pins both on all three axes rather than only `type`/`field`.
2. **"the only caller of the flat `theadHtml` branch" was false** in `CLAUDE.md`, `docs/testing.md` and the e2e docstring — see above. Reworded to "by default" in all three, because "only caller" is the line a later PR pivoting driving.html would read before deleting the branch and breaking grid/streets in a state only the advisory e2e job covers.
3. **The header click in `test_driving_takes_the_sidebar_without_taking_the_pivot` verified nothing** — it asserted the absence of `#distribution-strip`, `.strip-bar` and `td.delta-cell`, selectors nothing on driving.html can emit. The strip was what made a driving.html sort observable, so with it gone site-wide, **inert header buttons passed**. Now asserts `aria-sort` moving on and off, the `?sort=`/`&dir=` pair, and the leading row's own coverage figure reversing. The matching vacuous node test is deleted rather than repointed — its strings appear nowhere in `table-controls.js`, so it could not fail — along with its dead `global.formatCellNumber` stub.
4. **The `<aside>` rendered unconditionally**, so an empty or failed load showed a viewport-tall empty white sidebar card beside a one-line status message, and an empty landmark to AT. That is the ordinary state of driving.html before its first `fetch-driving-plan`, streets.html before the first road walk, or a transient 404. Fixed in the **chassis** for all three pages (grid.js and streets.js had the identical gap): `.table-layout` is authored `hidden` and only `createTableControls` clears it, and every empty/error path returns first.

**Cleanup, applying this PR's own "an alternative nothing renders is one nothing tests" rule consistently:**

- **`type: "range"` deleted** — see the section above.
- **The sidebar layout stopped being a modifier.** It was the only layout, but every page still had to set `.streets-main--wide` *and* `.table-layout.with-sidebar`, with a silent failure mode: a fourth page forgetting one lands on a 1200px strip layout nothing has rendered since, with `wireSidebarDisclosure` returning `null` and no error anywhere. `--wide` is folded into `.streets-main`, `.with-sidebar` is dropped from 21 selectors and both classes from the three HTMLs, and the base/override pairs the de-scoping exposed (`.table-controls`' card chrome, `.control-search input`, `.col-picker .col-panel`, three `align-self`es) are consolidated into one rule each. The `aside`/`details`/`summary` wrapper now comes from `createTableControls` instead of being hand-copied three times, so `wireSidebarDisclosure` moves off `DOMContentLoaded` to after the sidebar exists.
- **eslint**: `js/table-controls.js` no longer spreads `...tableGlobals` (its last table-utils use went to histogram-slider.js, and `no-undef` is the only thing enforcing the load order its docblock claims), and `histogramBuckets` leaves `tableControlGlobals` — no page script reads it.
- **Search perf on the site's largest table**: `applyFilters` folds the query once per pass instead of once per row, and each row's folded haystack is computed once for the life of the row model. ~76,000 NFD folds per apply on driving.html becomes ~3,800 plus one. The cache is keyed by the **field list** as well as the row, and that is asserted — ignoring it would be a wrong answer, not a slow one.
- Stale comments from the strip/layout deletion, and four **"1,501 rows"** figures that under-stated the widest page by ~2.5× (grid.html fell to ~1,190 when it pivoted; driving.html is ~3,800).
- `docs/testing.md`'s EOF-appended section duplicated three layout-test descriptions from the #250 section this PR also edits — exactly the collision shape `CLAUDE.md`'s "add to the section it belongs to" rule forbids. Now a `###` subsection under #250.

**One finding not taken as written:** the review also proposed deleting the three per-page `type: "histogram-range"` guards along with `range`. Kept, and their comments now say why — with `range` gone, a stale `range` descriptor renders a *checkbox*, so those guards got more load-bearing, not less.

## Verification

All four CI gates run clean locally: `eslint` clean, **386/386** node unit tests, **1695/1695** `pytest`, **59/59** Playwright e2e, `ruff check` + `ruff format --check` clean. QA'd by hand in a browser against the live published data.

Both halves of finding 4's fix were confirmed to fail on their own: an unrendered layout has no content, so it collapses to zero height and Playwright's `to_be_hidden()` passes either way — and `display: grid` is an author declaration that beats the UA stylesheet's `[hidden]` rule unless `.table-layout[hidden]` says otherwise. The new test asserts the attribute and the computed `display` separately.

Docs updated in both places per the router rule: `CLAUDE.md`, `docs/frontend.md` (new section: *All three table pages share one layout, and the alternatives are deleted*) and `docs/testing.md` (new section recording what each test now pins, and which deletions took their subject with them).

🤖 Generated with [Claude Code](https://claude.com/claude-code) — Opus 5 (1M context), claude-opus-5[1m]

Review by Fable 5 (`claude-fable-5`, effort: high); review fixes by Opus 5 (1M context) (`claude-opus-5[1m]`).

