### PR TITLE
Key the CARTO basemap so tiles stop rendering watermarked

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -205,6 +205,8 @@ The raw feed archive lives outside `data/` (mirroring a vendor's file is not our
 **Web frontend → [`docs/frontend.md`](docs/frontend.md).**
 Static vanilla JS + Leaflet + Chart.js 4 in `www/`, no build step, fetching the published `data/`.
 `www/js/streetscape-utils.js` holds the provider registry and `adaptCityRecord`, which flattens v1/v2/v3 aggregate records into one normalized shape.
+It also holds `addBasemapLayer` and the CARTO key, which is **the one place a tile URL is built** — because CARTO enforces its key by watermarking the tile rather than by refusing the request: a keyless request, a wrong key and the right key under the wrong parameter name all return HTTP 200 and a byte-identical PNG stamped "API KEY REQUIRED", so no error handling anywhere can see it and a duplicated call site renders perfectly, watermarked.
+The key is bearer-style (the issuing domain is measurably not enforced), so exposure is unavoidable but abuse is not; the detection path is `tests/e2e/test_basemap_key.py`, which compares a keyed tile against a keyless one by bytes.
 `grid.html`/`streets.html`/`driving.html` are configuration over one shared table chassis with **no pagination or virtualization** (a new page's row count is a design constraint), and `createTableControls` (`www/js/table-controls.js`) **owns the whole query string** — two instances on one page fight over it, which is why `driving.html` renders unmatched plan areas as a summary rather than a second filtered table.
 `grid.html` and `streets.html` are pivoted to **one row per city**, providers as sub-columns (#250), so "Collected by" is a **scope, not just a row filter** — it redirects what the numeric filters read, or "coverage over 80%" silently means "some provider's".
 Anything fanning out over the provider registry must gate on presence in the payload — a registered provider is not a collected one.
@@ -228,6 +230,7 @@ Keep any list a doc enumerates **alphabetical**, so two branches adding an entry
   Existing writeups — keep this list alphabetical, and answer "should we sample finer or differently?" from them before re-running anything:
 
   - `capture-date-precision.md`
+  - `carto-basemap-key.md`
   - `grid-density.md`
   - `kartaview-feasibility.md`
   - `kartaview-sweep-cost.md`

--- a/docs/experiments/README.md
+++ b/docs/experiments/README.md
@@ -26,6 +26,15 @@ Three things generalize.
 **(3) The sweep's denominator is the corpus; the repair's is the catalog, and they differ** — 9 files on disk carry month precision against 8 registered runs, the extra being an unregistered orphan (`saskatoon_sk_…`, superseded by the registered `saskatoon--sk_…` that carries day precision), which no catalog audit and no repair script can see.
 Also worth knowing before trusting a format census: 77% of all `capture_date` cells in the corpus are ABSENT (ZERO_RESULTS fill), so a share taken over rows rather than over dated rows describes the grid, not the imagery.
 
+### `carto-basemap-key.md`
+
+Issue #284 — how CARTO enforces its basemap key, and what leaving raster for vector would cost.
+Both answers are counter-intuitive enough to be worth the minutes.
+**CARTO enforces by watermarking the tile, not by refusing the request**: a keyless request, a well-formed wrong key, and the right key under the wrong parameter name all return HTTP 200 with a byte-identical PNG stamped "API KEY REQUIRED", so no client-side error handling can detect it and the break presents as a styling bug.
+That is why the detection path is differential (keyed bytes vs keyless bytes) rather than a pinned hash, and why the key had to be verified against our own URL form rather than the one CARTO documents.
+**The domain CARTO collects at issue time is not enforced** — issued origin, foreign origin and no `Referer` return identical bytes — so the key is bearer-style, which separates unavoidable *exposure* from mitigable *abuse* and makes "same as any Mapbox client key" the wrong analogy.
+**Vector is not a way off the key** (same key, same 5M/month ceiling), so it is purely a rendering-stack decision: maplibre-gl is 6.19x Leaflet's gzipped weight, plus a WebGL flake class and no basemap at all where WebGL is unavailable. Decision: stay on raster.
+
 ### `grid-density.md`
 
 Issue #106 — why production stays on the 20 m grid; below ~10 m you buy redundancy, not information, since official panos sit ~10 m apart.

--- a/docs/experiments/carto-basemap-key.md
+++ b/docs/experiments/carto-basemap-key.md
@@ -1,0 +1,101 @@
+# CARTO's basemap key: how it is enforced, and what leaving raster would cost
+
+Issue #284.
+Two questions measured on 2026-08-28, both cheap, both with answers that are easy to get wrong from the documentation alone.
+
+Numbers here come from [`carto-basemap-key_metrics.json`](carto-basemap-key_metrics.json), produced by `scripts/measure_carto_basemap.py --out-dir docs/experiments`.
+It sends the site's public basemap key to CARTO — the same key the deployed page sends on every tile request — and fetches two libraries from cdnjs.
+No imagery provider, no credentials, no catalog; about a dozen requests.
+There is no distribution to quote: both questions are deterministic, so what follows is a response matrix rather than percentiles, and the replication is re-running the one command.
+
+## 1. CARTO enforces the key by watermarking the tile, not by refusing the request
+
+Every way of getting the key wrong returns HTTP 200 and `image/png`, on our own URL form (`dark_all` shorthand, `{s}` subdomains, `{r}` retina), tile `12/655/1583`:
+
+| Request | Status | Bytes | SHA-256 (first 16) |
+|---|---|---|---|
+| `?key=<our key>` | 200 | 16,945 | `d36c88d307ff56ad` |
+| no query string at all | 200 | 15,516 | `cb4906d807d177ca` |
+| `?key=<well-formed but wrong>` | 200 | 15,516 | `cb4906d807d177ca` |
+| `?api_key=<our key>` | 200 | 15,516 | `cb4906d807d177ca` |
+
+**The three failure modes are byte-identical to each other.**
+A missing key, a wrong key and the right key under the wrong parameter name are literally the same response — a valid PNG with `API KEY REQUIRED / carto.com/basemaps/apikey` printed diagonally across the map.
+
+Three things follow, and they are the reason this is written down.
+
+**(1) No client-side error handling can ever detect this.**
+There is no failed request, no non-2xx, no `errorTileUrl` path, no console warning.
+The browser receives a perfectly good image and draws it.
+The site rendered watermarked for an unknown period before a human happened to say the maps looked odd, and it presented as a styling bug rather than an outage — which is the wrong first hypothesis, and cost time.
+
+**(2) The parameter name is load-bearing and unguessable from the docs.**
+CARTO's own documentation shows the `rastertiles/voyager/{z}/{x}/{y}.png` path; we use the `dark_all` shorthand.
+`api_key` is the plausible spelling and it silently fails.
+So the key had to be verified against **our** URL form rather than the documented one, and any future change to that URL has to be re-verified the same way.
+
+**(3) A detection path has to compare bytes.**
+`tests/e2e/test_basemap_key.py` fetches the same tile with and without the key and requires the two to differ.
+Differential rather than a pinned watermark hash, so it survives CARTO restyling the notice; it goes red for a revoked key, an exhausted quota and a dropped parameter alike.
+Pinning `d36c88d3…` instead would go red every time CARTO edits the cartography, which they do continuously.
+
+## 2. The domain CARTO collects at issue time is not enforced
+
+CARTO asks for a domain when issuing the key. Sending the key with three different `Referer` headers:
+
+| `Referer` | Status | Bytes | Same bytes as the issued origin? |
+|---|---|---|---|
+| the domain the key was issued for | 200 | 16,945 | — |
+| a domain it was not issued for | 200 | 16,945 | yes |
+| no `Referer` header at all | 200 | 16,945 | yes |
+
+All three are identical, so **the key is bearer-style: it works from anywhere.**
+
+This is the finding that changes what to do, because it separates two things that get conflated.
+*Exposure* is unavoidable and not worth arguing about — the browser sends the key to CARTO on every tile request, so it is readable off the deployed page wherever the repo keeps it, and there is no build step to inject it at (ADR 0001).
+*Abuse* is a different question, and it is mitigable.
+The usual protection for a public map key is exactly this origin lock — it is what makes a Mapbox or Google Maps JS key safe to publish — and here it is absent.
+So the comparison "same as any Mapbox / Google client key" does not hold, a copy lifted from this public repo works anywhere, and the free ceiling of 5M tile requests per calendar month is shared with whoever takes it.
+Exhausting that ceiling degrades to the same silent watermark as having no key.
+
+**The action is to ask CARTO to enforce the domain they already collected**, not to try to hide the key.
+Until then the ceiling is the exposure, and `tests/e2e/test_basemap_key.py` is how we would find out.
+
+## 3. Leaving raster for vector is a rendering-stack decision, not a way off the key
+
+Worth stating plainly because it is the intuitive escape hatch and it is not one: CARTO's key page counts the free tier across the raster **and** vector services, and CARTO says the vector key requirement is coming, just not live yet.
+So switching does not remove the key, the ceiling, or anything above.
+
+What it does cost is the renderer.
+Leaflet cannot draw MVT at all, so vector means replacing it with maplibre-gl.
+Gzipped transfer size off cdnjs, both halves each library needs to draw a map:
+
+| Library | Script | Stylesheet | Total gzipped |
+|---|---|---|---|
+| Leaflet 1.9.4 | 42,605 B | 3,526 B | **46,131 B** |
+| maplibre-gl 5.24.0 | 275,453 B | 10,090 B | **285,543 B** |
+
+**6.19× the bytes**, and that is the floor rather than the estimate: it excludes `@maplibre/maplibre-gl-leaflet`, which is not on cdnjs at all and would pull in a second CDN origin — and a cdnjs asset is already one of the two known e2e flakes.
+
+Two costs that are not bytes and matter more:
+
+- **WebGL in a headless screenshot suite is a new flake class**, on a job that already carries two.
+- **Where WebGL is unavailable there is no basemap at all**, where raster simply works.
+
+Set against that, CARTO has announced no raster end date.
+Their FAQ says they are *"considering stopping data updates to the raster basemaps, in which case raster cartography will stay where it is and the gap will widen over time"* (read 2026-08-28).
+That is materially weaker than a deprecation date, and the distinction is worth preserving: "stated retirement path" would have someone budgeting a migration against a deadline that does not exist.
+
+**Decision: stay on raster.**
+Revisit when CARTO announces an actual end date, or if the dense-city rendering path is ever reworked — MapLibre renders on the GPU, which is what `RENDER_CAP` and the `preferCanvas` subsampling exist to work around (#77 / #58), so that is the one change that would make the 6.19× buy something.
+That is a project, not a maintenance chore, and it should be decided on rendering grounds rather than on key grounds.
+
+## Caveats
+
+- **Both answers are properties of CARTO's service on 2026-08-28, not invariants.**
+  The `Referer` result in particular could change without notice, and would change silently in the safe direction (our own requests carry the issued origin) — so a future re-run is the only way to learn it.
+- **The byte counts are one tile.**
+  Tile size varies with content; the comparison is only ever between requests for the *same* tile, which is why the test is differential and never a threshold.
+- **The bundle sizes are cdnjs's current latest.**
+  They move with each release. The ratio is the durable number, not the absolute bytes.
+- **`wrong_key_value` mutates the tail of the real key** rather than using an unrelated string, so it tests a well-formed key that is not ours — the realistic rotation-gone-wrong case, not a malformed input.

--- a/docs/experiments/carto-basemap-key_metrics.json
+++ b/docs/experiments/carto-basemap-key_metrics.json
@@ -1,0 +1,122 @@
+{
+  "_about": {
+    "experiment": "carto-basemap-key",
+    "writeup": "docs/experiments/carto-basemap-key.md",
+    "generated_by": "scripts/measure_carto_basemap.py --out-dir docs/experiments",
+    "note": "CARTO began requiring an API key on basemaps.cartocdn.com (2026-08-28) and enforces it by watermarking the tile, not by returning an error, so every way of getting the key wrong is HTTP 200. `key_enforcement` compares each wrong variant against the keyed request BY DIGEST because a status code cannot tell them apart. `referer_enforcement` tests whether the domain CARTO collects when issuing a key is enforced. `renderer_bundles` is gzipped transfer size off cdnjs, sizing the raster-vs-vector decision -- vector needs the same key, so the only thing switching buys or costs is the rendering stack. The key itself is not recorded here; it lives in www/js/streetscape-utils.js."
+  },
+  "tile": "https://a.basemaps.cartocdn.com/dark_all/12/655/1583.png",
+  "key_enforcement": {
+    "keyed": {
+      "status": 200,
+      "bytes": 16945,
+      "sha256": "d36c88d307ff56ad0fb2a05137adebe5176be6f8e1d83c5037cf12ddd92ece99",
+      "content_type": "image/png",
+      "content_encoding": null,
+      "differs_from_keyed": false
+    },
+    "keyless": {
+      "status": 200,
+      "bytes": 15516,
+      "sha256": "cb4906d807d177ca6a4d40eebef42e8404498ad55c4b2b76cd7b9fd72c6569c4",
+      "content_type": "image/png",
+      "content_encoding": null,
+      "differs_from_keyed": true
+    },
+    "wrong_key_value": {
+      "status": 200,
+      "bytes": 15516,
+      "sha256": "cb4906d807d177ca6a4d40eebef42e8404498ad55c4b2b76cd7b9fd72c6569c4",
+      "content_type": "image/png",
+      "content_encoding": null,
+      "differs_from_keyed": true
+    },
+    "wrong_param_name": {
+      "status": 200,
+      "bytes": 15516,
+      "sha256": "cb4906d807d177ca6a4d40eebef42e8404498ad55c4b2b76cd7b9fd72c6569c4",
+      "content_type": "image/png",
+      "content_encoding": null,
+      "differs_from_keyed": true
+    }
+  },
+  "referer_enforcement": {
+    "issued_origin": {
+      "status": 200,
+      "bytes": 16945,
+      "sha256": "d36c88d307ff56ad0fb2a05137adebe5176be6f8e1d83c5037cf12ddd92ece99",
+      "content_type": "image/png",
+      "content_encoding": null,
+      "matches_issued_origin": true
+    },
+    "foreign_origin": {
+      "status": 200,
+      "bytes": 16945,
+      "sha256": "d36c88d307ff56ad0fb2a05137adebe5176be6f8e1d83c5037cf12ddd92ece99",
+      "content_type": "image/png",
+      "content_encoding": null,
+      "matches_issued_origin": true
+    },
+    "no_referer": {
+      "status": 200,
+      "bytes": 16945,
+      "sha256": "d36c88d307ff56ad0fb2a05137adebe5176be6f8e1d83c5037cf12ddd92ece99",
+      "content_type": "image/png",
+      "content_encoding": null,
+      "matches_issued_origin": true
+    }
+  },
+  "renderer_bundles": {
+    "leaflet": {
+      "assets": {
+        "leaflet.js": {
+          "status": 200,
+          "bytes": 42605,
+          "sha256": "4f9145e426ef2d94a3dea38346b010c13c2b54f3f0d09b5a12da5d3d39787069",
+          "content_type": "application/javascript; charset=utf-8",
+          "content_encoding": "gzip",
+          "url": "https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/leaflet.js"
+        },
+        "leaflet.css": {
+          "status": 200,
+          "bytes": 3526,
+          "sha256": "2a27dd90533ce37f43c8e9f6adbba93605a930801044c079309f5f468a69d31d",
+          "content_type": "text/css; charset=utf-8",
+          "content_encoding": "gzip",
+          "url": "https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/leaflet.css"
+        }
+      },
+      "total_gzipped_bytes": 46131
+    },
+    "maplibre-gl": {
+      "assets": {
+        "maplibre-gl.js": {
+          "status": 200,
+          "bytes": 275453,
+          "sha256": "ad5c44986f2210461e5942ff8d20baae41fe43330d68702c0d8852d327ea2d5e",
+          "content_type": "application/javascript; charset=utf-8",
+          "content_encoding": "gzip",
+          "url": "https://cdnjs.cloudflare.com/ajax/libs/maplibre-gl/5.24.0/maplibre-gl.js"
+        },
+        "maplibre-gl.css": {
+          "status": 200,
+          "bytes": 10090,
+          "sha256": "007683310140a1cc4a90ffefd661142f06618a502ea1c8cd919061ab53c0d613",
+          "content_type": "text/css; charset=utf-8",
+          "content_encoding": "gzip",
+          "url": "https://cdnjs.cloudflare.com/ajax/libs/maplibre-gl/5.24.0/maplibre-gl.css"
+        }
+      },
+      "total_gzipped_bytes": 285543
+    }
+  },
+  "summary": {
+    "wrong_is_indistinguishable_from_absent": true,
+    "keyed_differs_from_keyless": true,
+    "every_failure_mode_returns_200": true,
+    "referer_enforced": false,
+    "leaflet_gzipped_bytes": 46131,
+    "maplibre_gl_gzipped_bytes": 285543,
+    "maplibre_over_leaflet_ratio": 6.19
+  }
+}

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -154,3 +154,31 @@ All four keys are **indexed, not `.get()`-guarded**, matching the `search_area_k
 Guarding would also publish `{width: null, height: null, step: null}` — a *truthy* all-null block that no `if (rec.grid)` consumer can reject, the exact failure the absent-not-null convention exists to prevent.
 It is the **latest run's** grid, not the city's current frozen geometry: the two diverge for cities resized catalog-only by `scripts/cap_oversized_grids.py` (#166) until their next collection, and pairing the run's denominator with the run's geometry is the correct half — label it as the run's grid in any UI.
 `adaptCityRecord` surfaces both normalized (null on v1/v2 records, which will never carry them).
+## The basemap needs a CARTO key, and a bad key looks like a styling bug
+
+*Written after the split.*
+
+**The basemap needs a CARTO key, and every way of getting that key wrong is invisible.**
+CARTO began requiring an API key on `basemaps.cartocdn.com` on 2026-08-28, and the enforcement is not an error response:
+a keyless request returns HTTP 200 and `image/png`, with `API KEY REQUIRED / carto.com/basemaps/apikey` printed diagonally across the tile itself.
+Measured the same day, on our own URL form: keyless, a well-formed but wrong key, and the right key under the wrong parameter name (`api_key=` rather than `key=`) all returned the **byte-identical** watermarked tile, and only `?key=<our key>` returned a different one.
+So there is no fetch handling, no `errorTileUrl`, and no console warning that could ever have caught it — it reaches a reader as a map that looks oddly branded, and it reached ours for an unknown period before anyone said so.
+**If the maps ever look wrong again, check this first**, and check it with bytes rather than with a status code.
+
+`addBasemapLayer(map)` in `streetscape-utils.js` is the only place the tile URL is built; `index.js` and `city.js` call it and `www/js/__tests__/streetscape-utils.test.js` pins that neither of them contains an `L.tileLayer(` of its own.
+That pin is the point rather than tidiness: the two call sites were byte-identical duplicates, and a reintroduced duplicate renders perfectly well — watermarked.
+The generated boundary-review viewer (`scripts/boundary_review.template.html`) is a third CARTO map that cannot load the module, so `build_boundary_review.py` reads `CARTO_BASEMAP_KEY` out of the JS and substitutes it, raising if the const or the placeholder has gone.
+A watermark there is not cosmetic either — that tool exists to judge a city boundary by eye.
+
+**The key is public by construction and bearer-style, which are two different facts.**
+Public by construction: the browser sends it to CARTO on every tile request, so it is readable off the deployed page wherever the repo keeps it, and there is no build step to inject it at ([ADR 0001](adr/0001-no-backend.md)).
+Bearer-style: CARTO asks for a domain when issuing the key but does **not** enforce it — a tile request with a mismatched `Referer` and one with no `Referer` at all returned byte-identical keyed tiles — so unlike a conventionally domain-locked Mapbox or Google JS key, a copy scraped out of this public repo works anywhere.
+That is the part worth acting on: exposure is unavoidable, abuse is not, and the ask is for CARTO to enforce the domain they already collected.
+The free ceiling is 5M tile requests per calendar month across the raster **and** vector services, conditioned on crediting CARTO and OpenStreetMap — which is why `addBasemapLayer` sets the attribution, and why exhausting the ceiling degrades to the same silent watermark.
+Rotation is a reply to the issuing email plus editing the one const.
+
+**The detection path is `tests/e2e/test_basemap_key.py`**, marked `e2e` so it stays out of the fast no-network suite.
+It fetches one tile with the key and the same tile without, and requires the bytes to differ.
+Differential rather than a pinned watermark hash, so it survives CARTO restyling the notice, and it goes red for a revoked key, an exhausted quota, and a dropped or misspelled parameter alike.
+It also goes red if CARTO ever stops watermarking keyless requests, which is a false alarm worth having: the constraint this mechanism exists for would have changed.
+Whether to leave raster for vector is a separate, larger question — vector needs the same key, and Leaflet cannot draw MVT at all — and is worked through in [`experiments/carto-basemap-key.md`](experiments/carto-basemap-key.md).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,5 +46,5 @@ testpaths = ["tests"]
 # + a Chromium install and are intentionally kept out of the pure-logic suite.
 addopts = "-q -m 'not e2e'"
 markers = [
-  "e2e: browser end-to-end smoke tests (require pytest-playwright + chromium)",
+  "e2e: end-to-end tests that need the network - the browser smoke suite (pytest-playwright + chromium) and live third-party checks",
 ]

--- a/scripts/boundary_review.template.html
+++ b/scripts/boundary_review.template.html
@@ -298,8 +298,14 @@
 
     // ---- map + base layers ----
     const map = L.map("map", { zoomControl: true }).setView([20, 0], 2);
+    // The key is substituted by build_boundary_review.py out of
+    // www/js/streetscape-utils.js, so this page shares the site's one copy
+    // rather than carrying a second that could drift. Without a valid key
+    // CARTO returns HTTP 200 with "API KEY REQUIRED" printed across every
+    // tile, which on a tool for judging boundaries by eye is not cosmetic.
     const voyager = L.tileLayer(
-      "https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{r}.png",
+      "https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{r}.png"
+        + "?key=__CARTO_KEY__",
       { maxZoom: 19, attribution: "© OpenStreetMap contributors © CARTO" }).addTo(map);
     const satellite = L.tileLayer(
       "https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}",

--- a/scripts/build_boundary_review.py
+++ b/scripts/build_boundary_review.py
@@ -38,7 +38,9 @@ import csv
 import json
 import logging
 import os
+import re
 import sys
+from urllib.parse import quote
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
@@ -56,6 +58,15 @@ DEFAULT_AUDIT_DIR = os.path.join(_PROJECT_ROOT, "audit")
 TEMPLATE_PATH = os.path.join(_PROJECT_ROOT, "scripts", "boundary_review.template.html")
 DATA_PLACEHOLDER = "/*__DATA__*/"
 META_PLACEHOLDER = "/*__META__*/"
+CARTO_KEY_PLACEHOLDER = "__CARTO_KEY__"
+
+# The CARTO basemap key lives in exactly one place, the frontend module that
+# also serves it to the public site. This viewer is generated HTML that
+# cannot load that module, so the key is read out of it here rather than
+# pasted into the template -- a second copy is how one map silently keeps
+# rendering CARTO's "API KEY REQUIRED" watermark after the other is fixed.
+BASEMAP_KEY_SOURCE = os.path.join(_PROJECT_ROOT, "www", "js", "streetscape-utils.js")
+_CARTO_KEY_RE = re.compile(r'CARTO_BASEMAP_KEY\s*=\s*"([^"]+)"')
 
 # Coordinate precision for embedded polygons: ~1 m at the equator, small file.
 _COORD_DECIMALS = 5
@@ -416,6 +427,21 @@ def _json_for_script(obj) -> str:
     return json.dumps(obj, separators=(",", ":"), allow_nan=False).replace("</", "<\\/")
 
 
+def carto_basemap_key(source_path: str = BASEMAP_KEY_SOURCE) -> str:
+    """Read the CARTO basemap key out of the frontend module that owns it.
+
+    Raises rather than degrading: a missing or renamed const would otherwise
+    leave the viewer requesting tiles with a literal placeholder for a key,
+    and CARTO answers a bad key with HTTP 200 and a watermarked tile, so the
+    failure would reach a reviewer as a cosmetic oddity instead of an error.
+    """
+    with open(source_path, encoding="utf-8") as f:
+        match = _CARTO_KEY_RE.search(f.read())
+    if not match:
+        raise ValueError(f"no CARTO_BASEMAP_KEY const found in {source_path}")
+    return match.group(1)
+
+
 def render_html(
     payloads: list, template_path: str = TEMPLATE_PATH, meta: dict | None = None
 ) -> str:
@@ -424,7 +450,10 @@ def render_html(
         template = f.read()
     if DATA_PLACEHOLDER not in template:
         raise ValueError(f"template missing {DATA_PLACEHOLDER!r} placeholder")
+    if CARTO_KEY_PLACEHOLDER not in template:
+        raise ValueError(f"template missing {CARTO_KEY_PLACEHOLDER!r} placeholder")
     html = template.replace(DATA_PLACEHOLDER, _json_for_script(payloads))
+    html = html.replace(CARTO_KEY_PLACEHOLDER, quote(carto_basemap_key(), safe=""))
     if META_PLACEHOLDER in html:
         html = html.replace(META_PLACEHOLDER, _json_for_script(meta or {}))
     return html

--- a/scripts/measure_carto_basemap.py
+++ b/scripts/measure_carto_basemap.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+"""
+Measure CARTO's basemap key enforcement and the cost of leaving raster (#284).
+
+Two questions, both answered by a handful of HTTP requests, and both worth
+committing because the answers are counter-intuitive enough that the next
+person will otherwise re-measure them:
+
+  1. **How does CARTO enforce the key?**  Not with a status code. A keyless
+     request, a well-formed but wrong key, and the right key under the wrong
+     parameter name all return HTTP 200 ``image/png`` with "API KEY REQUIRED"
+     printed across the tile. This script records the status, the byte count
+     and the SHA-256 of each variant, so "wrong is byte-identical to absent"
+     is a recorded measurement rather than a claim. It also records whether
+     the ``Referer`` CARTO collects when issuing the key is enforced.
+
+  2. **What would moving to vector cost?**  Vector needs the same key, so it
+     is a rendering-stack decision, not a way off the key. The measurable part
+     of that decision is bundle weight: Leaflet cannot draw MVT at all, so
+     vector means maplibre-gl. This fetches both libraries from cdnjs with
+     ``Accept-Encoding: gzip`` and records what the browser would actually
+     transfer.
+
+Writes ``docs/experiments/carto-basemap-key_metrics.json``, which
+``docs/experiments/carto-basemap-key.md`` quotes.
+
+**Sends the site's public basemap key to CARTO** -- the same key the deployed
+page sends on every tile request -- and nothing else. Makes no calls to any
+imagery provider (GSV / Mapillary / KartaView), touches no credentials, and
+does not read or write the catalog. About a dozen requests in total.
+
+Usage:
+    python scripts/measure_carto_basemap.py
+    python scripts/measure_carto_basemap.py --out-dir docs/experiments
+    python scripts/measure_carto_basemap.py --dry-run     # print, write nothing
+"""
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+
+_PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+DEFAULT_OUT_DIR = os.path.join(_PROJECT_ROOT, "docs", "experiments")
+EXPERIMENT = "carto-basemap-key"
+
+# The key lives in exactly one place; this reads it rather than carrying a
+# second copy (see docs/frontend.md).
+BASEMAP_KEY_SOURCE = os.path.join(_PROJECT_ROOT, "www", "js", "streetscape-utils.js")
+_CARTO_KEY_RE = re.compile(r'CARTO_BASEMAP_KEY\s*=\s*"([^"]+)"')
+
+# One stable tile with real content on it (San Francisco, z12). An all-water
+# tile would be near-identical with and without a watermark, which would make
+# the byte comparison meaningless.
+TILE = "https://a.basemaps.cartocdn.com/dark_all/12/655/1583.png"
+
+# The domain the key was issued against, plus a domain it was not. If the two
+# return the same bytes, the key is bearer-style rather than origin-locked.
+ISSUED_ORIGIN = "https://makeabilitylab.cs.washington.edu/"
+FOREIGN_ORIGIN = "https://example.invalid/"
+
+# The two renderers the raster-vs-vector decision is actually between. Both
+# halves (script + stylesheet) count: a map needs each to draw.
+BUNDLES = {
+    "leaflet": [
+        "https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/leaflet.js",
+        "https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/leaflet.css",
+    ],
+    "maplibre-gl": [
+        "https://cdnjs.cloudflare.com/ajax/libs/maplibre-gl/5.24.0/maplibre-gl.js",
+        "https://cdnjs.cloudflare.com/ajax/libs/maplibre-gl/5.24.0/maplibre-gl.css",
+    ],
+}
+
+TIMEOUT_S = 60
+USER_AGENT = "streetscape-tracker-measurement"
+
+
+def carto_basemap_key(source_path: str = BASEMAP_KEY_SOURCE) -> str:
+    """Read the site's CARTO key out of the frontend module that owns it."""
+    with open(source_path, encoding="utf-8") as f:
+        match = _CARTO_KEY_RE.search(f.read())
+    if not match:
+        raise ValueError(f"no CARTO_BASEMAP_KEY const found in {source_path}")
+    return match.group(1)
+
+
+def fetch(url: str, headers: dict | None = None) -> dict:
+    """GET a URL and describe the response by size and digest, never by content.
+
+    The digest is the whole point: the watermark is inside a valid PNG, so
+    "did this request work?" can only be answered by comparing bytes against
+    a request we know did not.
+    """
+    request = urllib.request.Request(url, headers={"User-Agent": USER_AGENT, **(headers or {})})
+    try:
+        with urllib.request.urlopen(request, timeout=TIMEOUT_S) as response:
+            body = response.read()
+            status = response.status
+            content_type = response.headers.get("Content-Type")
+            encoding = response.headers.get("Content-Encoding")
+    except urllib.error.HTTPError as exc:
+        body, status = exc.read(), exc.code
+        content_type = exc.headers.get("Content-Type")
+        encoding = exc.headers.get("Content-Encoding")
+    return {
+        "status": status,
+        "bytes": len(body),
+        "sha256": hashlib.sha256(body).hexdigest(),
+        "content_type": content_type,
+        "content_encoding": encoding,
+    }
+
+
+def measure_key_enforcement(key: str) -> dict:
+    """How CARTO answers each way of getting the key right and wrong."""
+    bogus = (
+        re.sub(r"[0-9a-f]{8}$", "deadbeef", key)
+        if re.search(r"[0-9a-f]{8}$", key)
+        else key[:-8] + "deadbeef"
+    )
+    variants = {
+        "keyed": f"{TILE}?key={key}",
+        "keyless": TILE,
+        "wrong_key_value": f"{TILE}?key={bogus}",
+        "wrong_param_name": f"{TILE}?api_key={key}",
+    }
+    results = {name: fetch(url) for name, url in variants.items()}
+
+    keyed_digest = results["keyed"]["sha256"]
+    for _name, result in results.items():
+        result["differs_from_keyed"] = result["sha256"] != keyed_digest
+    return results
+
+
+def measure_referer_enforcement(key: str) -> dict:
+    """Whether the domain CARTO collects at issue time is actually enforced."""
+    url = f"{TILE}?key={key}"
+    results = {
+        "issued_origin": fetch(url, {"Referer": ISSUED_ORIGIN}),
+        "foreign_origin": fetch(url, {"Referer": FOREIGN_ORIGIN}),
+        "no_referer": fetch(url),
+    }
+    baseline = results["issued_origin"]["sha256"]
+    for result in results.values():
+        result["matches_issued_origin"] = result["sha256"] == baseline
+    return results
+
+
+def measure_bundles() -> dict:
+    """What each renderer costs the browser, gzipped, as a CDN would serve it."""
+    out = {}
+    for library, urls in BUNDLES.items():
+        assets = {}
+        for url in urls:
+            result = fetch(url, {"Accept-Encoding": "gzip"})
+            result["url"] = url
+            assets[os.path.basename(url)] = result
+        out[library] = {
+            "assets": assets,
+            "total_gzipped_bytes": sum(a["bytes"] for a in assets.values()),
+        }
+    return out
+
+
+def build_metrics(key: str) -> dict:
+    key_enforcement = measure_key_enforcement(key)
+    referer = measure_referer_enforcement(key)
+    bundles = measure_bundles()
+
+    leaflet = bundles["leaflet"]["total_gzipped_bytes"]
+    maplibre = bundles["maplibre-gl"]["total_gzipped_bytes"]
+
+    return {
+        "_about": {
+            "experiment": EXPERIMENT,
+            "writeup": f"docs/experiments/{EXPERIMENT}.md",
+            "generated_by": "scripts/measure_carto_basemap.py --out-dir docs/experiments",
+            "note": (
+                "CARTO began requiring an API key on basemaps.cartocdn.com (2026-08-28) and "
+                "enforces it by watermarking the tile, not by returning an error, so every way "
+                "of getting the key wrong is HTTP 200. `key_enforcement` compares each wrong "
+                "variant against the keyed request BY DIGEST because a status code cannot tell "
+                "them apart. `referer_enforcement` tests whether the domain CARTO collects when "
+                "issuing a key is enforced. `renderer_bundles` is gzipped transfer size off "
+                "cdnjs, sizing the raster-vs-vector decision -- vector needs the same key, so "
+                "the only thing switching buys or costs is the rendering stack. The key itself "
+                "is not recorded here; it lives in www/js/streetscape-utils.js."
+            ),
+        },
+        "tile": TILE,
+        "key_enforcement": key_enforcement,
+        "referer_enforcement": referer,
+        "renderer_bundles": bundles,
+        "summary": {
+            "wrong_is_indistinguishable_from_absent": (
+                key_enforcement["keyless"]["sha256"]
+                == key_enforcement["wrong_key_value"]["sha256"]
+                == key_enforcement["wrong_param_name"]["sha256"]
+            ),
+            "keyed_differs_from_keyless": key_enforcement["keyless"]["differs_from_keyed"],
+            "every_failure_mode_returns_200": all(
+                r["status"] == 200 for r in key_enforcement.values()
+            ),
+            "referer_enforced": not (
+                referer["foreign_origin"]["matches_issued_origin"]
+                and referer["no_referer"]["matches_issued_origin"]
+            ),
+            "leaflet_gzipped_bytes": leaflet,
+            "maplibre_gl_gzipped_bytes": maplibre,
+            "maplibre_over_leaflet_ratio": round(maplibre / leaflet, 2) if leaflet else None,
+        },
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("--out-dir", default=DEFAULT_OUT_DIR)
+    parser.add_argument("--dry-run", action="store_true", help="print the metrics, write nothing")
+    args = parser.parse_args()
+
+    metrics = build_metrics(carto_basemap_key())
+    rendered = json.dumps(metrics, indent=2) + "\n"
+
+    if args.dry_run:
+        print(rendered, end="")
+        return 0
+
+    out_path = os.path.join(args.out_dir, f"{EXPERIMENT}_metrics.json")
+    with open(out_path, "w", encoding="utf-8") as f:
+        f.write(rendered)
+    print(f"wrote {out_path}")
+
+    s = metrics["summary"]
+    print(
+        f"  wrong key is byte-identical to no key : {s['wrong_is_indistinguishable_from_absent']}"
+    )
+    print(f"  every failure mode returns HTTP 200   : {s['every_failure_mode_returns_200']}")
+    print(f"  Referer enforced                      : {s['referer_enforced']}")
+    print(
+        f"  maplibre-gl vs leaflet (gzipped)      : "
+        f"{s['maplibre_gl_gzipped_bytes']:,} B vs {s['leaflet_gzipped_bytes']:,} B "
+        f"({s['maplibre_over_leaflet_ratio']}x)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/e2e/test_basemap_key.py
+++ b/tests/e2e/test_basemap_key.py
@@ -1,0 +1,115 @@
+"""Live check that the CARTO basemap key is still buying us unwatermarked tiles.
+
+CARTO began requiring an API key on ``basemaps.cartocdn.com`` (2026-08-28), and
+the failure mode is silent by construction: a request with **no key, a bogus
+key, a mangled key, or the right key under the wrong parameter name** all
+return HTTP 200, ``image/png``, and a tile with "API KEY REQUIRED" printed
+across it. Nothing in the frontend's fetch handling can see that -- it is a
+valid image -- so the site rendered watermarked for an unknown period and the
+break presented as a styling oddity rather than an outage.
+
+That makes this the one thing worth checking over the network, because it is
+the one thing the offline suite structurally cannot:
+``www/js/__tests__/streetscape-utils.test.js`` pins the SHAPE of the request we
+build (the ``key=`` parameter, the key that reaches CARTO, the attribution) and
+that neither page script builds a tile URL of its own, but no offline test can
+know whether CARTO still honours the key.
+
+The assertion is differential rather than a pinned hash: fetch one tile with
+the key and the same tile without it, and require the bytes to differ. That
+holds without hardcoding what a watermark looks like, and it goes red for every
+way the key can stop working --
+
+  * revoked, expired, or rotated out from under us,
+  * the 5M-request/month free ceiling exhausted (including by someone who
+    scraped the key out of this public repo -- CARTO does not enforce the
+    domain it collected, so the key is bearer-style),
+  * a future edit that drops or misspells the query parameter.
+
+It would also go red if CARTO stopped watermarking keyless requests entirely.
+That is a false alarm, but a useful one: it means the constraint this whole
+mechanism exists for has changed and is worth re-reading.
+
+Marked ``e2e`` so it stays out of the fast, no-network suite and runs in the
+non-blocking e2e CI job. It needs no browser.
+"""
+
+import os
+import re
+import time
+import urllib.error
+import urllib.request
+
+import pytest
+
+pytestmark = pytest.mark.e2e
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_PROJECT_ROOT = os.path.dirname(os.path.dirname(_HERE))
+_UTILS_JS = os.path.join(_PROJECT_ROOT, "www", "js", "streetscape-utils.js")
+
+# One arbitrary but stable tile (San Francisco, z12). Any tile with content
+# works; an all-water tile would compress to near-identical bytes with and
+# without a watermark and would make the differential meaningless.
+_TILE = "https://a.basemaps.cartocdn.com/dark_all/12/655/1583.png"
+
+_TIMEOUT_S = 30
+
+# CARTO occasionally answers a burst of requests with a 429/5xx. That is a
+# statement about the moment, not about our key, so retry it once rather than
+# spend a red run on it -- this job already carries two known flakes and a
+# third would just train people to ignore it. A 4xx other than 429 is a real
+# verdict on the request and is NOT retried.
+_TRANSIENT_STATUSES = frozenset({408, 429, 500, 502, 503, 504})
+_ATTEMPTS = 2
+
+
+def _carto_basemap_key() -> str:
+    """The key the site actually ships, read from its single home."""
+    with open(_UTILS_JS, encoding="utf-8") as f:
+        match = re.search(r'CARTO_BASEMAP_KEY\s*=\s*"([^"]+)"', f.read())
+    assert match, f"no CARTO_BASEMAP_KEY const in {_UTILS_JS}"
+    return match.group(1)
+
+
+def _fetch(url: str) -> tuple[int, bytes]:
+    """GET a tile, turning a network-level failure into a skip, not a failure.
+
+    A DNS or connection error says something about the machine running the
+    test; it says nothing about our key, and failing on it would train people
+    to ignore this test. An HTTP error is different -- that IS a response from
+    CARTO -- so it is returned for the assertions to judge.
+    """
+    request = urllib.request.Request(url, headers={"User-Agent": "streetscape-tracker-e2e"})
+    for attempt in range(_ATTEMPTS):
+        try:
+            with urllib.request.urlopen(request, timeout=_TIMEOUT_S) as response:
+                return response.status, response.read()
+        except urllib.error.HTTPError as exc:  # a real answer from CARTO
+            status, body = exc.code, exc.read()
+            if status not in _TRANSIENT_STATUSES or attempt == _ATTEMPTS - 1:
+                return status, body
+        except (urllib.error.URLError, TimeoutError) as exc:
+            pytest.skip(f"cannot reach {_TILE}: {exc}")
+        time.sleep(2)
+    raise AssertionError("unreachable")
+
+
+def test_the_carto_key_still_buys_an_unwatermarked_tile():
+    keyed_status, keyed = _fetch(f"{_TILE}?key={_carto_basemap_key()}")
+    keyless_status, keyless = _fetch(_TILE)
+
+    assert keyed_status == 200, f"keyed tile request returned HTTP {keyed_status}"
+    assert keyless_status == 200, (
+        f"keyless tile returned HTTP {keyless_status}; CARTO has always answered 200 here, "
+        f"so the differential below is no longer measuring what it was written to measure"
+    )
+    assert keyed, "keyed tile came back empty"
+
+    assert keyed != keyless, (
+        "the keyed tile is byte-identical to the keyless one, so the key is buying nothing "
+        "and every map on the site is rendering CARTO's 'API KEY REQUIRED' watermark. "
+        "Check the key in www/js/streetscape-utils.js against the CARTO account: revoked, "
+        "rotated, or the 5M/month free ceiling exhausted. This never surfaces as an error "
+        "in the browser -- the watermark is inside a valid PNG."
+    )

--- a/tests/test_build_boundary_review.py
+++ b/tests/test_build_boundary_review.py
@@ -9,6 +9,8 @@ delegated to boundary_audit.frozen_rect_bounds, so we assert the two agree.
 import importlib.util
 import os
 
+import pytest
+
 PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 _spec = importlib.util.spec_from_file_location(
     "build_boundary_review", os.path.join(PROJECT_ROOT, "scripts", "build_boundary_review.py")
@@ -370,3 +372,66 @@ def test_render_html_neutralizes_close_tag():
     ]
     html = bbr.render_html(payloads)
     assert "danger <\\/script> tag" in html
+
+
+# ── CARTO basemap key ───────────────────────────────────────────────────────
+#
+# The viewer is generated, standalone HTML: it cannot load
+# www/js/streetscape-utils.js, so its basemap key is substituted in here. That
+# is worth pinning because the failure is invisible -- CARTO answers a
+# missing, stale or placeholder key with HTTP 200 and "API KEY REQUIRED"
+# printed across the tile, and on a tool whose whole job is judging a city
+# boundary by eye, a watermark over every tile is a working-looking page that
+# is harder to review.
+
+
+def test_render_html_substitutes_the_frontend_carto_key():
+    payloads = [
+        bbr.build_city_payload(
+            "boston",
+            group="manual",
+            current=CURRENT,
+            report=report_row(),
+            rec_source=manual_row(),
+            cache=None,
+        )
+    ]
+    html = bbr.render_html(payloads)
+    assert bbr.CARTO_KEY_PLACEHOLDER not in html
+    assert f"?key={bbr.carto_basemap_key()}" in html
+
+
+def test_carto_key_comes_from_the_frontend_module_not_a_second_copy():
+    """One key, one home. A second literal is how the two drift apart."""
+    js = os.path.join(PROJECT_ROOT, "www", "js", "streetscape-utils.js")
+    with open(js, encoding="utf-8") as f:
+        js_source = f.read()
+    assert f'CARTO_BASEMAP_KEY = "{bbr.carto_basemap_key()}"' in js_source
+
+    # The template must carry the placeholder, never the key itself.
+    with open(bbr.TEMPLATE_PATH, encoding="utf-8") as f:
+        template = f.read()
+    assert bbr.CARTO_KEY_PLACEHOLDER in template
+    assert bbr.carto_basemap_key() not in template
+
+
+def test_carto_key_read_raises_rather_than_degrading(tmp_path):
+    """A renamed const must fail the build, not ship a placeholder as the key.
+
+    Returning "" or the placeholder would render a page that looks fine until
+    a reviewer notices the watermark, which is exactly the failure mode this
+    whole change exists to remove.
+    """
+    empty = tmp_path / "no-key.js"
+    empty.write_text("const SOMETHING_ELSE = 1;\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="CARTO_BASEMAP_KEY"):
+        bbr.carto_basemap_key(str(empty))
+
+
+def test_render_html_raises_when_the_template_loses_the_key_placeholder(tmp_path):
+    with open(bbr.TEMPLATE_PATH, encoding="utf-8") as f:
+        template = f.read()
+    stripped = tmp_path / "template.html"
+    stripped.write_text(template.replace("?key=" + bbr.CARTO_KEY_PLACEHOLDER, ""), encoding="utf-8")
+    with pytest.raises(ValueError, match=bbr.CARTO_KEY_PLACEHOLDER):
+        bbr.render_html([], template_path=str(stripped))

--- a/www/eslint.config.js
+++ b/www/eslint.config.js
@@ -29,6 +29,8 @@ const vendorGlobals = {
 // streetscape-utils.js's own definitions aren't flagged as `no-redeclare`.
 const sharedGlobals = {
   STREETSCAPE_DATA_BASE_URL: "readonly",
+  CARTO_BASEMAP_KEY: "readonly",
+  addBasemapLayer: "readonly",
   RENDER_CAP: "readonly",
   PROVIDERS: "readonly",
   METRICS: "readonly",

--- a/www/eslint.config.js
+++ b/www/eslint.config.js
@@ -29,7 +29,6 @@ const vendorGlobals = {
 // streetscape-utils.js's own definitions aren't flagged as `no-redeclare`.
 const sharedGlobals = {
   STREETSCAPE_DATA_BASE_URL: "readonly",
-  CARTO_BASEMAP_KEY: "readonly",
   addBasemapLayer: "readonly",
   RENDER_CAP: "readonly",
   PROVIDERS: "readonly",

--- a/www/js/__tests__/streetscape-utils.test.js
+++ b/www/js/__tests__/streetscape-utils.test.js
@@ -43,6 +43,8 @@ const {
   computeVisibilityDelta,
   markerDateStyle,
   STREETSCAPE_DATA_BASE_URL,
+  CARTO_BASEMAP_KEY,
+  addBasemapLayer,
   streetwalkManifestUrl,
   fetchStreetwalkManifest,
   lookupStreetwalk,
@@ -1412,4 +1414,78 @@ test("run and diff filename contracts stay disjoint", () => {
   assert.equal(isValidDiffFilename(runName), false);
   assert.ok(isValidDiffFilename(diffName));
   assert.equal(isValidRunFilename(diffName), false);
+});
+
+// --- CARTO basemap key ----------------------------------------------------
+//
+// These pin the fix for the 2026-08-28 outage, which no ordinary assertion
+// could have caught: CARTO began requiring a key, and serves a KEYLESS request
+// HTTP 200 with "API KEY REQUIRED" burned into the tile PNG. A wrong param
+// name, a mangled key and a revoked key all return that same byte-identical
+// watermarked tile, so the browser sees a perfectly good image and every
+// behavioural check stays green while every map on the site is broken.
+//
+// What is pinnable offline is the SHAPE of the request we make. Whether the
+// key is still accepted is a live question, and lives in
+// tests/e2e/test_basemap_key.py, which diffs a keyed tile against a keyless
+// one over the network.
+
+test("addBasemapLayer sends the key under the param CARTO validates", () => {
+  const calls = [];
+  const previousL = global.L;
+  global.L = {
+    tileLayer(url, options) {
+      calls.push({ url, options });
+      return { addTo: (m) => ({ addedTo: m }) };
+    },
+  };
+  try {
+    const map = { id: "map" };
+    const layer = addBasemapLayer(map);
+
+    assert.equal(calls.length, 1);
+    assert.deepEqual(layer, { addedTo: map }, "the layer must be added to the map it was given");
+
+    const [base, query] = calls[0].url.split("?");
+    assert.equal(
+      base,
+      "https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png",
+      "the {s}/{r} placeholders are Leaflet's, and CARTO serves this shorthand style path"
+    );
+
+    // Read through URLSearchParams rather than matching the raw string: it
+    // undoes the encodeURIComponent, so this asserts the key CARTO actually
+    // RECEIVES, and keeps passing if a rotated key needs escaping. The param
+    // name is the load-bearing half — `api_key` is the plausible typo, and it
+    // returns the watermarked tile rather than an error.
+    const params = new URLSearchParams(query);
+    assert.equal(params.get("key"), CARTO_BASEMAP_KEY);
+    assert.ok(CARTO_BASEMAP_KEY.length > 0, "an empty key is a keyless request");
+
+    // The free tier is conditioned on the credit, so the attribution is part
+    // of the contract rather than decoration.
+    assert.match(calls[0].options.attribution, /CARTO/);
+    assert.match(calls[0].options.attribution, /OpenStreetMap/);
+  } finally {
+    global.L = previousL;
+  }
+});
+
+test("index.js and city.js take their basemap only from addBasemapLayer", () => {
+  // A source check because no behavioural one can catch this: a page script
+  // that rebuilt the URL inline would still render, and would render
+  // WATERMARKED, which is the exact bug the helper exists to make
+  // unrepeatable. The two call sites were byte-identical duplicates before
+  // they were collapsed, so the duplicate is the natural thing for the next
+  // edit to reintroduce.
+  for (const name of ["../index.js", "../city.js"]) {
+    const src = stripComments(readFileSync(require.resolve(name), "utf8"));
+    assert.equal(
+      /L\.tileLayer\s*\(/.test(src),
+      false,
+      name + " builds its own tile layer; call addBasemapLayer(map) instead, so the " +
+        "key and the attribution keep exactly one home"
+    );
+    assert.ok(/addBasemapLayer\s*\(/.test(src), name + " never adds a basemap at all");
+  }
 });

--- a/www/js/city.js
+++ b/www/js/city.js
@@ -31,10 +31,7 @@
 const map = L.map("map", { zoomControl: false, preferCanvas: true }).setView([0, 0], 13);
 L.control.zoom({ position: "bottomleft" }).addTo(map);
 
-L.tileLayer("https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png", {
-  attribution: "© OpenStreetMap contributors © CARTO",
-  maxZoom: 19,
-}).addTo(map);
+addBasemapLayer(map);
 
 // ── Module-level state ─────────────────────────────────────────
 let markersByYear = {};

--- a/www/js/index.js
+++ b/www/js/index.js
@@ -79,10 +79,7 @@ function baseFillOpacity(city) {
   return value == null && currentMetric === "streets" ? 0.2 : 0.6;
 }
 
-L.tileLayer("https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png", {
-  attribution: "© OpenStreetMap contributors © CARTO",
-  maxZoom: 19,
-}).addTo(map);
+addBasemapLayer(map);
 
 // ── Popup histogram ───────────────────────────────────────────
 

--- a/www/js/streetscape-utils.js
+++ b/www/js/streetscape-utils.js
@@ -36,11 +36,24 @@ const STREETSCAPE_DATA_BASE_URL =
  * raster AND vector services, conditioned on crediting CARTO and
  * OpenStreetMap — which is why addBasemapLayer sets the attribution.
  *
- * Raster PNG is on CARTO's stated retirement path, but vector will require
- * this same key eventually (CARTO: coming, not live yet, as of 2026-08-28).
- * So switching to vector is a rendering-stack decision — Leaflet cannot draw
- * MVT, and maplibre-gl is ~273 KB gzipped against Leaflet's ~42 KB — and not
- * a way off the key.
+ * Exposure is unavoidable; ABUSE is a separate question, and that one IS
+ * mitigable. The key is readable off the deployed page and out of this public
+ * repo both, and CARTO does not enforce the domain it collected — so a
+ * scraped copy spends our shared 5M ceiling, and exhaustion degrades to the
+ * same silent watermark as no key at all. Hence a detection path rather than
+ * a promise: tests/e2e/test_basemap_key.py asserts a keyed tile differs
+ * byte-wise from a keyless one, the one check that fails on a revoked,
+ * mistyped, mangled or exhausted key. Ask CARTO to enforce the domain if they
+ * ever offer it.
+ *
+ * CARTO says it is CONSIDERING stopping raster data updates and has announced
+ * no end date (FAQ, read 2026-08-28) — weaker than a retirement date, and
+ * the difference matters to anyone budgeting a migration against it. Vector
+ * will require this same key eventually (CARTO: coming, not live yet), so
+ * leaving raster is a rendering-stack decision and not a way off the key:
+ * Leaflet cannot draw MVT, and maplibre-gl is ~273 KB gzipped against
+ * Leaflet's ~42 KB. Measured, with the caveats:
+ * docs/experiments/carto-basemap-key.md.
  *
  * @see https://docs.carto.com/faqs/carto-basemaps
  */
@@ -54,15 +67,22 @@ const CARTO_BASEMAP_KEY = "cb1_2g44_1_b50596cc0f87c5ea43d9b94b";
  * the required attribution have exactly one place to be updated — two copies
  * of a key that must match is how one map silently keeps the watermark.
  *
+ * The key is encodeURIComponent'd rather than pasted in raw. Today's value is
+ * URL-safe, but a rotated one carrying `+`, `/`, `=` or `&` would be mangled
+ * in the query string — and a mangled key returns HTTP 200 with the
+ * watermark, indistinguishable from sending no key. The rotation the docblock
+ * above calls a one-line change has to actually stay one line.
+ *
  * @param {L.Map} map - Map to add the basemap to.
- * @returns {Object} The tile layer, already added to the map.
+ * @returns {L.TileLayer} The tile layer, already added to the map.
  */
 function addBasemapLayer(map) {
   return L.tileLayer(
-    `https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png?key=${CARTO_BASEMAP_KEY}`,
+    "https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png" +
+      `?key=${encodeURIComponent(CARTO_BASEMAP_KEY)}`,
     {
       attribution: "© OpenStreetMap contributors © CARTO",
-      maxZoom: 19
+      maxZoom: 19,
     }
   ).addTo(map);
 }

--- a/www/js/streetscape-utils.js
+++ b/www/js/streetscape-utils.js
@@ -2,10 +2,11 @@
  * streetscape-utils.js
  * Shared utilities for the Streetscape City Explorer.
  *
- * Provides the data-host base URL, the provider registry (GSV/Mapillary),
- * the YlOrRd color scale, filename→provider detection, gzip JSON fetching,
- * and the aggregate-record adapter — used by both the overview map
- * (index.js) and the per-city detail view (city.js).
+ * Provides the data-host base URL, the shared dark basemap layer, the
+ * provider registry (GSV/Mapillary), the YlOrRd color scale,
+ * filename→provider detection, gzip JSON fetching, and the aggregate-record
+ * adapter — used by both the overview map (index.js) and the per-city
+ * detail view (city.js).
  *
  * @module streetscape-utils
  */
@@ -13,6 +14,58 @@
 /** Base URL for all Streetscape Tracker data files. */
 const STREETSCAPE_DATA_BASE_URL =
   "https://makeabilitylab.cs.washington.edu/public/streetscape-tracker/data/";
+
+/**
+ * CARTO basemap API key — public on purpose, not a secret.
+ *
+ * CARTO now requires a key on basemaps.cartocdn.com (observed 2026-08-28).
+ * A keyless request still returns HTTP 200: the tile PNG itself comes back
+ * stamped "API KEY REQUIRED", so the break renders as a styling bug rather
+ * than an outage, and no amount of error handling on our side can see it.
+ *
+ * The token ships in static JS because it has to: the browser sends it to
+ * CARTO on every tile request, so it is readable off the deployed page no
+ * matter where the repo keeps it, and the site has no build step to hide it
+ * behind (ADR 0001). CARTO asks for a domain when issuing the key but does
+ * NOT enforce it — a tile request with a mismatched Referer and one with no
+ * Referer at all both returned the same keyed bytes (checked 2026-08-28) —
+ * so treat this as bearer-style. Rotate by replying to the issuing email; the
+ * key lives in this one const so that stays a one-line change.
+ *
+ * The free ceiling is 5M tile requests per calendar month, counted across the
+ * raster AND vector services, conditioned on crediting CARTO and
+ * OpenStreetMap — which is why addBasemapLayer sets the attribution.
+ *
+ * Raster PNG is on CARTO's stated retirement path, but vector will require
+ * this same key eventually (CARTO: coming, not live yet, as of 2026-08-28).
+ * So switching to vector is a rendering-stack decision — Leaflet cannot draw
+ * MVT, and maplibre-gl is ~273 KB gzipped against Leaflet's ~42 KB — and not
+ * a way off the key.
+ *
+ * @see https://docs.carto.com/faqs/carto-basemaps
+ */
+const CARTO_BASEMAP_KEY = "cb1_2g44_1_b50596cc0f87c5ea43d9b94b";
+
+/**
+ * Add the shared dark basemap to a Leaflet map.
+ *
+ * The overview map (index.js) and the per-city detail map (city.js) draw the
+ * same tiles. They call this instead of each repeating the URL so the key and
+ * the required attribution have exactly one place to be updated — two copies
+ * of a key that must match is how one map silently keeps the watermark.
+ *
+ * @param {L.Map} map - Map to add the basemap to.
+ * @returns {Object} The tile layer, already added to the map.
+ */
+function addBasemapLayer(map) {
+  return L.tileLayer(
+    `https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png?key=${CARTO_BASEMAP_KEY}`,
+    {
+      attribution: "© OpenStreetMap contributors © CARTO",
+      maxZoom: 19
+    }
+  ).addTo(map);
+}
 
 /**
  * Max pano dots the city map draws at once (issues #77/#58). Dense cities hold
@@ -1200,6 +1253,8 @@ function markerDateStyle(captureDateStr, selectedDateStr) {
 if (typeof module !== "undefined" && module.exports) {
   module.exports = {
     STREETSCAPE_DATA_BASE_URL,
+    CARTO_BASEMAP_KEY,
+    addBasemapLayer,
     RENDER_CAP,
     PROVIDERS,
     LOOSEST_EARLIEST_PLAUSIBLE_CAPTURE,


### PR DESCRIPTION
## What broke

Every map on the site is currently rendering with an `API KEY REQUIRED / carto.com/basemaps/apikey` watermark tiled across it.

This is not our code. CARTO now requires an API key on `basemaps.cartocdn.com`, and the failure mode is unusually quiet: **a keyless request still returns HTTP 200**, with the notice burned into the tile PNG itself. Confirmed with curl, no browser involved:

```
https://a.basemaps.cartocdn.com/dark_all/12/655/1583.png  →  200, image/png, 15516 bytes
```

...and the bytes are a watermarked tile. Nothing in our fetch handling could ever have caught this — it presents as a styling bug, not an outage. Worth remembering the next time a map looks wrong.

## The fix

The two `L.tileLayer` call sites (`city.js`, `index.js`) were byte-identical duplicates. Rather than paste `?key=` into both, they now call a single `addBasemapLayer(map)` in `streetscape-utils.js`, which both pages already load. The key and the attribution CARTO's free tier is conditioned on get exactly one home — two copies of a key that must match is how one map silently keeps the watermark.

`eslint.config.js` registers `addBasemapLayer` in `sharedGlobals`; without that `no-undef` fails the Lint job.

## How CARTO actually enforces the key

Measured against our own URL form, not the one CARTO documents, and committed as [`docs/experiments/carto-basemap-key.md`](docs/experiments/carto-basemap-key.md):

| Request (tile `12/655/1583`) | Status | Bytes | SHA-256 |
|---|---|---|---|
| `?key=<our key>` | 200 | 16,945 | `d36c88d3…` |
| no query string | 200 | 15,516 | `cb4906d8…` |
| `?key=<well-formed but wrong>` | 200 | 15,516 | `cb4906d8…` |
| `?api_key=<our key>` | 200 | 15,516 | `cb4906d8…` |

**The three failure modes are byte-identical to each other.** A missing key, a wrong key, and the right key under the wrong parameter name are literally the same response. So there is no status code, no failed fetch and no console warning to assert on — which is why the key had to be verified against the `dark_all` shorthand we use rather than the `rastertiles/voyager` path CARTO documents, and why the parameter name is load-bearing and unguessable.

## About the key being in the repo

It is public by construction and there is no private setting that would change that: the browser sends it to CARTO on every tile request, so it is readable off the deployed page wherever the repo keeps it, and the site has no build step to inject it at (ADR 0001).

But **exposure and abuse are two different questions**, and only the first is unavoidable. CARTO asks for a domain when issuing the key and does **not** enforce it — the issued origin, a foreign origin, and no `Referer` at all return byte-identical keyed tiles — so it is bearer-style. That makes the usual "same as any Mapbox / Google Maps JS client key" comparison the wrong one: those are conventionally domain-locked, and this demonstrably isn't, so a copy scraped out of this public repo works anywhere and spends the shared ceiling.

Two things follow. **The ask is for CARTO to enforce the domain they already collected.** And because quota exhaustion degrades to the same silent watermark, there is now a detection path rather than a promise: `tests/e2e/test_basemap_key.py` fetches one tile with the key and the same tile without, and requires the bytes to differ. Differential rather than a pinned hash, so it survives CARTO restyling the notice, and it covers a revoked key, an exhausted quota and a dropped parameter alike.

Free ceiling is 5M tile requests/month, counted across the raster **and** vector services, conditioned on crediting CARTO and OpenStreetMap. Rotation is a reply to the issuing email plus a one-line edit to the single const — which is why the key is `encodeURIComponent`'d, so a rotated value carrying `+`, `/`, `=` or `&` isn't silently mangled straight back into the watermark case.

## What keeps this from coming back

Three pins, because the bug is invisible to ordinary assertions:

- **A behavioural test** stubs `L.tileLayer`, calls `addBasemapLayer`, and reads the URL back through `URLSearchParams` — asserting the key CARTO *receives*, so it keeps working if a rotated key needs escaping.
- **A source scan** (in `streetscape-utils.test.js`'s existing `stripComments` idiom) pins that neither `index.js` nor `city.js` contains an `L.tileLayer(` of its own. The two call sites were byte-identical duplicates, and a reintroduced duplicate renders perfectly — watermarked.
- **The live check above**, marked `e2e` so it stays out of the fast no-network suite.

All mutation-verified: wrong param name, empty key, dropped attribution, an inlined keyless URL in `index.js`, and a bogus key each turn a test red.

## Should we have gone to vector instead?

Considered and declined, now with measured numbers rather than recollection; the reasoning is in [`docs/experiments/carto-basemap-key.md`](docs/experiments/carto-basemap-key.md) so it does not get re-litigated from scratch.

Vector is not a way off the key — CARTO's free tier is counted across both services, and their email says the vector key requirement is coming, just not live yet. So switching is purely a rendering-stack decision. Leaflet cannot draw MVT at all, so it means maplibre-gl: **285,543 B against Leaflet's 46,131 B gzipped, 6.19×**, counting the stylesheet each needs to draw a map (the script halves alone are 275,453 B vs 42,605 B). Add `@maplibre/maplibre-gl-leaflet`, which is not on cdnjs and would come off a second CDN origin — and a cdnjs asset is already one of the two known e2e flakes. WebGL in a headless screenshot suite is a further new flake class, and where WebGL is unavailable you get no basemap at all, where raster simply works.

Against that, CARTO has announced no raster end date: the FAQ says only that they are *"considering stopping data updates"*. Worth revisiting when there is an actual date, or if the dense-city rendering path is ever reworked — MapLibre renders on the GPU, which is what `RENDER_CAP` and the `preferCanvas` subsampling exist to work around (#77 / #58). That is a project, not a maintenance chore.

## The operator tool is keyed too

`scripts/boundary_review.template.html` had its own keyless CARTO layer. A watermark there isn't cosmetic — that tool exists to judge a city boundary by eye, and the notice runs diagonally across every tile.

It is standalone generated HTML that cannot load `streetscape-utils.js`, so rather than paste a second copy of the key, `build_boundary_review.py` reads the const out of the JS and substitutes it, raising if either the const or the placeholder has gone. The key still has exactly one home in the repo.

## Verification

- Key checked against **our** URL form, not the one CARTO documents — works, clean tile, on all four `{s}` subdomains.
- `npm run lint` clean · `npm test` **396/396** · `pytest` **1729 passed, 1 skipped** · `ruff check` and `ruff format --check` clean · `pytest tests/e2e/test_basemap_key.py -m e2e` green against live CARTO.

## After merge

Needs `./deploy_makelab1.sh` to reach the live site (that is what rsyncs `www/`; `sync_data_to_server.sh` only publishes `data/`), then a force-refresh — CARTO's CDN and the browser both cache tiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code) — Opus 5 (1M context), claude-opus-5[1m]
