### PR TITLE
Shift #292's pre-registered dates to the actual restart night

### DIFF
--- a/config/scheduler.makelab1.toml
+++ b/config/scheduler.makelab1.toml
@@ -55,12 +55,15 @@ daily_request_budget = 10000000
 # the 08-31 this said when it was written, and the prediction below is shifted
 # to match rather than left pointing at the pre-deploy plan.
 #
-# Pre-registered prediction, recorded in #286: each prior block came after
-# exactly 6 active collection days, so a fourth block around 2026-09-05/06
-# means rate, volume and request pattern are ALL dead and the trigger is
-# cadence (next move: rest days, not more pacing); clean through ~2026-09-09
-# means keep this. If it blocks: disable both channels again, sweep for
-# detached processes, probe once after ~24 h.
+# Pre-registered prediction, recorded in #286: each prior block landed ON the
+# 6th active collection night (08-13..08-20, 08-23..08-28), so with 08-30 as
+# night 1 a fourth block around 2026-09-04/05 means rate, volume and request
+# pattern are ALL dead and the trigger is cadence (next move: rest days, not
+# more pacing); clean through ~2026-09-09 means keep this. The prior blocks
+# were ALSO 8 calendar days apart, but only because each run contained two
+# paused days; this restart has none, so count active nights, not calendar
+# days. If it blocks: disable both channels again, sweep for detached
+# processes, probe once after ~24 h.
 [providers.mapillary]
 enabled = true
 # Counted in z14 vector-tile requests. Mapillary documents this endpoint as

--- a/config/scheduler.makelab1.toml
+++ b/config/scheduler.makelab1.toml
@@ -48,14 +48,19 @@ daily_request_budget = 10000000
 # the mechanism, not a re-derivation of numbers that were never the binding
 # constraint.
 #
-# RESUMED 2026-08-31 under issue #292: slower mean rate AND jittered request
+# RESUMED 2026-08-30 under issue #292: slower mean rate AND jittered request
 # gaps (see max_requests_per_minute / jitter below), with #291's shared census
-# halving a paired night's tile spend. Pre-registered prediction, recorded in
-# #286: each prior block came after exactly 6 active collection days, so a
-# fourth block around 2026-09-06/07 means rate, volume and request pattern are
-# ALL dead and the trigger is cadence (next move: rest days, not more pacing);
-# clean through ~2026-09-10 means keep this. If it blocks: disable both channels
-# again, sweep for detached processes, probe once after ~24 h.
+# halving a paired night's tile spend. Deployed 2026-08-29 afternoon, so the
+# first jittered night is the 08-30 02:13 timer fire -- ONE NIGHT EARLIER than
+# the 08-31 this said when it was written, and the prediction below is shifted
+# to match rather than left pointing at the pre-deploy plan.
+#
+# Pre-registered prediction, recorded in #286: each prior block came after
+# exactly 6 active collection days, so a fourth block around 2026-09-05/06
+# means rate, volume and request pattern are ALL dead and the trigger is
+# cadence (next move: rest days, not more pacing); clean through ~2026-09-09
+# means keep this. If it blocks: disable both channels again, sweep for
+# detached processes, probe once after ~24 h.
 [providers.mapillary]
 enabled = true
 # Counted in z14 vector-tile requests. Mapillary documents this endpoint as
@@ -168,7 +173,7 @@ spacing_m = 15
 # and this budget is drawn on only when the pair is split apart.
 # PAUSED 2026-08-28 with [providers.mapillary] — same IP, same tile CDN, so
 # pausing one and not the other would keep the host under exactly the load the
-# pause exists to stop — and RESUMED with it 2026-08-31 under #292: the pair
+# pause exists to stop — and RESUMED with it 2026-08-30 under #292: the pair
 # moves together in both directions.
 [providers.mapillary_streets]
 enabled = true

