### PR TITLE
Turn the kartaview channel on in the production config (#248)

### DIFF
--- a/config/scheduler.makelab1.toml
+++ b/config/scheduler.makelab1.toml
@@ -135,6 +135,34 @@ spacing_m = 15
 # See [providers.mapillary] — one per-IP rate budget, two channels.
 max_requests_per_minute = 60
 
+# KartaView (issue #248) — the one OPT-IN channel. Declaring this block enrolls
+# NOBODY: the nightly queue is exactly the cities an operator ran
+# `scheduler enroll-city CITY --channel kartaview` on, because a whole-catalog
+# pass prices at ~186,000 requests ~= 186 h. Seed set on this host is Krabi and
+# Yogyakarta. To see who is enrolled: `scheduler enroll-city --list`.
+#
+# daily_request_budget is a FLOOR to clear, NOT a ceiling on the night's spend
+# (#273/#274): the guard is a pre-flight check against an ESTIMATE, and the child
+# is handed no request cap, so a city that calibrates to r=500 can overspend this
+# figure with only the per-city wall-clock timeout to stop it. 10,000 clears the
+# largest city the cost study measured (Singapore, ~9,974); both seed cities are
+# far under it. Widen only after #273 — and re-check this floor before enrolling
+# any metro, since a city whose estimate exceeds it is skipped *permanently*.
+#
+# max_requests_per_minute is load-bearing beyond pacing: _kartaview_timeout_seconds
+# derives every sweep's per-city timeout from this rate, so lowering it here
+# silently shortens those timeouts too. 16/min = 960/h, under the 1,000/h
+# authenticated ceiling. Requires KARTAVIEW_ACCESS_TOKEN in .env — anonymous is
+# 100 req/h, which is not a slower channel, it is no channel.
+#
+# This is the FIFTH channel, so the effective max_concurrent_channels ceiling is
+# 4 of 5 (kartaview.org is a per-IP host shared with nothing). Moot at the knob's
+# current value of 1. See config/scheduler.toml for the full field docs.
+[providers.kartaview]
+enabled = true
+daily_request_budget = 10000
+max_requests_per_minute = 16
+
 [download]
 batch_size = 100
 connection_limit = 50

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -976,11 +976,29 @@ def test_makelab1_production_config_is_wired():
     # scheduler.toml alone changes nothing in production — the two must be kept
     # in step deliberately, which is what this assertion is for.
     cfg = load_scheduler_config(os.path.join(_PROJECT_ROOT, "config", "scheduler.makelab1.toml"))
-    assert cfg.enabled_providers() == ["gsv", "gsv_streets", "mapillary", "mapillary_streets"]
-    # kartaview is deliberately NOT here. The repo default declares it (#248),
-    # and turning it on in production is a separate deploy decision — the same
-    # posture as max_concurrent_channels below.
-    assert "kartaview" not in cfg.providers
+    # Order is canonical, not alphabetical: most expensive first, EXCEPT kartaview,
+    # which ranks LAST because a multi-hour sweep absorbs deadline truncation most
+    # cheaply (#238). Asserting the list therefore pins the launch order too.
+    assert cfg.enabled_providers() == [
+        "gsv",
+        "gsv_streets",
+        "mapillary",
+        "mapillary_streets",
+        "kartaview",
+    ]
+    # kartaview was turned on in production on 2026-08-28, the separate deploy
+    # decision this assertion previously withheld (#248). Enabling the CHANNEL
+    # enrols nobody: it is the one opt-in channel, so the nightly queue is exactly
+    # the cities `scheduler enroll-city` names, and the seed set is deliberately
+    # two (Krabi, Yogyakarta) because a whole-catalog pass is ~186,000 requests.
+    # The budget is a FLOOR to clear rather than a ceiling on the night's spend
+    # (#273/#274) — a city whose estimate exceeds it is skipped permanently — so
+    # this figure is pinned exactly, like the Mapillary ones below, and re-checked
+    # before any metro is enrolled.
+    assert cfg.providers["kartaview"].daily_request_budget == 10_000
+    # Load-bearing beyond pacing: _kartaview_timeout_seconds derives every sweep's
+    # per-city timeout from this rate, so lowering it shortens those timeouts too.
+    assert cfg.providers["kartaview"].max_requests_per_minute == 16
     # Channel concurrency is OFF in production until both of #240's deploy gates
     # clear: resume for the Mapillary tile census (#256), because a stop now kills
     # N children at once and a killed census re-spends tiles into a per-IP ceiling


### PR DESCRIPTION
The deploy-side half of #248. The dueness mechanism (#279) and the repo default (#280) are both merged, but production reads `config/scheduler.makelab1.toml` — so on makelab2 nothing changed: tonight's batch still logs only the four old channels, the catalog is still schema v12, and `runs` has never held a KartaView row.

This declares `[providers.kartaview]` in the file production actually loads.

### Declaring the channel enrols nobody
`kartaview` is the one **opt-in** channel, so its nightly queue is exactly the cities an operator ran `scheduler enroll-city` on. A whole-catalog pass prices at ~186,000 requests ≈ 186 h, which is why it works this way. The seed set is Krabi and Yogyakarta, enrolled as a separate post-merge step.

### Values
Both are the vetted repo defaults from #280:

| Key | Value | Why |
|---|---|---|
| `daily_request_budget` | 10,000 | A **floor to clear**, not a ceiling on the night's spend (#273/#274) — the guard is a pre-flight check against an estimate, and the child is handed no request cap. Clears the largest city the cost study measured (Singapore, ~9,974); both seed cities are far under. A city whose estimate exceeds it is skipped *permanently*, so this gets re-checked before any metro is enrolled. |
| `max_requests_per_minute` | 16 | 960/h, under the 1,000/h authenticated ceiling. Load-bearing beyond pacing: `_kartaview_timeout_seconds` derives every sweep's per-city timeout from this rate. |

### The pinning test
`test_makelab1_production_config_is_wired` asserted `"kartaview" not in cfg.providers` **on purpose** — enabling it in production was meant to require a deliberate edit to that test and this config together. So it is updated rather than relaxed, and now also pins the two budget values the same way the Mapillary ones are pinned.

Its channel list turned out to be canonical order — most expensive first, *except* kartaview last (#238, a multi-hour sweep absorbs deadline truncation most cheaply) — not alphabetical. The assertion therefore pins launch order too, which is worth keeping.

### Not in this PR
- `KARTAVIEW_ACCESS_TOKEN` in prod `.env` (required — anonymous is 100 req/h, which is no channel).
- `git pull` on makelab2, which also migrates the catalog to v13.
- `enroll-city` for the two seed cities.

Deliberately sequenced **after** tonight's batch drains: the scheduler spawns a child per city and the catalog auto-migrates on connect, so pulling mid-run would migrate to v13 underneath a parent still running v12 code.

### Testing
`1725 passed, 1 skipped`; `ruff check` and `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code) — Opus 5 (1M context), claude-opus-5[1m]