### PR TITLE
Pause both Mapillary channels after the third per-IP block (#241, #267)

### DIFF
--- a/config/scheduler.makelab1.toml
+++ b/config/scheduler.makelab1.toml
@@ -39,8 +39,16 @@ enabled = true
 # 10M/day covers cycling ~1,144 cities on the 90-day schedule with headroom.
 daily_request_budget = 10000000
 
+# PAUSED 2026-08-28 after the THIRD per-IP block (see the new-issue link in
+# docs/provider-access.md). Not a volume decision: the ledger rules out a fixed
+# threshold over every window from 1 to 8 days — 08-28 was refused at 1,938/day
+# while 08-14 spent 26,363 clean — so cutting the budget a third time has no
+# mechanism to work through. The budgets below are LEFT AS-IS deliberately: they
+# are the sizing #241/#267 argued for, and re-enabling should be a decision about
+# the mechanism, not a re-derivation of numbers that were never the binding
+# constraint. Flip `enabled` back to true to resume; nothing else needs changing.
 [providers.mapillary]
-enabled = true
+enabled = false
 # Counted in z14 vector-tile requests. Mapillary documents this endpoint as
 # "50,000 per day (not per minute)" per app — i.e. NO documented throughput
 # limit at all — and 4xx on exceeding it. Our block matched none of that: on
@@ -128,8 +136,11 @@ spacing_m = 15
 # issue #241 note in [providers.mapillary]. Split evenly: a road walk reads
 # the identical tile census as the grid run, so a paired night costs the
 # same on each channel and the budgets deplete in lockstep.
+# PAUSED 2026-08-28 with [providers.mapillary] — same IP, same tile CDN, so
+# pausing one and not the other would keep the host under exactly the load the
+# pause exists to stop. Re-enable the pair together.
 [providers.mapillary_streets]
-enabled = true
+enabled = false
 daily_request_budget = 1750
 spacing_m = 15
 # See [providers.mapillary] — one per-IP rate budget, two channels.

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -979,13 +979,18 @@ def test_makelab1_production_config_is_wired():
     # Order is canonical, not alphabetical: most expensive first, EXCEPT kartaview,
     # which ranks LAST because a multi-hour sweep absorbs deadline truncation most
     # cheaply (#238). Asserting the list therefore pins the launch order too.
-    assert cfg.enabled_providers() == [
-        "gsv",
-        "gsv_streets",
-        "mapillary",
-        "mapillary_streets",
-        "kartaview",
-    ]
+    #
+    # Both Mapillary channels are PAUSED as of 2026-08-28 (third per-IP block), so
+    # they are configured-but-disabled and drop out of this list. Pinned as an
+    # absence rather than deleted: resuming them must be a deliberate edit here.
+    assert cfg.enabled_providers() == ["gsv", "gsv_streets", "kartaview"]
+    for paused in ("mapillary", "mapillary_streets"):
+        assert paused in cfg.providers, f"{paused} block must survive the pause"
+        assert not cfg.providers[paused].enabled
+    # The pause is about the mechanism, not the sizing — the budgets stay at the
+    # values #241/#267 argued for so that resuming is one flag, not a re-derivation.
+    assert cfg.providers["mapillary"].daily_request_budget == 1_750
+    assert cfg.providers["mapillary_streets"].daily_request_budget == 1_750
     # kartaview was turned on in production on 2026-08-28, the separate deploy
     # decision this assertion previously withheld (#248). Enabling the CHANNEL
     # enrols nobody: it is the one opt-in channel, so the nightly queue is exactly


### PR DESCRIPTION
`tiles.mapillary.com` refused makelab2 for the **third** time on **2026-08-28 at 10:40:37** — exit 75, `HTTP 302 → www.mapillary.com/login`, the same signature as 08-12 and 08-20. The breaker worked: 20 remaining channel-attempts skipped, night published, alert sent, unit exited nonzero. GSV was unaffected.

## This is not a volume decision

Two rounds of volume mitigation are already in force (60/min limiter, then the 3,500/day combined cut on 08-22). Both held. The block came anyway, at **55% of the cut budget**.

Checking the block against clean days from the same week, **every accumulation window from 1 to 8 days is contradicted**:

| Window | Blocked 08-28 | A clean day that was higher |
|---|---|---|
| 1 day | 1,938 | 08-23: 3,190 |
| 2 day | 4,272 | 08-24: 6,482 |
| 3 day | 6,250 | 08-25: 8,082 |
| 7 day | 14,332 | 08-26: 15,073 |
| 8 day | 14,332 | 08-27: 17,407 |

The starkest pair is **08-14: 26,363 requests in one day, no block**, against **08-28: 1,938, blocked** — a 13.6× spread in the wrong direction.

This falsifies #241's fitted bands, 2-day `(7,061, 10,766]` and 3-day `(10,284, 12,074]`, which are the sizing premise #267 is built on.

## What is invariant is timing

| Block | Date | Gap | Active collection days since previous |
|---|---|---|---|
| 1 | 08-12 | — | — |
| 2 | 08-20 | 8 days | **6** |
| 3 | 08-28 | 8 days | **6** |

Cumulative spend between blocks was *not* constant (48,019 then 14,332), so this does not look like a spend budget resetting. n=3 blocks / n=2 intervals, so it is a hypothesis — but it explains why two budget cuts failed and predicts a third would too. It also matches the **repeat-offender penalty** rival that #267 already flagged as "equally good fit, deliberately not being tested". This block tested it involuntarily.

## What this PR does

- `enabled = false` on `[providers.mapillary]` and `[providers.mapillary_streets]`.
- **Paused as a pair** — same IP, same tile CDN, so pausing one would leave the host under exactly the load the pause exists to stop.
- **Budgets left untouched.** They are the sizing #241/#267 argued for; resuming should be a decision about the mechanism, not a re-derivation of numbers that were never the binding constraint. Resuming is one flag per channel.
- `test_makelab1_production_config_is_wired` pins the pause as an *absence* (blocks present, `enabled` false, budgets unchanged) rather than deleting the assertion, so resuming is a deliberate edit here too.

GSV, `gsv_streets` and the newly-enabled `kartaview` are unaffected; `enabled_providers()` becomes `["gsv", "gsv_streets", "kartaview"]`.

## Testing

`1725 passed, 1 skipped`; `ruff check` and `ruff format --check` clean.

## Follow-ups filed separately

The analysis above, the Graph API lead, and the duplicate tile census are follow-up issues rather than part of this pause.

🤖 Generated with [Claude Code](https://claude.com/claude-code) — Opus 5 (1M context), claude-opus-5[1m]