--- a/docs/provider-access.md
+++ b/docs/provider-access.md
@@ -238,9 +238,12 @@ Mapillary tile fetches jitter **by default** (`DEFAULT_TILE_JITTER = 0.6`, `--ma
 The budgets are left at 1,750 because a fourth cut has no mechanism to work through.
 
 **This is a pre-registered test, not a fix**, and the prediction is recorded in #286 before the restart.
-Each prior block came after exactly **6 active collection days** (8 calendar days apart: 08-12, 08-20, 08-28).
+Each prior block landed **on the 6th active collection night**: 08-13…08-20 and 08-23…08-28 are each a run of six collecting nights ending in the block.
+Those two runs were also 8 calendar days apart, but only because each happened to contain exactly two paused days — so the calendar reading and the active-night reading coincided by accident.
+This restart has no paused days, the two readings diverge, and the active-night rule is the one stated here.
 The restart was planned for Mon 2026-08-31 but the deploy landed on Sat 2026-08-29 afternoon, so the first jittered night is the **08-30 02:13 PDT** timer fire and every date below is one day earlier than #286's original table — shifted here rather than silently left pointing at the pre-deploy plan, because moving a pre-registered date *after* the outcome is known is the thing this whole section exists to avoid.
-A fourth block around **2026-09-05/06** under jitter and the shared census's halved paired-night spend (issue #290, PR #291) means rate, volume *and* request pattern are all dead, the trigger is cadence (consecutive active days, or a trust score), and the next move is scheduling rest days for the Mapillary channels — not more pacing.
+#286's table also counted the restart night as day 0, which placed its estimate a night later than the 6th active night the rule actually names; both corrections are made here, five nights before night 6, and posted to #286 rather than only recorded locally.
+A fourth block around **2026-09-04/05** — the 6th active night is 09-04 — under jitter and the shared census's halved paired-night spend (issue #290, PR #291) means rate, volume *and* request pattern are all dead, the trigger is cadence (consecutive active days, or a trust score), and the next move is scheduling rest days for the Mapillary channels — not more pacing.
 That inference is only as strong as the treatment, which is why the distribution was moved from uniform to exponential before the restart rather than after: at CV 0.35 a fourth block would have been ambiguous between "the trigger is cadence" and "the jitter was too mild to move the score", and at CV 0.6 against Poisson's 1.0 that second reading is much harder to sustain.
 It is not *impossible* to sustain — the remaining gap to 1.0, and the unchanged duty cycle (~44 minutes of unbroken traffic, no gap over ~10 s), are the honest limits on the conclusion.
 Clean through ~2026-09-09 means keep the setting.

--- a/docs/provider-access.md
+++ b/docs/provider-access.md
@@ -239,10 +239,11 @@ The budgets are left at 1,750 because a fourth cut has no mechanism to work thro
 
 **This is a pre-registered test, not a fix**, and the prediction is recorded in #286 before the restart.
 Each prior block came after exactly **6 active collection days** (8 calendar days apart: 08-12, 08-20, 08-28).
-A fourth block around **2026-09-06/07** under jitter and the shared census's halved paired-night spend (issue #290, PR #291) means rate, volume *and* request pattern are all dead, the trigger is cadence (consecutive active days, or a trust score), and the next move is scheduling rest days for the Mapillary channels — not more pacing.
+The restart was planned for Mon 2026-08-31 but the deploy landed on Sat 2026-08-29 afternoon, so the first jittered night is the **08-30 02:13 PDT** timer fire and every date below is one day earlier than #286's original table — shifted here rather than silently left pointing at the pre-deploy plan, because moving a pre-registered date *after* the outcome is known is the thing this whole section exists to avoid.
+A fourth block around **2026-09-05/06** under jitter and the shared census's halved paired-night spend (issue #290, PR #291) means rate, volume *and* request pattern are all dead, the trigger is cadence (consecutive active days, or a trust score), and the next move is scheduling rest days for the Mapillary channels — not more pacing.
 That inference is only as strong as the treatment, which is why the distribution was moved from uniform to exponential before the restart rather than after: at CV 0.35 a fourth block would have been ambiguous between "the trigger is cadence" and "the jitter was too mild to move the score", and at CV 0.6 against Poisson's 1.0 that second reading is much harder to sustain.
 It is not *impossible* to sustain — the remaining gap to 1.0, and the unchanged duty cycle (~44 minutes of unbroken traffic, no gap over ~10 s), are the honest limits on the conclusion.
-Clean through ~2026-09-10 means keep the setting.
+Clean through ~2026-09-09 means keep the setting.
 Bundling the shared census (#290) with the jitter means a clean result cannot say which one worked; that is accepted, since a block would falsify both at once.
 Deliberately **not** changed in the same round: tile order (raster → shuffled), because a second pattern change would confound the same test.
 


### PR DESCRIPTION
Follow-up to #293, comments and prose only. Two corrections to the pre-registration, both made while the outcome is still unknown.

## 1. The restart landed a night early

#293 was written assuming a **Mon 2026-08-31** restart, and both the prod config comment and `docs/provider-access.md` recorded the prediction against that date. The deploy actually landed **Sat 2026-08-29 afternoon**, so the first jittered Mapillary night was the **2026-08-30 02:13 PDT** timer fire — one night earlier than planned.

## 2. The date arithmetic was off by one night anyway

Reviewing the shift surfaced a second error that has nothing to do with the deploy date. The stated rule is **six active collection nights**, and each prior block landed *on* the sixth — 08-13…08-20 and 08-23…08-28 — but the prediction was derived as if the restart night were night 0, putting it a night late.

Those two runs were also 8 calendar days apart, but only because each happened to contain exactly two paused days. This restart has no paused days, so the calendar reading and the active-night reading diverge for the first time, and the active-night one is the rule the prediction actually rests on.

| | was | now |
|---|---|---|
| First jittered night | 2026-08-31 | **2026-08-30** |
| 4th block ⇒ trigger is cadence | ~09-06/07 | **~09-04/05** (night 6 is 09-04) |
| Clean through ⇒ keep the setting | ~09-10 | **~09-09** |

Corrected **now, five nights before night 6**, rather than reconciled afterwards — adjusting a pre-registered date after the fact is precisely what that section exists to prevent — and the reason is recorded beside the new dates rather than left as an unexplained edit.

## Night 1 (2026-08-30) ran clean

Batch 02:13 → 09:00 PDT, 6.77 h, 77/77 runs across 20 cities, exit 0, full tail and publish. No 302s, no blocked-family exit codes. The pacer logged `mean 40/min, exponentially jittered (CV 0.60; gaps floor 0.60 s, mean 1.50 s, p99 4.74 s, no ceiling)`.

Day's Mapillary tile spend **755**, against 1,938 on the 08-28 block night for a comparable slate — #291's shared census working as designed: all 20 paired road walks reused the grid crawl for **0 tile requests**, where `mapillary_streets` previously matched the grid channel request for request (969/969 on 08-28).

## Deploy status (for the record)

Prod (makelab2) is at `5ec0293` as of 2026-08-29 afternoon, carrying #284, #291 and #293:

- fast-forward `29d00a0 → 5ec0293`, clean, no unit changes, no new deps;
- catalog auto-migrated **v13 → v14** (two `ALTER TABLE … ADD COLUMN`, no DEFAULT), verified `PRAGMA user_version = 14`;
- suite green on prod's own interpreter (1,868 passed);
- both Mapillary channels live at 40/min, jitter 0.6, budgets 0/1,750;
- site deployed and the docroot verified in sync — the owed CARTO key from #284 is finally live, confirmed by the differential check in `tests/e2e/test_basemap_key.py` rather than by the key merely being present.

The corresponding correction has been posted to https://github.com/jonfroehlich/streetscape-tracker/issues/286, which also fixes a third staleness in the posted table that this PR does not touch: it describes the jitter as uniform 0.6–2.4 s, which was #293's first-pushed distribution, not the shifted exponential that shipped after review.

🤖 Generated with [Claude Code](https://claude.com/claude-code) — Opus 5 (1M context), claude-opus-5[1m]
