### PR TITLE
KartaView road-walk collector, on an explicit provider dispatch and a shared census scorer (#268, #258)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,7 @@ python -m streetscape_street_analyzer.analyze "Seattle, WA" --provider gsv
 python -m streetscape_street_analyzer.collect "Seattle, WA" --estimate      # cost preview, no key used
 python -m streetscape_street_analyzer.collect "Seattle, WA" --spacing 15
 python -m streetscape_street_analyzer.collect "Seattle, WA" --provider mapillary
+python -m streetscape_street_analyzer.collect "Seattle, WA" --provider kartaview   # free on a paired night (#290 cache)
 python -m streetscape_street_analyzer.collect "Seattle, WA" --network-type all_public   # a SEPARATE walk series, not a replacement
 
 # Worldwide sampling frame (docs/worldwide_sampling.md)
@@ -104,6 +105,7 @@ Credentials live in `.env`, loaded per channel by `streetscape_metadata_tracker/
 | `mapillary` | `MAPILLARY_ACCESS_TOKEN` | Free client token |
 | `kartaview` | `KARTAVIEW_ACCESS_TOKEN` | **Required, not optional**: anonymous is 100 req/h vs 1,000 authenticated — at 100/h a p95 city is hours and Singapore is days, so it is not a slower channel, it is no channel. Scheduled but **opt-in** (#248) |
 | `gsv_streets` | `GMAPS_STREETS_API_KEY` | Isolated street-collection key (#99) with its own `api_usage` string, so street experiments can't exhaust production quotas; **live** |
+| `kartaview_streets` | `KARTAVIEW_STREETS_ACCESS_TOKEN` | The one street channel that **falls back to `KARTAVIEW_ACCESS_TOKEN`** rather than requiring its own: one machine-wide `host_lock(HOST_KARTAVIEW)` serializes every KartaView request, so there is no parallel burn to isolate. CLI-only, **not yet scheduled** (#258) |
 | `mapillary_streets` | `MAPILLARY_STREETS_ACCESS_TOKEN` | Same isolation; **dormant** |
 
 A run requires EVERY named provider's key up-front, `--provider all` included (fail-fast so the series can't drift); a single-provider run needs only its own key.

--- a/docs/street-coverage.md
+++ b/docs/street-coverage.md
@@ -67,7 +67,9 @@ GSV issues one metadata request per sample location (Seattle: 247k).
 Consequence: a Mapillary walk's cost is the tile census — *independent of sample spacing* (Corvallis: 25,555 sample points scored for 42 requests, and a test pins equal `api_requests` across spacing 15 vs 30) but **not independent of city size**, since tile count scales with bbox area: median 12, mean 57.8, max 870 over the catalog (the distribution measured in `docs/provider-access.md`).
 Only the spacing half of that is a real invariant — an earlier version of this documentation claimed both, which would price Moscow like a village.
 Either way it is orders of magnitude below GSV's one-request-per-sample-point, which is why it can run everywhere GSV can't; `collect --estimate` prints the actual figure for a city before spending.
-Each provider meters against its own isolated key + `api_usage` channel (`gsv_streets` / `mapillary_streets`).
+Each provider meters against its own `api_usage` channel (`gsv_streets` / `kartaview_streets` / `mapillary_streets`), so a road walk can never exhaust a grid collector's quota.
+Two of the three also isolate the **credential**: `gsv_streets` and `mapillary_streets` require their own key, because a walk and a grid run of those providers can be in flight at once and would otherwise burn one quota in parallel.
+`kartaview_streets` deliberately does not — it falls back to `KARTAVIEW_ACCESS_TOKEN` when `KARTAVIEW_STREETS_ACCESS_TOKEN` is unset, because one machine-wide `host_lock(HOST_KARTAVIEW)` serializes every KartaView request in the repo, so there is no parallel burn to isolate; on a paired night the walk reuses the grid run's census and spends nothing at all.
 The Mapillary arm emits #116's status vocabulary at sample level
 — `OK`/`NO_DATE` for a 360° pano in range, `FLAT_ONLY` (null capture_date) when only flat imagery is, `ZERO_RESULTS` otherwise
 — which `compute_streetwalk_coverage` turns into **two numbers per edge**: `coverage_fraction` (360°) and `coverage_fraction_any`, summarized as `coverage_pct_by_length[_any]`.

--- a/streetscape_metadata_tracker/census.py
+++ b/streetscape_metadata_tracker/census.py
@@ -238,11 +238,35 @@ def status_for_capture_dates(capture_dates) -> np.ndarray:
     grid downloader and road-walk collector so one provider's status vocabulary
     can't drift from another's.
 
+    MISSING IS ANY OF ``""``, None, NaN or NaT, not just the empty string. The
+    empty string is the in-repo convention and every current parser emits it
+    (`.fillna("")`), but this is the function a NEW census provider binds
+    against through `CensusWalkSpec.capture_dates_for`, and `None != ""` is
+    True: a guard testing only the empty string reads a null date as **OK with
+    no date**. That row would be counted as covered, its NO_DATE silently lost,
+    and written into an immutable dated snapshot -- and because undated imagery
+    arrives in batches it would read as a property of the provider's data
+    rather than as a bug. Cheap to make total, so it is total.
+
     Args:
-        capture_dates: array-like of 'YYYY-MM-DD'/'' from the provider's
-            vectorized date parser.
+        capture_dates: array-like of 'YYYY-MM-DD' / '' from the provider's
+            vectorized date parser. None/NaN/NaT are accepted and treated as
+            missing, but '' is what a parser should emit.
     """
-    return np.where(np.asarray(capture_dates) != "", "OK", "NO_DATE")
+    dates = np.asarray(capture_dates)
+    if dates.dtype.kind in "US":
+        # The fast path, and the only one a current parser takes: a fixed-width
+        # string array cannot hold None or NaN, so there is nothing to check
+        # for. Keyed on the STRING kinds rather than on `== object` because an
+        # all-null column arrives as float64 NaN, which is neither.
+        # This runs once per census row (#157's memory contract).
+        missing = dates == ""
+    else:
+        # Comparing a float array against "" yields a scalar False rather than
+        # an elementwise mask, so the null check comes first and the empty
+        # string is asked of an object view.
+        missing = pd.isna(dates) | (dates.astype(object) == "")
+    return np.where(missing, "NO_DATE", "OK")
 
 
 def _check_image_columns(

--- a/streetscape_metadata_tracker/config.py
+++ b/streetscape_metadata_tracker/config.py
@@ -257,7 +257,46 @@ def load_config(provider: str = "gsv") -> dict[str, Any]:
             )
         return config
 
+    if provider == "kartaview_streets":
+        # FALLS BACK to the grid channel's token, unlike its two sibling street
+        # channels which require their own (issue #258).
+        #
+        # Those two exist for QUOTA isolation: two Google keys can burn one
+        # project's per-minute quota in parallel, and two Mapillary tokens can
+        # spend one IP's tile budget in parallel. Neither is reachable here.
+        # Every KartaView request in the repo goes through one machine-wide
+        # host_lock(HOST_KARTAVIEW), so the grid run and the walk CANNOT be in
+        # flight at once -- and since #290 a paired night's walk reuses the grid
+        # run's census for zero requests, so the usual case spends nothing at
+        # all. A second token would buy no isolation the lock does not already
+        # give, while making the channel un-runnable until someone creates one.
+        #
+        # An override is still honoured, so isolating later is a .env line
+        # rather than a code change.
+        config = {
+            "access_token": (
+                os.environ.get("KARTAVIEW_STREETS_ACCESS_TOKEN")
+                or os.environ.get("KARTAVIEW_ACCESS_TOKEN")
+            ),
+        }
+        if not config["access_token"]:
+            raise ValueError(
+                "Neither KARTAVIEW_STREETS_ACCESS_TOKEN nor KARTAVIEW_ACCESS_TOKEN "
+                "found in environment variables.\n\n"
+                "The KartaView road walk reads the same census as the grid run and "
+                "is serialized against it by the machine-wide host lock, so it "
+                "shares the grid channel's token by default (issue #258). Set "
+                "KARTAVIEW_STREETS_ACCESS_TOKEN only if you want the walk metered "
+                "under a separate credential.\n\n"
+                "Add it to the .env file in your project root:\n"
+                "  KARTAVIEW_ACCESS_TOKEN=YOUR_TOKEN\n\n"
+                "Sign in at https://kartaview.org with Google or Facebook and read "
+                "the token from the session."
+            )
+        return config
+
     raise ValueError(
         f"Unknown provider {provider!r} "
-        f"(known: gsv, mapillary, kartaview, gsv_streets, mapillary_streets)"
+        f"(known: gsv, mapillary, kartaview, gsv_streets, mapillary_streets, "
+        f"kartaview_streets)"
     )

--- a/streetscape_metadata_tracker/config.py
+++ b/streetscape_metadata_tracker/config.py
@@ -147,6 +147,34 @@ def warn_if_credentials_world_readable(env_path: str) -> bool:
     return False
 
 
+# Credential channel -> the env var(s) load_config reads for it, most specific
+# first. The FIRST entry is the channel's own variable and the one CLAUDE.md's
+# credentials table documents; a second is a documented fallback.
+#
+# Declared rather than left implicit in load_config's if-chain because that
+# chain is not enumerable, and #258 shipped `kartaview_streets` with no row in
+# the router's credentials table -- while being the one street channel whose
+# credential behaviour differs from its siblings. Two tests close the loop:
+# test_load_config_reads_no_env_var_outside_the_declared_table asserts this
+# covers every variable the chain actually reads, and
+# test_every_credential_channel_appears_in_the_routers_credentials_table
+# asserts CLAUDE.md covers every channel here. Adding a channel fails both
+# until it is declared and documented.
+CHANNEL_ENV_VARS: dict[str, tuple[str, ...]] = {
+    "gsv": ("GMAPS_API_KEY",),
+    "gsv_streets": ("GMAPS_STREETS_API_KEY",),
+    "kartaview": ("KARTAVIEW_ACCESS_TOKEN",),
+    # The one channel with a fallback: a walk and a grid run of KartaView are
+    # serialized by one machine-wide host_lock(HOST_KARTAVIEW), so there is no
+    # parallel quota burn to isolate the way gsv_streets and mapillary_streets
+    # must. Its own token still overrides, for an operator who wants the walk
+    # metered separately upstream.
+    "kartaview_streets": ("KARTAVIEW_STREETS_ACCESS_TOKEN", "KARTAVIEW_ACCESS_TOKEN"),
+    "mapillary": ("MAPILLARY_ACCESS_TOKEN",),
+    "mapillary_streets": ("MAPILLARY_STREETS_ACCESS_TOKEN",),
+}
+
+
 def load_config(provider: str = "gsv") -> dict[str, Any]:
     """
     Load the API credential for the given provider from the environment.

--- a/streetscape_metadata_tracker/download_kartaview.py
+++ b/streetscape_metadata_tracker/download_kartaview.py
@@ -1473,6 +1473,15 @@ class SweepCheckpoint:
     path: str
     radius_m: int
     channel: str | None = None
+    # WHICH crawl of that channel. A road walk's --network-type is what
+    # separates two crawls of one city inside one channel, so the channel alone
+    # does not identify a sweep once #258's walk exists: `drive` and
+    # `all_public` meter into the SAME ledger and are not the same crawl.
+    # Mirrors download_mapillary's tile checkpoint, whose commit record has
+    # carried the variant since #256 -- checkpointing.checkpoint_path_for's
+    # docstring asserts that every provider's record stores it, and until #258
+    # KartaView's did not, leaving the path token as the only separation.
+    variant: str | None = None
     # When the FIRST commit of this sweep landed, carried forward by every later
     # one. The age cap is measured from here rather than from `updated_at`
     # (issue #272), for the reason Mapillary's checkpoint already records: a
@@ -1620,6 +1629,7 @@ def load_checkpoint(
     ipp: int,
     requested_radius_m: int | None,
     channel: str | None = None,
+    variant: str | None = None,
 ) -> SweepCheckpoint | None:
     """
     Resume state for this sweep, or None if there is nothing usable here.
@@ -1646,6 +1656,14 @@ def load_checkpoint(
             resume a sweep whose spend belongs to a different ledger. The
             state file records what it was written as, and a mismatch --
             including a checkpoint from before this field existed -- discards.
+        variant: WHICH crawl of that channel -- a road walk's --network-type,
+            or None for the grid run. The channel alone stopped identifying a
+            sweep when #258 gave one channel two walks of a city: `drive` and
+            `all_public` meter into the SAME ledger, so this is the only thing
+            separating them. A mismatch discards for the reason the channel one
+            does -- resuming would price this crawl with another one's requests
+            -- and a record written before this field existed reads None, which
+            is exactly right for the grid run that wrote it.
 
     Returns:
         A :class:`SweepCheckpoint` with its uncommitted parts already swept
@@ -1667,6 +1685,13 @@ def load_checkpoint(
                 f"{channel!r}; the two meter into different api_usage ledgers"
             )
             return None
+        if state.get("variant") != variant:
+            discard(
+                f"it belongs to the {state.get('variant')!r} crawl of this channel and "
+                f"this run is {variant!r}; resuming it would price this crawl with "
+                f"another one's requests"
+            )
+            return None
         reason = _sweep_matches_caller(state, ipp=ipp, requested_radius_m=requested_radius_m)
         if reason is None:
             cp, reason = _validate_sweep_store(path, state, bbox=bbox)
@@ -1674,6 +1699,7 @@ def load_checkpoint(
             discard(reason)
             return None
         cp.channel = channel
+        cp.variant = variant
         cp.created_at = state["created_at"]
         # MEASURED FROM created_at -- WHEN THE FIRST COMMIT LANDED -- NOT FROM
         # updated_at (issue #272). The one guard here that protects an ARTIFACT
@@ -1890,6 +1916,7 @@ def _commit_checkpoint(
         "bbox": list(bbox),
         "radius_m": cp.radius_m,
         "channel": cp.channel,
+        "variant": cp.variant,
         "ipp": ipp,
         "root_count": root_count,
         "roots_done": cp.roots_done,
@@ -2456,6 +2483,7 @@ async def _fetch_city_images(
             ipp=ipp,
             requested_radius_m=radius_m,
             channel=checkpoint_channel,
+            variant=checkpoint_variant,
         )
 
     limiter = AsyncRateLimiter(max_requests_per_minute)
@@ -2546,7 +2574,10 @@ async def _fetch_city_images(
                 # The radius is settled, so the checkpoint can be opened against
                 # the lattice it will actually describe.
                 cp = resumed or SweepCheckpoint(
-                    path=checkpoint_path, radius_m=radius_m, channel=checkpoint_channel
+                    path=checkpoint_path,
+                    radius_m=radius_m,
+                    channel=checkpoint_channel,
+                    variant=checkpoint_variant,
                 )
 
             roots = cells_for_bbox(*bbox, radius_m * math.sqrt(2))
@@ -3027,8 +3058,15 @@ async def _fetch_city_images(
             census_cache_marker(
                 "kartaview",
                 # RECORDED, never keyed -- the entry is reusable by any channel.
+                # But recorded as the PAIR: same_crawl compares (channel,
+                # variant), so a walk that hardcoded None here would fail to
+                # recognise its OWN entry on a re-finalize -- reporting
+                # api_requests_total=0 for a sweep it paid for, while
+                # census_fetched_by names itself as the payer -- and would take
+                # reconcile_cache_hit's cross-channel path, inheriting its own
+                # failed cells instead of re-probing them.
                 fetched_by=cp.channel,
-                fetched_variant=None,
+                fetched_variant=cp.variant,
                 crawl_started_at=cp.created_at,
                 api_requests_total=prior_requests + api_requests,
                 failed=[_cell_to_dict(c) for c in failed_cells],

--- a/streetscape_metadata_tracker/download_kartaview.py
+++ b/streetscape_metadata_tracker/download_kartaview.py
@@ -2154,6 +2154,7 @@ async def fetch_city_images_async(
     checkpoint_path: str | None = None,
     checkpoint_request_interval: int = DEFAULT_CHECKPOINT_REQUEST_INTERVAL,
     checkpoint_channel: str | None = None,
+    checkpoint_variant: str | None = None,
     census_cache: CensusCache | None = None,
 ) -> dict[str, Any]:
     """
@@ -2192,6 +2193,7 @@ async def fetch_city_images_async(
             checkpoint_path=checkpoint_path,
             checkpoint_request_interval=checkpoint_request_interval,
             checkpoint_channel=checkpoint_channel,
+            checkpoint_variant=checkpoint_variant,
             census_cache=census_cache,
         )
 
@@ -2211,6 +2213,7 @@ async def _fetch_city_images(
     checkpoint_path: str | None = None,
     checkpoint_request_interval: int = DEFAULT_CHECKPOINT_REQUEST_INTERVAL,
     checkpoint_channel: str | None = None,
+    checkpoint_variant: str | None = None,
     census_cache: CensusCache | None = None,
 ) -> dict[str, Any]:
     """
@@ -2420,12 +2423,19 @@ async def _fetch_city_images(
             cache_path=census_cache.path,
             checkpoint_path=checkpoint_path,
             channel=checkpoint_channel,
-            variant=None,
+            # The VARIANT, not None. A road walk's --network-type is what
+            # separates two crawls of one city inside one channel, so a
+            # hardcoded None here would have the 'drive' walk reconcile against
+            # the 'all_public' walk's checkpoint and inherit its holes. None is
+            # still correct for the grid run, which has no variant -- it now
+            # arrives as one rather than being assumed (#258).
+            variant=checkpoint_variant,
         ):
             return _reuse_cached_sweep(
                 cached,
                 city_name=city_name,
                 checkpoint_channel=checkpoint_channel,
+                checkpoint_variant=checkpoint_variant,
             )
 
     resumed: SweepCheckpoint | None = None

--- a/streetscape_street_analyzer/census_walk.py
+++ b/streetscape_street_analyzer/census_walk.py
@@ -64,11 +64,16 @@ class CensusWalkSpec:
 
     Attributes:
         capture_dates_for: ``(census, positions) -> array`` of ISO date strings
-            (or None) for those census rows. The one genuinely divergent piece:
-            Mapillary reads ``captured_at_ms``, KartaView reads ``shot_date``
-            against ``date_added``. A date the provider's own guard rejects
-            comes back None, which becomes NO_DATE below — never a dropped
-            sample, because an undated pano still covers (issue #257).
+            for those census rows. The one genuinely divergent piece: Mapillary
+            reads ``captured_at_ms``, KartaView reads ``shot_date`` against
+            ``date_added``. A date the provider's own guard rejects must come
+            back as **the empty string**, which becomes NO_DATE below — never a
+            dropped sample, because an undated pano still covers (issue #257).
+            Both current bindings emit ``""`` (`.fillna("")`);
+            ``status_for_capture_dates`` also treats None/NaN/NaT as missing,
+            so a binding that returns None is scored correctly rather than
+            silently publishing OK with a null date, but ``""`` is the
+            convention to write against.
         build_image_rows: the provider's binding of ``census.build_image_rows``.
         build_empty_rows: the provider's binding of ``census.build_empty_rows``.
     """
@@ -243,10 +248,11 @@ def build_streetwalk_rows(
         spec.capture_dates_for(census, chosen[matched_idx][pano_of_matched])
     )
     # status_for_capture_dates is evaluated over every matched row, including
-    # the flat ones whose capture_date is None — those transiently read "OK"
-    # (None != "") and are then overridden by the outer where. Kept whole-array
-    # rather than masked so the OK/NO_DATE rule has exactly one statement,
-    # shared with the grid downloader; a flat row's status never escapes it.
+    # the flat ones whose capture_date is None — those transiently read
+    # "NO_DATE" (the guard treats None as missing) and are then overridden by
+    # the outer where. Kept whole-array rather than masked so the OK/NO_DATE
+    # rule has exactly one statement, shared with the grid downloader; a flat
+    # row's status never escapes it.
     status = np.where(~pano_of_matched, FLAT_ONLY, status_for_capture_dates(capture_dates))
     image_rows = spec.build_image_rows(
         census,

--- a/streetscape_street_analyzer/census_walk.py
+++ b/streetscape_street_analyzer/census_walk.py
@@ -39,7 +39,7 @@ import geopandas as gpd
 import numpy as np
 import pandas as pd
 
-from streetscape_metadata_tracker.analysis import FLAT_ONLY
+from streetscape_metadata_tracker.analysis import FLAT_ONLY, REQUEST_FAILED
 from streetscape_metadata_tracker.census import census_is_pano, status_for_capture_dates
 
 WGS84 = "EPSG:4326"
@@ -182,6 +182,7 @@ def build_streetwalk_rows(
     match_dist_m: float,
     query_timestamp: str,
     spec: CensusWalkSpec,
+    unmeasured_mask: Callable[[np.ndarray, np.ndarray], np.ndarray] | None = None,
 ) -> pd.DataFrame:
     """
     Score every sample location against the census into METADATA rows.
@@ -197,6 +198,9 @@ def build_streetwalk_rows(
         presence marker with a **null capture_date**, so flat timestamps never
         enter a dated statistic; counts only toward any-imagery coverage.
       * ``ZERO_RESULTS`` — no imagery of any kind in range.
+      * ``REQUEST_FAILED`` — nothing in range, but this sample sits under part
+        of the bbox the fetch never measured, so "no imagery" was never
+        observed here (see ``unmeasured_mask``).
 
     Args:
         query_points: the deterministic on-street sample points.
@@ -204,6 +208,19 @@ def build_streetwalk_rows(
         match_dist_m: max sample-to-image distance in metres.
         query_timestamp: the observation timestamp stamped on every row.
         spec: the provider's :class:`CensusWalkSpec`.
+        unmeasured_mask: ``(lats, lons) -> bool array`` marking sample points
+            under a tile or cell the fetch never got back — KartaView's
+            ``_points_in_cells`` over ``failed_cells``, and the same seam
+            Mapillary's ``failed_tiles`` needs for #259. None for a clean
+            sweep, which pays nothing.
+
+            Recording an unswept sample as ZERO_RESULTS publishes an absence we
+            never observed into an immutable dated snapshot, and street
+            coverage is a share of samples — so an unmeasured hole would read
+            as measured emptiness and understate the city forever. Applied only
+            to samples that matched nothing: one that found imagery within
+            ``match_dist_m`` was measured by construction, whatever cell it
+            sits in.
     """
     pano_positions, flat_positions = nearest_images_to_samples(query_points, census, match_dist_m)
     sample_lats = np.array([p[0] for p in query_points], dtype=np.float64)
@@ -244,11 +261,18 @@ def build_streetwalk_rows(
     empty_idx = np.flatnonzero(~matched)
     if not len(empty_idx):
         return image_rows
+    empty_lats = sample_lats[empty_idx]
+    empty_lons = sample_lons[empty_idx]
+    if unmeasured_mask is None:
+        empty_status = "ZERO_RESULTS"
+    else:
+        unknown = np.asarray(unmeasured_mask(empty_lats, empty_lons), dtype=bool)
+        empty_status = np.where(unknown, REQUEST_FAILED, "ZERO_RESULTS")
     empty_rows = spec.build_empty_rows(
-        sample_lats[empty_idx],
-        sample_lons[empty_idx],
+        empty_lats,
+        empty_lons,
         query_timestamp,
-        "ZERO_RESULTS",
+        empty_status,
     )
     # Restore sample order: the two frames were built by kind, not by position.
     combined = pd.concat([image_rows, empty_rows], ignore_index=True)

--- a/streetscape_street_analyzer/census_walk.py
+++ b/streetscape_street_analyzer/census_walk.py
@@ -1,0 +1,257 @@
+"""
+The census → road-walk scorer, shared by every census provider (issue #258).
+
+A census provider has no per-sample-point endpoint. Its "walk" is not a walk of
+requests at all: it fetches one census over the city's frozen grid bbox and
+joins it **locally** onto the same deterministic on-street sample points the GSV
+walk queries one at a time. That join, and the status vocabulary it produces,
+are identical for every such provider — only the fetch and the provider's own
+column schema differ.
+
+So this module holds the join ONCE, parameterized by a :class:`CensusWalkSpec`,
+for the same reason ``census.py`` holds the grid pipeline once (see CLAUDE.md):
+the contracts it enforces are invisible in a review of the second copy. Before
+#258 this lived in ``collect_mapillary``, whose own comment said in so many
+words that ``build_streetwalk_rows`` "is Mapillary-specific and will have to be
+generalized" — this is that generalization, and the KartaView walk is the second
+caller it was waiting for.
+
+What is genuinely per-provider is small and explicit:
+
+  * how a census row's capture date is derived (Mapillary stores epoch
+    milliseconds; KartaView stores a shot date that is nulled when it is not
+    strictly older than the ingest timestamp),
+  * the provider's output row schema, via its own ``build_image_rows`` /
+    ``build_empty_rows`` bindings of the ``census.py`` core.
+
+Everything else — the nearest-image join, the pano-beats-flat rule, the
+OK/NO_DATE/FLAT_ONLY/ZERO_RESULTS vocabulary and the sample-order restore — is
+shared and stated exactly once.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+import geopandas as gpd
+import numpy as np
+import pandas as pd
+
+from streetscape_metadata_tracker.analysis import FLAT_ONLY
+from streetscape_metadata_tracker.census import census_is_pano, status_for_capture_dates
+
+WGS84 = "EPSG:4326"
+
+# Sample points per sjoin_nearest call. The join's peak memory is driven by the
+# match set it materializes, so a big city (hundreds of thousands of samples
+# against a multi-million-image census) is chunked rather than joined in one go.
+# Purely a memory knob — the result is identical at any block size, since each
+# sample's nearest image is decided independently.
+_JOIN_CHUNK_SIZE = 50_000
+
+
+@dataclass(frozen=True)
+class CensusWalkSpec:
+    """
+    The provider-specific half of a census road walk.
+
+    Three bindings, deliberately no more: anything else a provider might want to
+    vary belongs in the census it hands in, not in the scorer. Adding a field
+    here is a claim that the JOIN itself differs between providers, which is the
+    thing this module exists to deny.
+
+    Attributes:
+        capture_dates_for: ``(census, positions) -> array`` of ISO date strings
+            (or None) for those census rows. The one genuinely divergent piece:
+            Mapillary reads ``captured_at_ms``, KartaView reads ``shot_date``
+            against ``date_added``. A date the provider's own guard rejects
+            comes back None, which becomes NO_DATE below — never a dropped
+            sample, because an undated pano still covers (issue #257).
+        build_image_rows: the provider's binding of ``census.build_image_rows``.
+        build_empty_rows: the provider's binding of ``census.build_empty_rows``.
+    """
+
+    capture_dates_for: Callable[[pd.DataFrame, np.ndarray], Any]
+    build_image_rows: Callable[..., pd.DataFrame]
+    build_empty_rows: Callable[..., pd.DataFrame]
+
+
+def nearest_images_to_samples(
+    query_points: list[tuple[float, float, int, int]],
+    census: pd.DataFrame,
+    match_dist_m: float,
+) -> tuple[np.ndarray, np.ndarray]:
+    """
+    For each sample location, the nearest 360° pano and the nearest flat image
+    within ``match_dist_m``.
+
+    Uses ``gpd.sjoin_nearest`` on the local UTM CRS — the same idiom the
+    grid-attribution path uses to match panos to edges (street_coverage.py), so
+    distances are true metres rather than degree approximations. Panos and
+    flats are joined separately because they answer different questions: 360°
+    coverage and any-imagery coverage (issue #116's distinction, applied to
+    streets).
+
+    The samples run through the join in ``_JOIN_CHUNK_SIZE`` blocks rather than
+    one call. Now that the street channels are scheduled across the catalog, a
+    dense city pairs a multi-million-image census with a few hundred thousand
+    sample points, and a single join materializes the whole match set at once.
+    Chunking bounds peak memory at the census plus one block's matches; it
+    cannot change the result, because a sample never spans two blocks and the
+    nearest-image choice is per sample.
+
+    Provider-agnostic already — it touches only ``lon``/``lat``/``is_pano``,
+    which every census schema shares — which is why it moved here whole rather
+    than being parameterized.
+
+    Args:
+        query_points: ``(lat, lon, seq, _)`` tuples from
+            ``road_sampling.dedupe_query_points``.
+        census: the columnar census for any provider.
+        match_dist_m: max sample-to-image distance in metres.
+
+    Returns:
+        ``(pano_positions, flat_positions)`` — two int arrays as long as
+        ``query_points``, holding the census position of the nearest qualifying
+        image per sample and ``-1`` where nothing is in range. Positions rather
+        than image records: Colorado Springs pairs 360k samples with a 6.5M
+        image census, and a dict of per-sample image dicts is a copy of the
+        census the arrays do not need (issue #157).
+    """
+    n_samples = len(query_points)
+    none_matched = np.full(n_samples, -1, dtype=np.int64)
+    if not n_samples or not len(census):
+        return none_matched, none_matched.copy()
+
+    samples_gdf = gpd.GeoDataFrame(
+        {"sample_idx": range(n_samples)},
+        geometry=gpd.points_from_xy([p[1] for p in query_points], [p[0] for p in query_points]),
+        crs=WGS84,
+    )
+    # A city's sample points span a single UTM zone in every realistic case;
+    # estimate_utm_crs picks it from the sample extent.
+    metric_crs = samples_gdf.estimate_utm_crs()
+    samples_m = samples_gdf.to_crs(metric_crs)
+
+    def _join(positions: np.ndarray) -> np.ndarray:
+        matches = np.full(n_samples, -1, dtype=np.int64)
+        if not len(positions):
+            return matches
+        # image_idx carries the position in the FULL census, not in this
+        # subset, so the caller can index the census directly.
+        # Built once, outside the chunk loop: the census is the same for every
+        # block, and reprojecting it per block would dominate the runtime.
+        images_gdf = gpd.GeoDataFrame(
+            {"image_idx": positions},
+            geometry=gpd.points_from_xy(
+                census["lon"].to_numpy()[positions], census["lat"].to_numpy()[positions]
+            ),
+            crs=WGS84,
+        ).to_crs(metric_crs)
+
+        for start in range(0, len(samples_m), _JOIN_CHUNK_SIZE):
+            block = samples_m.iloc[start : start + _JOIN_CHUNK_SIZE]
+            joined = gpd.sjoin_nearest(
+                block,
+                images_gdf,
+                how="inner",
+                max_distance=match_dist_m,
+                distance_col="dist_m",
+            )
+            # sjoin_nearest emits every tied nearest neighbour; keep the closest
+            # single image per sample so each sample yields exactly one row.
+            joined = joined.sort_values("dist_m").drop_duplicates("sample_idx", keep="first")
+            matches[joined["sample_idx"].to_numpy()] = joined["image_idx"].to_numpy()
+        return matches
+
+    # Through census_is_pano, not census["is_pano"].to_numpy(): a provider is
+    # free to declare the column nullable (KartaView's projection is decoded to
+    # a plain bool today, but both OUTPUT schemas use pd.BooleanDtype()), and a
+    # single null degrades .to_numpy() to an object array on which `~` raises --
+    # after the whole paced census fetch is spent. Same reason the grid tail
+    # reads it there.
+    is_pano = census_is_pano(census)
+    return _join(np.flatnonzero(is_pano)), _join(np.flatnonzero(~is_pano))
+
+
+def build_streetwalk_rows(
+    query_points: list[tuple[float, float, int, int]],
+    census: pd.DataFrame,
+    match_dist_m: float,
+    query_timestamp: str,
+    spec: CensusWalkSpec,
+) -> pd.DataFrame:
+    """
+    Score every sample location against the census into METADATA rows.
+
+    Exactly one row per sample, in ``query_points`` order. Status vocabulary
+    matches the grid downloader exactly (issue #116):
+
+      * ``OK`` / ``NO_DATE`` — a 360° pano is in range (NO_DATE when its
+        capture date is one the provider's guard rejects), which is what 360°
+        street coverage counts. Both are PRESENT: a sample covered by an
+        undated pano covers, it simply ages nothing (issue #257).
+      * ``FLAT_ONLY`` — no pano in range but flat/perspective imagery is. A
+        presence marker with a **null capture_date**, so flat timestamps never
+        enter a dated statistic; counts only toward any-imagery coverage.
+      * ``ZERO_RESULTS`` — no imagery of any kind in range.
+
+    Args:
+        query_points: the deterministic on-street sample points.
+        census: the provider's columnar census over the frozen grid bbox.
+        match_dist_m: max sample-to-image distance in metres.
+        query_timestamp: the observation timestamp stamped on every row.
+        spec: the provider's :class:`CensusWalkSpec`.
+    """
+    pano_positions, flat_positions = nearest_images_to_samples(query_points, census, match_dist_m)
+    sample_lats = np.array([p[0] for p in query_points], dtype=np.float64)
+    sample_lons = np.array([p[1] for p in query_points], dtype=np.float64)
+
+    has_pano = pano_positions >= 0
+    # A pano wins wherever there is one; a flat only speaks for samples no pano
+    # reached, which is exactly what makes the row FLAT_ONLY rather than OK.
+    matched = has_pano | (flat_positions >= 0)
+    chosen = np.where(has_pano, pano_positions, flat_positions)
+
+    matched_idx = np.flatnonzero(matched)
+    capture_dates = np.full(len(matched_idx), None, dtype=object)
+    pano_of_matched = has_pano[matched_idx]
+    # Dates are asked for the PANO rows only. A flat row's timestamp is never a
+    # capture date -- it stays None and the status override below makes the row
+    # FLAT_ONLY -- so handing flats to the provider's date guard would be asking
+    # a question whose answer is discarded.
+    capture_dates[pano_of_matched] = np.asarray(
+        spec.capture_dates_for(census, chosen[matched_idx][pano_of_matched])
+    )
+    # status_for_capture_dates is evaluated over every matched row, including
+    # the flat ones whose capture_date is None — those transiently read "OK"
+    # (None != "") and are then overridden by the outer where. Kept whole-array
+    # rather than masked so the OK/NO_DATE rule has exactly one statement,
+    # shared with the grid downloader; a flat row's status never escapes it.
+    status = np.where(~pano_of_matched, FLAT_ONLY, status_for_capture_dates(capture_dates))
+    image_rows = spec.build_image_rows(
+        census,
+        chosen[matched_idx],
+        sample_lats[matched_idx],
+        sample_lons[matched_idx],
+        query_timestamp,
+        status,
+        capture_dates,
+    )
+
+    empty_idx = np.flatnonzero(~matched)
+    if not len(empty_idx):
+        return image_rows
+    empty_rows = spec.build_empty_rows(
+        sample_lats[empty_idx],
+        sample_lons[empty_idx],
+        query_timestamp,
+        "ZERO_RESULTS",
+    )
+    # Restore sample order: the two frames were built by kind, not by position.
+    combined = pd.concat([image_rows, empty_rows], ignore_index=True)
+    return combined.iloc[
+        np.argsort(np.concatenate([matched_idx, empty_idx]), kind="stable")
+    ].reset_index(drop=True)

--- a/streetscape_street_analyzer/collect.py
+++ b/streetscape_street_analyzer/collect.py
@@ -87,6 +87,10 @@ from streetscape_metadata_tracker.download_common import (
     jitter_fraction,
 )
 from streetscape_metadata_tracker.download_gsv import collect_points_async
+from streetscape_metadata_tracker.download_kartaview import (
+    DEFAULT_SWEEP_REQUESTS_PER_MINUTE,
+    estimate_sweep_requests,
+)
 from streetscape_metadata_tracker.download_mapillary import (
     DEFAULT_TILE_JITTER,
     DEFAULT_TILE_REQUESTS_PER_MINUTE,
@@ -102,6 +106,7 @@ from streetscape_metadata_tracker.naming import (
 from streetscape_metadata_tracker.paths import get_default_data_dir
 from streetscape_metadata_tracker.walk_diff import compute_and_record_walk_diff
 
+from .collect_kartaview import collect_kartaview_street_samples_async
 from .collect_mapillary import collect_mapillary_street_samples_async
 from .download_street_network import fetch_street_edges
 from .road_sampling import dedupe_query_points, generate_samples
@@ -120,6 +125,7 @@ logger = logging.getLogger(__name__)
 # quota (issue #141).
 STREET_BUDGET_CHANNELS = {
     "gsv": "gsv_streets",
+    "kartaview": "kartaview_streets",
     "mapillary": "mapillary_streets",
 }
 
@@ -165,6 +171,13 @@ class StreetCostModel:
 # walk wearing another provider's name.
 STREET_COST_MODELS: dict[str, StreetCostModel] = {
     "gsv": StreetCostModel(unit="GSV queries", estimate=None),
+    # estimate_sweep_requests is a FLOOR, not a budget: it counts one page-1 per
+    # root cell and nothing else, and the cost study measured real sweeps at
+    # 1.80x it (Yogyakarta ran 3.0x). The pre-flight is deliberately still built
+    # on the floor -- it is the number a collector can compute up front, and the
+    # safe direction is to under-refuse a walk whose census may well be free
+    # from the cache anyway. See docs/experiments/kartaview-sweep-cost.md.
+    "kartaview": StreetCostModel(unit="KartaView sweep requests", estimate=estimate_sweep_requests),
     "mapillary": StreetCostModel(unit="Mapillary tile requests", estimate=estimate_tile_count),
 }
 
@@ -446,6 +459,22 @@ def run_collect(args: argparse.Namespace) -> int:
                         request_timeout=args.timeout,
                         max_requests_per_minute=args.mapillary_max_requests_per_minute,
                         jitter=args.mapillary_jitter,
+                        checkpoint_path=checkpoint_path,
+                        checkpoint_channel=budget_channel,
+                        checkpoint_variant=args.network_type,
+                        census_cache=census_cache,
+                    )
+                )
+            elif provider == "kartaview":
+                dict_results = asyncio.run(
+                    collect_kartaview_street_samples_async(
+                        query_points,
+                        city,
+                        config["access_token"],
+                        out_csv,
+                        match_dist_m=args.match_dist,
+                        request_timeout=args.timeout,
+                        max_requests_per_minute=args.kartaview_max_requests_per_minute,
                         checkpoint_path=checkpoint_path,
                         checkpoint_channel=budget_channel,
                         checkpoint_variant=args.network_type,
@@ -775,6 +804,19 @@ def build_parser() -> argparse.ArgumentParser:
             "cadence). Rate and daily volume were both falsified as the per-IP "
             "block trigger, so the metronomic request pattern is the axis under "
             "test (issue #292)"
+        ),
+    )
+    parser.add_argument(
+        "--kartaview-max-requests-per-minute",
+        type=int,
+        default=DEFAULT_SWEEP_REQUESTS_PER_MINUTE,
+        help=(
+            "Client-side pacing cap for KartaView sweep requests "
+            f"(default: {DEFAULT_SWEEP_REQUESTS_PER_MINUTE}); <= 0 disables "
+            "pacing. Its own flag rather than the Mapillary one because "
+            "kartaview.org is a separate per-IP-metered host, shared with no "
+            "other channel -- and because the authenticated ceiling is "
+            "1,000/h, which this default sits under (issue #258)"
         ),
     )
     parser.add_argument(

--- a/streetscape_street_analyzer/collect.py
+++ b/streetscape_street_analyzer/collect.py
@@ -81,6 +81,7 @@ from streetscape_metadata_tracker.checkpointing import (
 )
 from streetscape_metadata_tracker.config import load_config
 from streetscape_metadata_tracker.download_common import (
+    SWEEP_INCOMPLETE_EXIT_CODE,
     DownloadError,
     HostUnavailableError,
     host_exit_code,
@@ -89,6 +90,7 @@ from streetscape_metadata_tracker.download_common import (
 from streetscape_metadata_tracker.download_gsv import collect_points_async
 from streetscape_metadata_tracker.download_kartaview import (
     DEFAULT_SWEEP_REQUESTS_PER_MINUTE,
+    SweepIncompleteError,
     estimate_sweep_requests,
 )
 from streetscape_metadata_tracker.download_mapillary import (
@@ -475,6 +477,7 @@ def run_collect(args: argparse.Namespace) -> int:
                         match_dist_m=args.match_dist,
                         request_timeout=args.timeout,
                         max_requests_per_minute=args.kartaview_max_requests_per_minute,
+                        max_requests=args.kartaview_max_requests,
                         checkpoint_path=checkpoint_path,
                         checkpoint_channel=budget_channel,
                         checkpoint_variant=args.network_type,
@@ -518,6 +521,21 @@ def run_collect(args: argparse.Namespace) -> int:
                 logger.warning(
                     "Recorded %d %s requests spent by the failed crawl", spent, budget_channel
                 )
+            if isinstance(e, SweepIncompleteError):
+                # PROGRESS, not breakage: the sweep stopped at its request cap
+                # or deadline and CHECKPOINTED what it paid for, so the next
+                # run resumes instead of re-paying. Logged at INFO without a
+                # traceback and given its own exit code, exactly as the grid
+                # CLI does (cli.py) -- the scheduler amnesties 83 rather than
+                # counting a consecutive_failure, and folding this into 1 would
+                # quarantine a city that is making progress every night.
+                logger.info(
+                    "KartaView sweep paused at %s/%s root cells; re-run to resume from %s",
+                    e.roots_done,
+                    e.root_count,
+                    e.checkpoint_path,
+                )
+                return SWEEP_INCOMPLETE_EXIT_CODE
             if isinstance(e, DownloadError):
                 logger.error("Collection failed: %s", e)
             else:
@@ -817,6 +835,21 @@ def build_parser() -> argparse.ArgumentParser:
             "kartaview.org is a separate per-IP-metered host, shared with no "
             "other channel -- and because the authenticated ceiling is "
             "1,000/h, which this default sits under (issue #258)"
+        ),
+    )
+    parser.add_argument(
+        "--kartaview-max-requests",
+        type=int,
+        default=None,
+        help=(
+            "Hard ceiling on the requests this KartaView walk may issue. The "
+            "--daily-budget gate is priced from estimate_sweep_requests, which "
+            "is a geometric FLOOR (measured overhead 1.80x, and Yogyakarta ran "
+            "3.0x), so a gate that passes does not bound what the sweep then "
+            "spends against a host that meters by IP. Stopping at the cap "
+            "checkpoints the work and exits "
+            f"{SWEEP_INCOMPLETE_EXIT_CODE}, so the next run resumes rather "
+            "than re-paying (issues #238, #273)"
         ),
     )
     parser.add_argument(

--- a/streetscape_street_analyzer/collect.py
+++ b/streetscape_street_analyzer/collect.py
@@ -63,6 +63,8 @@ import json
 import logging
 import os
 import sys
+from collections.abc import Callable
+from dataclasses import dataclass
 from datetime import UTC, date, datetime
 
 from dotenv import find_dotenv, load_dotenv
@@ -120,6 +122,70 @@ STREET_BUDGET_CHANNELS = {
     "gsv": "gsv_streets",
     "mapillary": "mapillary_streets",
 }
+
+
+@dataclass(frozen=True)
+class StreetCostModel:
+    """
+    How one provider's road walk is PRICED and what one request is called.
+
+    ``unit`` is the noun printed by ``--estimate`` and by the run summary;
+    ``estimate`` is the bbox-driven cost floor, or None for a provider billed
+    one request per on-street sample point.
+
+    None is the meaningful distinction, not a missing value: a per-point
+    provider's cost scales with ``--spacing`` and a census provider's does not
+    (it sweeps the frozen bbox and joins locally), so the two are different
+    cost SHAPES rather than two numbers.
+    """
+
+    unit: str
+    estimate: Callable[[float, float, float, float, float], int] | None
+
+
+# Provider -> cost model, keyed by the SAME tokens as STREET_BUDGET_CHANNELS.
+#
+# A TABLE, not a chain of `if provider == "gsv" ... else <mapillary>` (issue
+# #268). Four of those arms existed, and every one of them made `else` mean
+# Mapillary: the --estimate text, the --daily-budget pre-flight, the collector
+# dispatch and the summary's unit label. All four are unreachable today because
+# argparse gates --provider on STREET_BUDGET_CHANNELS -- and all four would go
+# live, silently and simultaneously, the moment a third key is added there
+# (#258 has to add "kartaview" for --provider kartaview to be accepted at all).
+#
+# The failure was not a crash but a plausible success: a KartaView walk fetched
+# from tiles.mapillary.com under a KartaView token, priced with the tile cost
+# model, and published under a kartaview filename -- an immutable dated snapshot
+# carrying another provider's data, the exact class CLAUDE.md's filename
+# contract exists to prevent. Same shape as the `_collect_one_run` chain PR #263
+# closed on the grid side.
+#
+# test_street_cost_models_cover_every_budget_channel asserts set EQUALITY, so
+# adding a channel without a cost model is a red test rather than a Mapillary
+# walk wearing another provider's name.
+STREET_COST_MODELS: dict[str, StreetCostModel] = {
+    "gsv": StreetCostModel(unit="GSV queries", estimate=None),
+    "mapillary": StreetCostModel(unit="Mapillary tile requests", estimate=estimate_tile_count),
+}
+
+
+def street_cost_model(provider: str) -> StreetCostModel:
+    """
+    This provider's cost model, or a loud failure.
+
+    Raises rather than defaulting, for the reason the table above exists: every
+    default here is some other provider's cost model, and applying one silently
+    misprices a walk instead of stopping it.
+    """
+    try:
+        return STREET_COST_MODELS[provider]
+    except KeyError:
+        raise ValueError(
+            f"No street cost model for provider {provider!r}. Add one to "
+            f"STREET_COST_MODELS beside its STREET_BUDGET_CHANNELS entry."
+        ) from None
+
+
 DEFAULT_PROVIDER = "gsv"
 DEFAULT_SPACING_M = 15
 
@@ -198,20 +264,25 @@ def run_collect(args: argparse.Namespace) -> int:
 
         if args.estimate:
             # Dry run: no key, no API calls — just report the work + cost.
-            # Only GSV bills per sample location; Mapillary reads a tile census
-            # whose size is set by the city's area, not by the sample count.
+            # Which of the two cost SHAPES applies comes from the provider's
+            # StreetCostModel, not from naming a provider here: a per-point
+            # provider bills per sample location, a census provider reads a
+            # sweep of the frozen bbox whose size is set by the city's area and
+            # not by the sample count (so --spacing does not move it).
+            model = street_cost_model(provider)
             cached = _cached_census_marker(city, provider, args)
             if cached is not None:
                 cost = (
-                    f"0 Mapillary tile requests (cached census fetched by "
+                    f"0 {model.unit} (cached census fetched by "
                     f"{cached.get('fetched_by')}, crawl started "
                     f"{cached.get('crawl_started_at')})"
                 )
+            elif model.estimate is None:
+                cost = f"{len(query_points)} unique {model.unit}"
             else:
                 cost = (
-                    f"{len(query_points)} unique GSV queries"
-                    if provider == "gsv"
-                    else f"~{estimate_tile_count(city.center_lat, city.center_lon, city.grid_width_m, city.grid_height_m, city.step_m)} Mapillary tile requests (independent of spacing)"
+                    f"~{model.estimate(city.center_lat, city.center_lon, city.grid_width_m, city.grid_height_m, city.step_m)}"
+                    f" {model.unit} (independent of spacing)"
                 )
             print(
                 f"{city.city_id} [{args.network_type}]: {len(edges)} edges, "
@@ -315,19 +386,19 @@ def run_collect(args: argparse.Namespace) -> int:
         # "cost" and deliberately not about "will validate"; an entry the
         # collector then rejects costs a re-fetch that was not budgeted, which
         # is the safe direction (the ledger still records what was spent).
-        estimated_requests = (
-            len(query_points)
-            if provider == "gsv"
-            else 0
-            if _cached_census_marker(city, provider, args) is not None
-            else estimate_tile_count(
+        model = street_cost_model(provider)
+        if model.estimate is None:
+            estimated_requests = len(query_points)
+        elif _cached_census_marker(city, provider, args) is not None:
+            estimated_requests = 0
+        else:
+            estimated_requests = model.estimate(
                 city.center_lat,
                 city.center_lon,
                 city.grid_width_m,
                 city.grid_height_m,
                 city.step_m,
             )
-        )
         if args.daily_budget is not None:
             already = db.get_api_usage(conn, run_date, provider=budget_channel)
             if already + estimated_requests > args.daily_budget:
@@ -363,7 +434,7 @@ def run_collect(args: argparse.Namespace) -> int:
                         max_requests_per_minute=args.max_requests_per_minute,
                     )
                 )
-            else:
+            elif provider == "mapillary":
                 dict_results = asyncio.run(
                     collect_mapillary_street_samples_async(
                         query_points,
@@ -380,6 +451,20 @@ def run_collect(args: argparse.Namespace) -> int:
                         checkpoint_variant=args.network_type,
                         census_cache=census_cache,
                     )
+                )
+            else:
+                # Unreachable while argparse gates --provider on
+                # STREET_BUDGET_CHANNELS, and that is the point: this arm is
+                # what makes ADDING a key safe. Before #268 it read `else:
+                # <mapillary>`, so a new provider's first walk would have gone
+                # to tiles.mapillary.com carrying that provider's token and
+                # been published under that provider's filename -- a plausible
+                # success, not a crash. Raise instead, so wiring a channel
+                # without a collector stops the walk rather than mislabelling
+                # one. street_cost_model() guards the same seam for pricing.
+                raise ValueError(
+                    f"No street collector for provider {provider!r}. Add a dispatch "
+                    f"arm here beside its STREET_BUDGET_CHANNELS entry."
                 )
         except Exception as e:
             # Failed crawls still spent real requests; record them so a later
@@ -553,7 +638,7 @@ def run_collect(args: argparse.Namespace) -> int:
             if totals["coverage_pct_by_length_any"] == totals["coverage_pct_by_length"]
             else f", {totals['coverage_pct_by_length_any']}% including flat imagery"
         )
-        unit = "GSV queries" if provider == "gsv" else "Mapillary tile requests"
+        unit = street_cost_model(provider).unit
         print(
             f"{city.city_id} [streetwalk {provider}/{args.network_type} {run_date}]: "
             f"{len(samples)} samples over {totals['edges']} edges "

--- a/streetscape_street_analyzer/collect_kartaview.py
+++ b/streetscape_street_analyzer/collect_kartaview.py
@@ -1,0 +1,238 @@
+"""
+KartaView road-walk sample collection (issue #258).
+
+KartaView, like Mapillary, publishes no per-sample-point endpoint. Its census is
+a paginated **radius sweep** of overlapping circles over the frozen grid bbox,
+so a KartaView "walk" is not a walk of requests at all: it is one sweep plus a
+purely local spatial join onto the same deterministic on-street sample points
+the GSV walk queries one at a time. The join itself lives in
+:mod:`census_walk`; this module supplies the provider half.
+
+Three consequences worth holding onto:
+
+  * **Cost is bbox area, not sample count.** A KartaView street collection costs
+    what a KartaView grid run costs -- the swept-circle lattice over the frozen
+    bbox -- which is independent of ``--spacing`` (pinned by a test) but not of
+    city size: a catalog median of 12 root cells against a max of 4,500.
+  * **On a paired night it costs NOTHING.** The census cache (#290) keys on
+    (provider, city, bbox) with no channel, variant or date in it, so the grid
+    run's sweep minutes earlier is this walk's census for zero requests -- and
+    a second ``--network-type`` is free on top of that. This is the whole reason
+    the walk is affordable at all; see :func:`checkpointing.crawl_store_for`.
+  * **Comparability.** Every provider's walk scores the SAME sample points from
+    the same frozen OSM network, so ``coverage_pct_by_length`` is directly
+    comparable across providers -- unlike raw pano counts, which are census vs.
+    sample (see the provider model in CLAUDE.md).
+
+The output is a METADATA-schema snapshot, one row per unique sample location,
+exactly like the GSV and Mapillary collectors' -- so everything downstream
+(``compute_streetwalk_coverage``, the coverage GeoJSON, the catalog row, the
+manifest, the frontend) is shared, not duplicated. streets.html renders a
+KartaView walk the moment one reaches the manifest, with no frontend change.
+"""
+
+from __future__ import annotations
+
+import gzip
+import logging
+import os
+from datetime import UTC, datetime
+from typing import Any
+
+import pandas as pd
+
+from streetscape_metadata_tracker.census import census_is_pano
+from streetscape_metadata_tracker.checkpointing import CensusCache, observation_timestamp
+from streetscape_metadata_tracker.download_kartaview import (
+    DEFAULT_SWEEP_REQUESTS_PER_MINUTE,
+    _kartaview_capture_dates,
+    _points_in_cells,
+    build_empty_rows,
+    build_image_rows,
+    fetch_city_images_async,
+    grid_bbox,
+)
+from streetscape_metadata_tracker.fileutils import load_city_csv_file
+from streetscape_street_analyzer.census_walk import CensusWalkSpec
+from streetscape_street_analyzer.census_walk import (
+    build_streetwalk_rows as census_walk_rows,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# KartaView's binding of the shared census→walk scorer (issue #258).
+#
+# The date rule is the one genuinely divergent piece, and it is the reason #257
+# had to land first: KartaView serves ingest timestamps as capture dates for
+# part of its catalog, so `shot_date >= date_added` is rejected -- `>=`, not `>`
+# -- which makes NO_DATE a LARGE population here by construction rather than a
+# rare edge. An undated pano still covers; it simply ages nothing.
+KARTAVIEW_WALK = CensusWalkSpec(
+    capture_dates_for=_kartaview_capture_dates,
+    build_image_rows=build_image_rows,
+    build_empty_rows=build_empty_rows,
+)
+
+
+def build_streetwalk_rows(
+    query_points: list[tuple[float, float, int, int]],
+    census: pd.DataFrame,
+    match_dist_m: float,
+    query_timestamp: str,
+    unmeasured_mask=None,
+) -> pd.DataFrame:
+    """
+    Score KartaView census images against the walk's sample points.
+
+    A thin binding of :func:`census_walk.build_streetwalk_rows`; the contract
+    and the status vocabulary are documented there. Kept as a named function on
+    this module rather than a bare partial so the collector below resolves it as
+    a module global, which is what lets a test substitute it to simulate a tail
+    failure after the sweep is already paid for.
+    """
+    return census_walk_rows(
+        query_points,
+        census,
+        match_dist_m,
+        query_timestamp,
+        KARTAVIEW_WALK,
+        unmeasured_mask=unmeasured_mask,
+    )
+
+
+async def collect_kartaview_street_samples_async(
+    query_points: list[tuple[float, float, int, int]],
+    city,
+    access_token: str,
+    output_csv_gz_path: str,
+    match_dist_m: float,
+    request_timeout: float = 30,
+    max_requests_per_minute: int = DEFAULT_SWEEP_REQUESTS_PER_MINUTE,
+    max_requests: int | None = None,
+    checkpoint_path: str | None = None,
+    checkpoint_channel: str | None = None,
+    checkpoint_variant: str | None = None,
+    census_cache: CensusCache | None = None,
+) -> dict[str, Any]:
+    """
+    Collect KartaView street samples for a city and write the snapshot csv.gz.
+
+    Returns the same contract as ``download_gsv.collect_points_async`` (``df``,
+    ``filename_with_path``, ``api_requests``, ``started_at``, ``finished_at``)
+    plus ``num_flat_images``, so ``collect.py`` treats every provider
+    identically after the download step -- and ``api_requests_total`` (the
+    sweep's spend across resumes, for the ``street_walks`` row) and
+    ``checkpoint_path`` (the caller's to discard once that row is committed).
+
+    ``api_requests`` is THIS PROCESS's spend and ``api_requests_total`` is the
+    sweep's across every resume. They are different numbers and the distinction
+    is load-bearing: ``db.add_api_usage`` is additive and keyed by (date,
+    provider), so a resumed walk reporting the whole sweep would charge last
+    night's requests against tonight's budget gate.
+
+    The census is fetched over the city's **frozen grid bbox** -- the same bbox
+    the grid run sweeps -- which is what lets the two share a cache entry and
+    makes this walk free on a paired night.
+    """
+    started_at = datetime.now(UTC).isoformat()
+    if not output_csv_gz_path.endswith(".csv.gz"):
+        raise ValueError(f"output_csv_gz_path must end in .csv.gz, got: {output_csv_gz_path}")
+    os.makedirs(os.path.dirname(os.path.abspath(output_csv_gz_path)), exist_ok=True)
+
+    bbox = grid_bbox(
+        city.center_lat, city.center_lon, city.grid_width_m, city.grid_height_m, city.step_m
+    )
+    fetched = await fetch_city_images_async(
+        city.display_name,
+        bbox,
+        access_token,
+        request_timeout=request_timeout,
+        max_requests_per_minute=max_requests_per_minute,
+        max_requests=max_requests,
+        checkpoint_path=checkpoint_path,
+        checkpoint_channel=checkpoint_channel,
+        checkpoint_variant=checkpoint_variant,
+        census_cache=census_cache,
+    )
+    # A reused census is stamped with when the provider was observed, a fresh
+    # one with this process's clock; see checkpointing.observation_timestamp.
+    query_timestamp = observation_timestamp(fetched, started_at)
+    failed_cells = fetched.get("failed_cells") or []
+    # THE TAIL IS WRAPPED BECAUSE THE CHECKPOINT CHANGES WHAT A CRASH HERE COSTS
+    # (#239/#256). Without one, a failure below lost the spend with the process
+    # and the caller recorded whatever the exception carried. With one, the
+    # checkpoint survives complete and the NEXT invocation re-finalizes it for
+    # ZERO requests — so a tail failure that carried no spend would land this
+    # sweep's requests in no api_usage row, EVER. That is the gap PR #251 closed
+    # for the KartaView grid run; the walk needs it for the same reason.
+    try:
+        # pop, not [] — `fetched` is a live local until this function returns, so
+        # indexing it would keep the whole census resident past the `del` below,
+        # through the join, the row build and the CSV write.
+        census = fetched.pop("census")
+        num_flat_images = int((~census_is_pano(census)).sum())
+        logger.info(
+            "%s: %d KartaView images (%d panos, %d flat) from %d cells → scoring %d sample points",
+            city.city_id,
+            len(census),
+            len(census) - num_flat_images,
+            num_flat_images,
+            fetched.get("cells_visited") or 0,
+            len(query_points),
+        )
+
+        df = build_streetwalk_rows(
+            query_points,
+            census,
+            match_dist_m,
+            query_timestamp,
+            # A cell nothing came back for leaves its samples UNKNOWN rather
+            # than empty, exactly as the grid run does; a clean sweep passes
+            # None and pays nothing. Street coverage is a share of SAMPLES, so
+            # publishing an unswept sample as ZERO_RESULTS would read as
+            # measured emptiness and understate the city in an immutable dated
+            # snapshot. The sweep refuses to finalize past
+            # MAX_FAILED_AREA_FRACTION, so this only ever describes a small
+            # remainder.
+            unmeasured_mask=(
+                (lambda lats, lons: _points_in_cells(lats, lons, failed_cells))
+                if failed_cells
+                else None
+            ),
+        )
+        del census
+        # Straight into the gzip handle: to_csv() with no path builds the whole CSV
+        # as a str and then a second copy as bytes, which at a big city's sample
+        # count is pure duplication of a file being written out anyway (issue #157).
+        with gzip.open(output_csv_gz_path, "wt", encoding="utf-8", newline="") as f:
+            df.to_csv(f, index=False)
+
+        # Read back through the shared loader so dtypes match the GSV path exactly.
+        df = load_city_csv_file(output_csv_gz_path)
+    except BaseException as e:
+        e.api_requests = fetched["api_requests"]
+        e.api_requests_total = fetched["api_requests_total"]
+        raise
+    return {
+        "df": df,
+        "filename_with_path": output_csv_gz_path,
+        # This process's spend, for the additive daily ledger; the cumulative
+        # figure below is for the street_walks row (#239's rule, #290's census).
+        "api_requests": fetched["api_requests"],
+        "api_requests_total": fetched["api_requests_total"],
+        "checkpoint_path": fetched.get("checkpoint_path"),
+        "census_fetched_by": fetched.get("census_fetched_by"),
+        "census_fetched_at": fetched.get("census_fetched_at"),
+        "census_reused": bool(fetched.get("census_reused")),
+        "num_flat_images": num_flat_images,
+        "started_at": started_at,
+        "finished_at": datetime.now(UTC).isoformat(),
+    }
+
+
+__all__ = [
+    "KARTAVIEW_WALK",
+    "build_streetwalk_rows",
+    "collect_kartaview_street_samples_async",
+]

--- a/streetscape_street_analyzer/collect_mapillary.py
+++ b/streetscape_street_analyzer/collect_mapillary.py
@@ -36,11 +36,9 @@ import os
 from datetime import UTC, datetime
 from typing import Any
 
-import geopandas as gpd
 import numpy as np
 import pandas as pd
 
-from streetscape_metadata_tracker.analysis import FLAT_ONLY
 from streetscape_metadata_tracker.census import census_is_pano
 from streetscape_metadata_tracker.checkpointing import CensusCache, observation_timestamp
 from streetscape_metadata_tracker.download_mapillary import (
@@ -51,116 +49,34 @@ from streetscape_metadata_tracker.download_mapillary import (
     captured_at_to_iso_dates,
     fetch_city_images_async,
     grid_bbox,
-    status_for_capture_dates,
 )
 from streetscape_metadata_tracker.fileutils import load_city_csv_file
+from streetscape_street_analyzer.census_walk import CensusWalkSpec
+from streetscape_street_analyzer.census_walk import (
+    build_streetwalk_rows as census_walk_rows,
+)
 
 logger = logging.getLogger(__name__)
 
 WGS84 = "EPSG:4326"
 
-# Sample points per sjoin_nearest call. The join's peak memory is driven by the
-# match set it materializes, so a big city (hundreds of thousands of samples
-# against a multi-million-image census) is chunked rather than joined in one go.
-# Purely a memory knob — the result is identical at any block size, since each
-# sample's nearest image is decided independently.
-_JOIN_CHUNK_SIZE = 50_000
+
+# Mapillary's binding of the shared census→walk scorer (issue #258).
+#
+# The join, the pano-beats-flat rule and the OK/NO_DATE/FLAT_ONLY/ZERO_RESULTS
+# vocabulary all live in census_walk now; what is left here is the one piece
+# that genuinely differs -- Mapillary stores capture time as epoch milliseconds
+# -- plus this module's own output-schema bindings.
+def _mapillary_capture_dates(census: pd.DataFrame, positions: np.ndarray):
+    """ISO capture dates for those census rows, from Mapillary's epoch ms."""
+    return captured_at_to_iso_dates(census["captured_at_ms"].to_numpy()[positions]).to_numpy()
 
 
-def nearest_images_to_samples(
-    query_points: list[tuple[float, float, int, int]],
-    census: pd.DataFrame,
-    match_dist_m: float,
-) -> tuple[np.ndarray, np.ndarray]:
-    """
-    For each sample location, the nearest 360° pano and the nearest flat image
-    within ``match_dist_m``.
-
-    Uses ``gpd.sjoin_nearest`` on the local UTM CRS — the same idiom the
-    grid-attribution path uses to match panos to edges (street_coverage.py), so
-    distances are true metres rather than degree approximations. Panos and
-    flats are joined separately because they answer different questions: 360°
-    coverage and any-imagery coverage (issue #116's distinction, applied to
-    streets).
-
-    The samples run through the join in ``_JOIN_CHUNK_SIZE`` blocks rather than
-    one call. Now that ``mapillary_streets`` is scheduled across the whole
-    catalog, a dense city pairs a multi-million-image census with a few hundred
-    thousand sample points, and a single join materializes the whole match set
-    at once. Chunking bounds peak memory at the census plus one block's matches;
-    it cannot change the result, because a sample never spans two blocks and the
-    nearest-image choice is per sample.
-
-    Args:
-        query_points: ``(lat, lon, seq, _)`` tuples from
-            ``road_sampling.dedupe_query_points``.
-        census: the columnar Mapillary census (``fetch_city_images_async``).
-        match_dist_m: max sample-to-image distance in metres.
-
-    Returns:
-        ``(pano_positions, flat_positions)`` — two int arrays as long as
-        ``query_points``, holding the census position of the nearest qualifying
-        image per sample and ``-1`` where nothing is in range. Positions rather
-        than image records: Colorado Springs pairs 360k samples with a 6.5M
-        image census, and a dict of per-sample image dicts is a copy of the
-        census the arrays do not need (issue #157).
-    """
-    n_samples = len(query_points)
-    none_matched = np.full(n_samples, -1, dtype=np.int64)
-    if not n_samples or not len(census):
-        return none_matched, none_matched.copy()
-
-    samples_gdf = gpd.GeoDataFrame(
-        {"sample_idx": range(n_samples)},
-        geometry=gpd.points_from_xy([p[1] for p in query_points], [p[0] for p in query_points]),
-        crs=WGS84,
-    )
-    # A city's sample points span a single UTM zone in every realistic case;
-    # estimate_utm_crs picks it from the sample extent.
-    metric_crs = samples_gdf.estimate_utm_crs()
-    samples_m = samples_gdf.to_crs(metric_crs)
-
-    def _join(positions: np.ndarray) -> np.ndarray:
-        matches = np.full(n_samples, -1, dtype=np.int64)
-        if not len(positions):
-            return matches
-        # image_idx carries the position in the FULL census, not in this
-        # subset, so the caller can index the census directly.
-        # Built once, outside the chunk loop: the census is the same for every
-        # block, and reprojecting it per block would dominate the runtime.
-        images_gdf = gpd.GeoDataFrame(
-            {"image_idx": positions},
-            geometry=gpd.points_from_xy(
-                census["lon"].to_numpy()[positions], census["lat"].to_numpy()[positions]
-            ),
-            crs=WGS84,
-        ).to_crs(metric_crs)
-
-        for start in range(0, len(samples_m), _JOIN_CHUNK_SIZE):
-            block = samples_m.iloc[start : start + _JOIN_CHUNK_SIZE]
-            joined = gpd.sjoin_nearest(
-                block,
-                images_gdf,
-                how="inner",
-                max_distance=match_dist_m,
-                distance_col="dist_m",
-            )
-            # sjoin_nearest emits every tied nearest neighbour; keep the closest
-            # single image per sample so each sample yields exactly one row.
-            joined = joined.sort_values("dist_m").drop_duplicates("sample_idx", keep="first")
-            matches[joined["sample_idx"].to_numpy()] = joined["image_idx"].to_numpy()
-        return matches
-
-    # Through census_is_pano, not census["is_pano"].to_numpy(): a provider is
-    # free to declare the column nullable (KartaView's projection is decoded to
-    # a plain bool today, but both OUTPUT schemas use pd.BooleanDtype()), and a
-    # single null degrades .to_numpy() to an object array on which `~` raises --
-    # after the whole paced tile fetch is spent. Same reason the grid tail reads
-    # it there -- and this function in particular is the one a second census
-    # provider reuses verbatim (it touches only lon/lat/is_pano); its neighbour
-    # build_streetwalk_rows is Mapillary-specific and will have to be generalized.
-    is_pano = census_is_pano(census)
-    return _join(np.flatnonzero(is_pano)), _join(np.flatnonzero(~is_pano))
+MAPILLARY_WALK = CensusWalkSpec(
+    capture_dates_for=_mapillary_capture_dates,
+    build_image_rows=build_image_rows,
+    build_empty_rows=build_empty_rows,
+)
 
 
 def build_streetwalk_rows(
@@ -170,65 +86,15 @@ def build_streetwalk_rows(
     query_timestamp: str,
 ) -> pd.DataFrame:
     """
-    Score every sample location against the census into METADATA rows.
+    Score Mapillary census images against the walk's sample points.
 
-    Exactly one row per sample, in ``query_points`` order. Status vocabulary
-    matches the grid downloader exactly (issue #116):
-
-      * ``OK`` / ``NO_DATE`` — a 360° pano is in range (NO_DATE when its
-        contributor timestamp is unusable), which is what 360° street coverage
-        counts.
-      * ``FLAT_ONLY`` — no pano in range but flat/perspective imagery is. A
-        presence marker with a **null capture_date**, so flat timestamps never
-        enter a dated statistic; counts only toward any-imagery coverage.
-      * ``ZERO_RESULTS`` — no imagery of any kind in range.
+    A thin binding of :func:`census_walk.build_streetwalk_rows`; the contract
+    and the status vocabulary are documented there. Kept as a named function on
+    this module rather than a bare partial so the collector below still resolves
+    it as a module global -- which is what lets a test substitute it to simulate
+    a tail failure after the census is already paid for.
     """
-    pano_positions, flat_positions = nearest_images_to_samples(query_points, census, match_dist_m)
-    sample_lats = np.array([p[0] for p in query_points], dtype=np.float64)
-    sample_lons = np.array([p[1] for p in query_points], dtype=np.float64)
-
-    has_pano = pano_positions >= 0
-    # A pano wins wherever there is one; a flat only speaks for samples no pano
-    # reached, which is exactly what makes the row FLAT_ONLY rather than OK.
-    matched = has_pano | (flat_positions >= 0)
-    chosen = np.where(has_pano, pano_positions, flat_positions)
-
-    matched_idx = np.flatnonzero(matched)
-    capture_dates = np.full(len(matched_idx), None, dtype=object)
-    pano_of_matched = has_pano[matched_idx]
-    capture_dates[pano_of_matched] = captured_at_to_iso_dates(
-        census["captured_at_ms"].to_numpy()[chosen[matched_idx][pano_of_matched]]
-    ).to_numpy()
-    # status_for_capture_dates is evaluated over every matched row, including
-    # the flat ones whose capture_date is None — those transiently read "OK"
-    # (None != "") and are then overridden by the outer where. Kept whole-array
-    # rather than masked so the OK/NO_DATE rule has exactly one statement,
-    # shared with the grid downloader; a flat row's status never escapes it.
-    status = np.where(~pano_of_matched, FLAT_ONLY, status_for_capture_dates(capture_dates))
-    image_rows = build_image_rows(
-        census,
-        chosen[matched_idx],
-        sample_lats[matched_idx],
-        sample_lons[matched_idx],
-        query_timestamp,
-        status,
-        capture_dates,
-    )
-
-    empty_idx = np.flatnonzero(~matched)
-    if not len(empty_idx):
-        return image_rows
-    empty_rows = build_empty_rows(
-        sample_lats[empty_idx],
-        sample_lons[empty_idx],
-        query_timestamp,
-        "ZERO_RESULTS",
-    )
-    # Restore sample order: the two frames were built by kind, not by position.
-    combined = pd.concat([image_rows, empty_rows], ignore_index=True)
-    return combined.iloc[
-        np.argsort(np.concatenate([matched_idx, empty_idx]), kind="stable")
-    ].reset_index(drop=True)
+    return census_walk_rows(query_points, census, match_dist_m, query_timestamp, MAPILLARY_WALK)
 
 
 async def collect_mapillary_street_samples_async(

--- a/tests/test_census.py
+++ b/tests/test_census.py
@@ -345,6 +345,51 @@ def test_the_mapillary_names_are_bindings_of_the_generic_ones():
     assert dm.status_for_capture_dates is census.status_for_capture_dates
 
 
+@pytest.mark.parametrize("missing", ["", None, np.nan, pd.NaT])
+def test_every_spelling_of_a_missing_date_is_no_date(missing):
+    """
+    '' is the in-repo convention and every current parser emits it, but this is
+    the guard a NEW census provider binds against through
+    CensusWalkSpec.capture_dates_for -- and `None != ""` is True, so a guard
+    testing only the empty string scores a null date as OK.
+
+    That is not a cosmetic difference: the row counts as covered, its NO_DATE
+    is lost, and the pair goes into an immutable dated snapshot. Undated
+    imagery arrives in batches, so a provider whose dates silently vanished
+    would publish full coverage that ages nothing and read as a property of the
+    data rather than as a bug.
+    """
+    assert list(census.status_for_capture_dates([missing])) == ["NO_DATE"]
+
+
+def test_a_real_date_beside_every_missing_spelling_still_reads_ok():
+    """
+    The positive half: a guard that answered NO_DATE unconditionally would pass
+    the test above and lose every date in the catalog.
+    """
+    dates = ["2024-01-01", "", None, "2019-06-30", np.nan]
+    assert list(census.status_for_capture_dates(dates)) == [
+        "OK",
+        "NO_DATE",
+        "NO_DATE",
+        "OK",
+        "NO_DATE",
+    ]
+
+
+def test_the_string_fast_path_is_not_dragged_through_the_null_check():
+    """
+    A parser's output is a fixed-width string array, which cannot hold None at
+    all -- so the null check is skipped for it. Pinned because this runs once
+    per census row (#157's memory contract) and the object-dtype conversion
+    that would make it total unconditionally is the kind of cost that gets
+    added quietly.
+    """
+    dates = np.asarray(["2024-01-01", ""])
+    assert dates.dtype != object, "a parser hands in a string array, not object"
+    assert list(census.status_for_capture_dates(dates)) == ["OK", "NO_DATE"]
+
+
 # ── the grid run: a census becomes a run CSV ───────────────────────────────
 #
 # write_census_grid_run is the ~150-line back half every census provider needs:

--- a/tests/test_claude_md_router.py
+++ b/tests/test_claude_md_router.py
@@ -197,6 +197,34 @@ def test_the_router_and_the_experiments_readme_name_the_same_writeups():
         )
 
 
+def test_every_credential_channel_appears_in_the_routers_credentials_table():
+    """
+    The credentials table is rule-bearing: it is where a session learns which
+    env var a channel reads, and #258's `kartaview_streets` shipped without a
+    row -- while being the one street channel whose credential behaviour
+    DIFFERS from its siblings (it falls back to KARTAVIEW_ACCESS_TOKEN rather
+    than requiring its own key). A missing row is worse than no table, because
+    the four rows that are there read as complete.
+
+    Set equality against the code, following
+    test_every_scheduled_channel_declares_its_per_ip_hosts: adding a channel
+    without documenting it fails here, and so does documenting one that no
+    longer exists.
+    """
+    from streetscape_metadata_tracker.config import CHANNEL_ENV_VARS
+
+    text = _ROUTER.read_text(encoding="utf-8")
+    documented = dict(re.findall(r"^\| `([a-z_]+)` \| `([A-Z_]+)`", text, re.MULTILINE))
+    assert set(documented) == set(CHANNEL_ENV_VARS), (
+        "every credential channel needs a row in CLAUDE.md's credentials table"
+    )
+    for channel, env_var in documented.items():
+        assert env_var == CHANNEL_ENV_VARS[channel][0], (
+            f"the table says {channel} reads {env_var}, the code reads "
+            f"{CHANNEL_ENV_VARS[channel][0]} first"
+        )
+
+
 def test_no_doc_writes_a_long_flag_with_an_underscore():
     """Every argparse long option in this repo is hyphenated, so an underscore
     flag in the prose is always a typo -- and one copied out of CLAUDE.md fails

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,7 +1,13 @@
 """load_config tests — the function cli.py's both-provider fail-fast relies on."""
 
+import inspect
+import os
+import re
+from unittest import mock
+
 import pytest
 
+from streetscape_metadata_tracker import config
 from streetscape_metadata_tracker.config import load_config, warn_if_credentials_world_readable
 
 
@@ -57,6 +63,54 @@ def test_load_config_empty_credential_raises(monkeypatch, provider, env_var):
     monkeypatch.setenv(env_var, "")
     with pytest.raises(ValueError, match=env_var):
         load_config(provider)
+
+
+def test_load_config_reads_no_env_var_outside_the_declared_table():
+    """
+    CHANNEL_ENV_VARS is only worth having if it cannot drift from the if-chain
+    it describes -- and that chain is a sequence of `if provider == ...` blocks
+    with no enumerable form, which is how #258 added a channel that no table
+    mentioned.
+
+    So: read the source and assert every credential variable load_config
+    actually reaches for is declared. Adding a channel then fails HERE (and in
+    the router's credentials-table test) until it is written down.
+    """
+    source = inspect.getsource(config.load_config)
+    read = set(re.findall(r'os\.environ\.get\("([A-Z_]+)"\)', source))
+    declared = {var for variables in config.CHANNEL_ENV_VARS.values() for var in variables}
+    assert read == declared
+
+
+@pytest.mark.parametrize("channel", sorted(config.CHANNEL_ENV_VARS))
+def test_every_declared_channel_loads_from_its_own_variable(channel):
+    """
+    The other direction: a declared channel must be one load_config accepts,
+    reading the variable the table names first. Pinned per channel so a typo in
+    the table is a named failure rather than a KeyError somewhere downstream.
+    """
+    primary = config.CHANNEL_ENV_VARS[channel][0]
+    with mock.patch.dict(os.environ, {primary: "SENTINEL"}, clear=True):
+        loaded = config.load_config(channel)
+    assert "SENTINEL" in loaded.values()
+
+
+def test_the_kartaview_walk_falls_back_but_prefers_its_own_token():
+    """
+    The one declared fallback, in both directions. It exists because a KartaView
+    walk and grid run are serialized by one machine-wide host lock, so there is
+    no parallel quota burn to isolate -- but an operator who DOES set a separate
+    token must get it, or the isolation they asked for silently does nothing.
+    """
+    with mock.patch.dict(os.environ, {"KARTAVIEW_ACCESS_TOKEN": "SHARED"}, clear=True):
+        assert config.load_config("kartaview_streets")["access_token"] == "SHARED"
+
+    with mock.patch.dict(
+        os.environ,
+        {"KARTAVIEW_ACCESS_TOKEN": "SHARED", "KARTAVIEW_STREETS_ACCESS_TOKEN": "OWN"},
+        clear=True,
+    ):
+        assert config.load_config("kartaview_streets")["access_token"] == "OWN"
 
 
 def test_load_config_unknown_provider_raises():

--- a/tests/test_kartaview_collector.py
+++ b/tests/test_kartaview_collector.py
@@ -2794,6 +2794,227 @@ def test_the_sweeps_own_channel_re_probes_its_failed_cells_rather_than_inheritin
     assert not (tmp_path / "cp-grid").exists()
 
 
+def test_a_walks_own_refinalize_carries_the_sweep_it_paid_for(monkeypatch, tmp_path):
+    """
+    The variant counterpart of the re-finalize test above, and the one the grid
+    run cannot cover: the grid run's variant is None, so a promotion that
+    hardcoded ``fetched_variant=None`` was correct for it and wrong for every
+    walk.
+
+    same_crawl compares the PAIR, so a walk stamping None writes
+    ("kartaview_streets", None) and later asks ("kartaview_streets", "drive")
+    -- its own entry, unrecognised. The row then prices a sweep it paid for at
+    0 while census_fetched_by names itself as the payer, a row that contradicts
+    itself, and it under-reports spend against the one host that meters by IP.
+    """
+    cache = _cache(tmp_path)
+    walk, walk_calls = _sweep_cached(
+        monkeypatch,
+        _photos,
+        cache,
+        channel="kartaview_streets",
+        checkpoint_variant="drive",
+        path=tmp_path / "cp-walk",
+    )
+    assert walk_calls, "the walk paid for it"
+    assert load_census_cache_marker(cache)["fetched_variant"] == "drive", (
+        "the marker must record WHICH crawl paid, not just which channel"
+    )
+
+    refinalize, calls = _sweep_cached(
+        monkeypatch,
+        _photos,
+        cache,
+        channel="kartaview_streets",
+        checkpoint_variant="drive",
+        path=tmp_path / "cp-walk-again",
+    )
+    assert calls == [], "the entry is its own; nothing is re-asked"
+    assert refinalize["api_requests"] == 0, "this process issued none"
+    assert refinalize["api_requests_total"] == len(walk_calls), (
+        "a walk coming back to write its row must still price the collection"
+    )
+    assert refinalize["census_fetched_by"] == "kartaview_streets"
+
+
+def test_the_other_variant_of_one_channel_is_a_reuse_not_a_refinalize(monkeypatch, tmp_path):
+    """
+    The discrimination the pair exists for, and the thing a fix that compared
+    only the CHANNEL would break: `drive` and `all_public` are two walks of one
+    city in one channel, so channel equality would price the second walk's
+    collection at the first's cost -- double-counting one sweep across two
+    catalog rows.
+    """
+    cache = _cache(tmp_path)
+    drive, drive_calls = _sweep_cached(
+        monkeypatch,
+        _photos,
+        cache,
+        channel="kartaview_streets",
+        checkpoint_variant="drive",
+        path=tmp_path / "cp-drive",
+    )
+    assert drive_calls
+
+    broad, calls = _sweep_cached(
+        monkeypatch,
+        _photos,
+        cache,
+        channel="kartaview_streets",
+        checkpoint_variant="all_public",
+        path=tmp_path / "cp-all-public",
+    )
+    assert calls == [], "the census is the same observation; it is free"
+    assert broad["api_requests"] == 0
+    assert broad["api_requests_total"] == 0, "this walk did not pay for that sweep"
+    assert broad["census_fetched_by"] == "kartaview_streets"
+
+
+def test_the_walks_own_variant_re_probes_its_failed_cells_rather_than_inheriting_them(
+    monkeypatch, tmp_path, caplog
+):
+    """
+    The variant counterpart of the own-channel re-probe. reconcile_cache_hit's
+    "hand the crawl's own entry back so the resume re-probes it" branch is
+    gated on same_crawl, so a walk whose marker said None never took it: its
+    own refusals would be inherited verbatim for the whole 7-day window and --
+    with #258's unmeasured_mask -- republished as REQUEST_FAILED holes in every
+    walk snapshot across it. A refusal is time-varying; a channel never
+    inherits its own holes.
+    """
+    seen = []
+
+    def one_bad_cell(call):
+        seen.append(call)
+        if len(seen) == 1:
+            raise kv.ResponseError("HTTP 500")
+        return _photos(call)
+
+    monkeypatch.setattr(kv, "MAX_FAILED_AREA_FRACTION", 0.9)
+    cache = _cache(tmp_path)
+    walk, _ = _sweep_cached(
+        monkeypatch,
+        one_bad_cell,
+        cache,
+        channel="kartaview_streets",
+        checkpoint_variant="drive",
+        path=tmp_path / "cp-walk",
+        retries=0,
+    )
+    assert len(walk["failed_cells"]) == 1
+
+    with caplog.at_level(logging.WARNING):
+        again, calls = _sweep_cached(
+            monkeypatch,
+            _photos,
+            cache,
+            channel="kartaview_streets",
+            checkpoint_variant="drive",
+            path=tmp_path / "cp-walk",
+        )
+    assert calls, "the failed cell was re-asked"
+    assert "re-probes them" in caplog.text
+    assert again["failed_cells"] == []
+    assert load_census_cache_marker(cache)["failed"] == []
+
+    # ...while the OTHER variant, which is a genuine reuse, still inherits it.
+    cache_two = _cache(tmp_path / "cache-two")
+    walk_two, _ = _sweep_cached(
+        monkeypatch,
+        one_bad_cell,
+        cache_two,
+        channel="kartaview_streets",
+        checkpoint_variant="drive",
+        path=tmp_path / "cp-drive-two",
+        retries=0,
+    )
+    seen.clear()
+    broad, broad_calls = _sweep_cached(
+        monkeypatch,
+        _photos,
+        cache_two,
+        channel="kartaview_streets",
+        checkpoint_variant="all_public",
+        path=tmp_path / "cp-all-public-two",
+    )
+    assert broad_calls == [], "a different crawl republishes the observation as it stands"
+    assert broad["failed_cells"] == walk_two["failed_cells"]
+
+
+def test_a_checkpoint_from_another_variant_of_this_channel_is_discarded(monkeypatch, tmp_path):
+    """
+    The channel guard's blind spot once one channel has two walks of a city.
+    `drive` and `all_public` meter into the SAME ledger, so the channel check
+    passes and every geometric check passes too -- they sweep the identical
+    frozen bbox at the same ipp and radius. Only the variant separates them,
+    and resuming across it would price this crawl with the other one's
+    requests. Mirrors download_mapillary.load_tile_checkpoint, whose record has
+    carried the variant since #256.
+    """
+    ckpt = tmp_path / "sweep"
+    _failed_sweep_ckpt(
+        monkeypatch,
+        _empty,
+        ckpt,
+        max_requests=2,
+        checkpoint_channel="kartaview_streets",
+        checkpoint_variant="drive",
+    )
+    assert _state(ckpt)["variant"] == "drive", "the commit record stores which crawl wrote it"
+
+    result, calls = _sweep_ckpt(
+        monkeypatch,
+        _empty,
+        ckpt,
+        checkpoint_channel="kartaview_streets",
+        checkpoint_variant="all_public",
+    )
+    assert len(calls) == result["cells"], "another variant's checkpoint must sweep afresh"
+    assert result["api_requests_total"] == len(calls), "no spend inherited across crawls"
+    assert _state(ckpt)["variant"] == "all_public"
+
+    ckpt_two = tmp_path / "sweep2"
+    _failed_sweep_ckpt(
+        monkeypatch,
+        _empty,
+        ckpt_two,
+        max_requests=2,
+        checkpoint_channel="kartaview_streets",
+        checkpoint_variant="drive",
+    )
+    result, calls = _sweep_ckpt(
+        monkeypatch,
+        _empty,
+        ckpt_two,
+        checkpoint_channel="kartaview_streets",
+        checkpoint_variant="drive",
+    )
+    assert len(calls) == result["cells"] - 2, "the matching variant still resumes"
+
+
+def test_a_checkpoint_written_before_variants_existed_still_resumes_the_grid_run(
+    monkeypatch, tmp_path
+):
+    """
+    Every KartaView checkpoint on prod today was written by the grid run, whose
+    variant is None, and none of them carry the key. `state.get("variant")`
+    reads None for exactly those, which is what the grid run asks for -- so the
+    field arrives without discarding a single in-flight sweep. A guard that
+    compared a MISSING key against None wrongly would re-sweep every enrolled
+    city mid-crawl.
+    """
+    ckpt = tmp_path / "sweep"
+    _failed_sweep_ckpt(monkeypatch, _empty, ckpt, max_requests=2, checkpoint_channel="kartaview")
+
+    state_path = ckpt / kv.CHECKPOINT_STATE_FILENAME
+    state = json.loads(state_path.read_text())
+    del state["variant"]
+    state_path.write_text(json.dumps(state))
+
+    result, calls = _sweep_ckpt(monkeypatch, _empty, ckpt, checkpoint_channel="kartaview")
+    assert len(calls) == result["cells"] - 2, "a pre-variant record still resumes"
+
+
 def test_the_promoted_checkpoint_is_not_left_behind_for_the_caller_to_discard(
     monkeypatch, tmp_path
 ):

--- a/tests/test_streetwalk_collect.py
+++ b/tests/test_streetwalk_collect.py
@@ -16,7 +16,7 @@ import geopandas as gpd
 import pytest
 from shapely.geometry import LineString
 
-from streetscape_metadata_tracker import db
+from streetscape_metadata_tracker import db, naming
 from streetscape_metadata_tracker import download_gsv as dg
 from streetscape_street_analyzer import collect
 
@@ -685,22 +685,31 @@ def test_street_cost_model_refuses_an_unmodelled_provider():
     """
     Raises rather than defaulting: every default here is some OTHER provider's
     cost model, which misprices a walk instead of stopping it.
+
+    A synthetic name, not a real provider. This test's whole subject is the
+    provider the table does NOT know about, so naming a real one dates it to
+    whichever provider happened to be unwired that week -- it was written with
+    'kartaview' and went green the moment #258 wired it, which is the failure
+    mode being avoided here.
     """
-    with pytest.raises(ValueError, match="No street cost model for provider 'kartaview'"):
-        collect.street_cost_model("kartaview")
+    with pytest.raises(ValueError, match="No street cost model for provider 'newprovider'"):
+        collect.street_cost_model("newprovider")
 
 
 def test_dispatch_refuses_a_provider_with_no_collector(tmp_path, monkeypatch, caplog):
     """
     The arm that matters most, driven through the REAL flow.
 
-    Before #268 this was `else: <mapillary>`, so a KartaView walk would have
-    fetched from tiles.mapillary.com carrying a KartaView token and been
-    published under a kartaview filename -- a plausible success, not a crash.
+    Before #268 this was `else: <mapillary>`, so a new provider's walk would
+    have fetched from tiles.mapillary.com carrying that provider's token and been
+    published under that provider's own filename -- a plausible success, not a
+    crash.
 
-    Reproduces the half-wired state #258 necessarily passes through: a budget
-    channel and a cost model exist (so argparse accepts --provider kartaview and
-    the pre-flight prices it) but no dispatch arm does. Mutating the
+    Reproduces the half-wired state a new provider necessarily passes through: a
+    budget channel and a cost model exist (so argparse accepts the flag and the
+    pre-flight prices it) but no dispatch arm does. Uses a SYNTHETIC provider
+    rather than a real one -- written against 'kartaview', it went green the
+    moment #258 wired that arm, testing nothing. Mutating the
     construction site rather than reading the shipped table, because a test over
     today's two providers would pass while `else` still meant Mapillary.
 
@@ -711,11 +720,17 @@ def test_dispatch_refuses_a_provider_with_no_collector(tmp_path, monkeypatch, ca
     artifact assertions below pin.
     """
     data_dir = _setup(tmp_path, monkeypatch)
-    monkeypatch.setitem(collect.STREET_BUDGET_CHANNELS, "kartaview", "kartaview_streets")
+    monkeypatch.setitem(collect.STREET_BUDGET_CHANNELS, "newprovider", "newprovider_streets")
+    # naming.KNOWN_PROVIDERS is a SECOND guard on this path and it fires first
+    # in the real flow -- generate_streetwalk_filename refuses a provider it has
+    # no token for, before the dispatch is reached. That layering is deliberate
+    # and worth stating, but it is not what this test is about, so widen it here
+    # to let the run get as far as the dispatch arm under test.
+    monkeypatch.setattr(naming, "KNOWN_PROVIDERS", (*naming.KNOWN_PROVIDERS, "newprovider"))
     monkeypatch.setitem(
         collect.STREET_COST_MODELS,
-        "kartaview",
-        collect.StreetCostModel(unit="KartaView sweep requests", estimate=lambda *a: 7),
+        "newprovider",
+        collect.StreetCostModel(unit="NewProvider requests", estimate=lambda *a: 7),
     )
     # The kartaview_streets channel has no config arm until #258; patch it so the
     # test fails at the DISPATCH rather than earlier, on credential loading.
@@ -723,14 +738,14 @@ def test_dispatch_refuses_a_provider_with_no_collector(tmp_path, monkeypatch, ca
 
     # Any call into the Mapillary collector is the defect itself, not a side effect.
     def boom(*a, **k):  # pragma: no cover - must never run
-        raise AssertionError("KartaView walk reached the MAPILLARY collector")
+        raise AssertionError("an unwired provider's walk reached the MAPILLARY collector")
 
     monkeypatch.setattr(collect, "collect_mapillary_street_samples_async", boom)
 
-    rc = collect.run_collect(_args(data_dir, provider="kartaview"))
+    rc = collect.run_collect(_args(data_dir, provider="newprovider"))
 
     assert rc == 1
-    assert "No street collector for provider 'kartaview'" in caplog.text
+    assert "No street collector for provider 'newprovider'" in caplog.text
     # Nothing was published under the kartaview name -- the failure this prevents
     # is an immutable dated snapshot carrying another provider's data.
-    assert not [f for f in os.listdir(data_dir) if "kartaview" in f]
+    assert not [f for f in os.listdir(data_dir) if "newprovider" in f]

--- a/tests/test_streetwalk_collect.py
+++ b/tests/test_streetwalk_collect.py
@@ -640,3 +640,97 @@ def test_an_ordinary_network_failure_still_exits_1(tmp_path, monkeypatch):
 
     with pytest.raises(DownloadError):
         collect.run_collect(_args(data_dir))
+
+
+# ── Provider dispatch is explicit, never gsv-or-else (issue #268) ────────────
+#
+# Four arms in collect.py used to read `if provider == "gsv" ... else <mapillary>`:
+# the --estimate text, the --daily-budget pre-flight, the collector dispatch and
+# the summary's unit label. All four are unreachable while argparse gates
+# --provider on STREET_BUDGET_CHANNELS -- and all four go live the instant a
+# third key is added there, which #258 has to do for `--provider kartaview` to
+# be accepted at all. These tests are what turn that addition into a red test
+# rather than a Mapillary walk published under another provider's name.
+
+
+def test_street_cost_models_cover_every_budget_channel():
+    """
+    Set EQUALITY, so a channel cannot be wired without a cost model.
+
+    Equality rather than a subset in either direction: a channel with no model
+    would be priced by whichever `else` arm caught it, and a model with no
+    channel is a cost model nothing can reach -- both are the drift this pins.
+    """
+    assert set(collect.STREET_COST_MODELS) == set(collect.STREET_BUDGET_CHANNELS)
+
+
+def test_every_street_provider_has_a_unit_and_a_declared_cost_shape():
+    """
+    A provider is billed per SAMPLE POINT or per BBOX SWEEP, and which one it is
+    has to be stated rather than defaulted.
+
+    `estimate is None` is meaningful (per-point, scales with --spacing), so the
+    test asserts the field is present and correctly shaped rather than truthy --
+    a `None` check alone would pass for a provider that simply forgot it.
+    """
+    for provider, model in collect.STREET_COST_MODELS.items():
+        assert isinstance(model.unit, str) and model.unit, provider
+        assert model.estimate is None or callable(model.estimate), provider
+    # The two shapes that exist today, pinned by name so a silent flip is caught.
+    assert collect.STREET_COST_MODELS["gsv"].estimate is None
+    assert callable(collect.STREET_COST_MODELS["mapillary"].estimate)
+
+
+def test_street_cost_model_refuses_an_unmodelled_provider():
+    """
+    Raises rather than defaulting: every default here is some OTHER provider's
+    cost model, which misprices a walk instead of stopping it.
+    """
+    with pytest.raises(ValueError, match="No street cost model for provider 'kartaview'"):
+        collect.street_cost_model("kartaview")
+
+
+def test_dispatch_refuses_a_provider_with_no_collector(tmp_path, monkeypatch, caplog):
+    """
+    The arm that matters most, driven through the REAL flow.
+
+    Before #268 this was `else: <mapillary>`, so a KartaView walk would have
+    fetched from tiles.mapillary.com carrying a KartaView token and been
+    published under a kartaview filename -- a plausible success, not a crash.
+
+    Reproduces the half-wired state #258 necessarily passes through: a budget
+    channel and a cost model exist (so argparse accepts --provider kartaview and
+    the pre-flight prices it) but no dispatch arm does. Mutating the
+    construction site rather than reading the shipped table, because a test over
+    today's two providers would pass while `else` still meant Mapillary.
+
+    Asserts rc == 1 rather than pytest.raises: the dispatch sits inside
+    run_collect's broad `except Exception`, so the guard surfaces as a refused
+    run with a logged traceback. That still delivers what the ordering needs --
+    no Mapillary traffic and no mislabelled artifact -- which is what the
+    artifact assertions below pin.
+    """
+    data_dir = _setup(tmp_path, monkeypatch)
+    monkeypatch.setitem(collect.STREET_BUDGET_CHANNELS, "kartaview", "kartaview_streets")
+    monkeypatch.setitem(
+        collect.STREET_COST_MODELS,
+        "kartaview",
+        collect.StreetCostModel(unit="KartaView sweep requests", estimate=lambda *a: 7),
+    )
+    # The kartaview_streets channel has no config arm until #258; patch it so the
+    # test fails at the DISPATCH rather than earlier, on credential loading.
+    monkeypatch.setattr(collect, "load_config", lambda ch: {"access_token": "KV-TOKEN"})
+
+    # Any call into the Mapillary collector is the defect itself, not a side effect.
+    def boom(*a, **k):  # pragma: no cover - must never run
+        raise AssertionError("KartaView walk reached the MAPILLARY collector")
+
+    monkeypatch.setattr(collect, "collect_mapillary_street_samples_async", boom)
+
+    rc = collect.run_collect(_args(data_dir, provider="kartaview"))
+
+    assert rc == 1
+    assert "No street collector for provider 'kartaview'" in caplog.text
+    # Nothing was published under the kartaview name -- the failure this prevents
+    # is an immutable dated snapshot carrying another provider's data.
+    assert not [f for f in os.listdir(data_dir) if "kartaview" in f]

--- a/tests/test_streetwalk_kartaview.py
+++ b/tests/test_streetwalk_kartaview.py
@@ -1,0 +1,419 @@
+"""End-to-end tests for the KARTAVIEW arm of the road-walk collector (#258).
+
+KartaView, like Mapillary, has no per-point metadata endpoint: a road walk reads
+the radius-sweep census once and joins it onto the same on-street sample points
+the GSV walk uses. These tests drive the real `collect.run_collect` flow with the
+OSM fetch and the sweep both served from memory, and assert the things that make
+this arm trustworthy in its own right rather than by analogy to Mapillary:
+
+  * one row per sample location, with the #116 status vocabulary and the
+    match-distance guard applied;
+  * requests metered under `kartaview_streets`, never `kartaview`;
+  * NO_DATE covering the street while ageing nothing -- KartaView's
+    `shot_date >= date_added -> NULL` rule makes this a LARGE population by
+    construction, which is why #257 was a hard prerequisite;
+  * the census cache (#290): on a paired night the grid run's sweep is this
+    walk's census for ZERO requests, which is what makes the arm affordable;
+  * a failed cell publishing REQUEST_FAILED rather than ZERO_RESULTS, so an
+    unswept sample is never recorded as measured emptiness;
+  * cost independent of sample spacing (the whole point of a census).
+"""
+
+import gzip
+import os
+from datetime import date
+
+import geopandas as gpd
+from shapely.geometry import LineString
+
+from streetscape_metadata_tracker import db
+from streetscape_metadata_tracker.checkpointing import census_cache_path_for
+from streetscape_metadata_tracker.download_common import grid_bbox
+from streetscape_metadata_tracker.download_kartaview import Cell, records_to_census
+from streetscape_metadata_tracker.naming import (
+    generate_streetwalk_filename,
+    streetwalk_coverage_filename,
+)
+from streetscape_street_analyzer import collect
+from streetscape_street_analyzer import collect_kartaview as ck
+
+# Same geometry as the GSV and Mapillary walk tests, so the three arms are
+# scored over an identical street network and their numbers are comparable.
+LONG_EDGE = LineString([(-121.30, 44.05), (-121.30, 44.052)])
+SHORT_EDGE = LineString([(-121.30, 44.052), (-121.30, 44.0525)])
+CITY_QUERY = "Bend, Oregon, United States"
+CITY_ID = "bend--oregon--united-states"
+RUN_DATE = "2026-07-08"
+
+
+def _edges():
+    return gpd.GeoDataFrame(
+        {"edge_id": ["1_2", "2_3"], "highway": ["residential", "service"], "length": [222.0, 55.0]},
+        geometry=[LONG_EDGE, SHORT_EDGE],
+        crs="EPSG:4326",
+    )
+
+
+def _image(image_id, lat, lon, *, is_pano=True, shot_date="2024-05-01", date_added="2024-06-01"):
+    """One decoded KartaView photo (decode_photo_items' shape).
+
+    `shot_date` before `date_added` is the DATED case. Passing a shot_date at or
+    after date_added is how a test reaches NO_DATE, because that is KartaView
+    serving an ingest timestamp as a capture date.
+    """
+    return {
+        "id": str(image_id),
+        "lat": lat,
+        "lon": lon,
+        "shot_date": shot_date,
+        "date_added": date_added,
+        "is_pano": is_pano,
+        "username": "OpenStreetView",
+        "sequence_id": "8312969",
+        "sequence_index": 1,
+        "field_of_view": 360.0 if is_pano else 90.0,
+        "compass_angle": 12.5,
+        "org_code": "CMNT",
+        "way_id": "627024267",
+    }
+
+
+def _setup(tmp_path, monkeypatch, images, *, api_requests=9, failed_cells=None, token=None):
+    """Data dir + catalog with one city; edges and the sweep served locally."""
+    data_dir = str(tmp_path)
+    conn = db.connect(db.get_default_db_path(data_dir))
+    db.register_city(
+        conn,
+        city_name="Bend",
+        state_name="Oregon",
+        state_code="OR",
+        country_name="United States",
+        country_code="US",
+        center_lat=44.05,
+        center_lon=-121.30,
+        grid_width_m=200,
+        grid_height_m=200,
+        step_m=20,
+    )
+    conn.close()
+    monkeypatch.setattr(collect, "fetch_street_edges", lambda *a, **k: _edges())
+
+    calls = {"n": 0}
+
+    async def fake_sweep(city_name, bbox, access_token, **kwargs):
+        calls["n"] += 1
+        calls["access_token"] = access_token
+        calls["checkpoint_path"] = kwargs.get("checkpoint_path")
+        calls["checkpoint_channel"] = kwargs.get("checkpoint_channel")
+        calls["checkpoint_variant"] = kwargs.get("checkpoint_variant")
+        calls["max_requests_per_minute"] = kwargs.get("max_requests_per_minute")
+        policy = kwargs.get("census_cache")
+        calls["cache_path"] = policy.path if policy else None
+        calls["reuse_census"] = policy.reuse if policy else None
+        return {
+            "census": records_to_census(images),
+            "api_requests": api_requests,
+            "api_requests_total": api_requests,
+            "checkpoint_path": kwargs.get("checkpoint_path"),
+            "cells_visited": 4,
+            "failed_cells": failed_cells or [],
+            "census_fetched_by": kwargs.get("checkpoint_channel"),
+            "census_fetched_at": None,
+            "census_reused": False,
+        }
+
+    monkeypatch.setattr(ck, "fetch_city_images_async", fake_sweep)
+    monkeypatch.setenv("KARTAVIEW_ACCESS_TOKEN", token or "KV-TESTTOKEN")
+    return data_dir, calls
+
+
+def _args(data_dir, **overrides):
+    argv = [
+        CITY_QUERY,
+        "--data-dir",
+        data_dir,
+        "--run-date",
+        RUN_DATE,
+        "--spacing",
+        "15",
+        "--provider",
+        "kartaview",
+    ]
+    for k, v in overrides.items():
+        argv += [f"--{k}", str(v)] if v is not True else [f"--{k}"]
+    return collect.build_parser().parse_args(argv)
+
+
+def _walk_csv(data_dir, network_type="drive"):
+    stem = generate_streetwalk_filename(
+        CITY_ID,
+        200,
+        200,
+        20,
+        15,
+        date.fromisoformat(RUN_DATE),
+        provider="kartaview",
+        network_type=network_type,
+    )
+    return os.path.join(data_dir, stem + ".csv.gz")
+
+
+def _rows(path):
+    with gzip.open(path, "rt") as f:
+        return f.read().splitlines()
+
+
+# ── The arm exists at all ────────────────────────────────────────────────────
+
+
+def test_kartaview_walk_writes_artifacts_and_meters_its_own_channel(tmp_path, monkeypatch):
+    """
+    The whole arm, end to end: the sweep is joined locally, both artifacts land
+    under the KARTAVIEW filename, and the spend is metered under
+    kartaview_streets rather than the grid channel it shares a token with.
+
+    The ledger assertion is the one that would go wrong silently: the walk and
+    the grid run use the same credential by design (see config.load_config), so
+    nothing about the request itself distinguishes them -- only the channel the
+    caller meters it under.
+    """
+    images = [_image("kv1", 44.0500, -121.30), _image("kv2", 44.0510, -121.30)]
+    data_dir, calls = _setup(tmp_path, monkeypatch, images, api_requests=9)
+
+    assert collect.run_collect(_args(data_dir)) == 0
+    assert calls["n"] == 1
+
+    csv_path = _walk_csv(data_dir)
+    assert os.path.exists(csv_path)
+    assert os.path.exists(
+        os.path.join(data_dir, streetwalk_coverage_filename(os.path.basename(csv_path)))
+    )
+    # One row per sample location, plus the header.
+    assert len(_rows(csv_path)) > 1
+
+    conn = db.connect(db.get_default_db_path(data_dir))
+    assert db.get_api_usage(conn, date.fromisoformat(RUN_DATE), provider="kartaview_streets") == 9
+    assert db.get_api_usage(conn, date.fromisoformat(RUN_DATE), provider="kartaview") == 0
+    conn.close()
+
+
+def test_the_walk_shares_the_grid_channels_token_by_default(tmp_path, monkeypatch):
+    """
+    KARTAVIEW_ACCESS_TOKEN alone is enough to run the walk -- unlike gsv_streets
+    and mapillary_streets, which refuse without their own credential.
+
+    Those two isolate a QUOTA that two processes could burn in parallel. Here
+    one machine-wide host lock serializes every KartaView request in the repo,
+    so there is no parallel spend to isolate, and requiring a second token would
+    only make the channel un-runnable. The override is still honoured, which the
+    next assertion pins.
+    """
+    data_dir, calls = _setup(tmp_path, monkeypatch, [_image("kv1", 44.05, -121.30)])
+    monkeypatch.delenv("KARTAVIEW_STREETS_ACCESS_TOKEN", raising=False)
+
+    assert collect.run_collect(_args(data_dir)) == 0
+    assert calls["access_token"] == "KV-TESTTOKEN"
+
+    # An explicit streets token wins where one is set.
+    monkeypatch.setenv("KARTAVIEW_STREETS_ACCESS_TOKEN", "KV-STREETS")
+    assert collect.run_collect(_args(data_dir, force=True)) == 0
+    assert calls["access_token"] == "KV-STREETS"
+
+
+# ── NO_DATE is a large population here, not an edge case (#257) ──────────────
+
+
+def test_undated_kartaview_panos_cover_the_street_but_age_nothing(tmp_path, monkeypatch):
+    """
+    The arm the Mapillary tests structurally under-exercise.
+
+    KartaView rejects a shot_date at or after its date_added -- that is an
+    ingest timestamp being served as a capture date -- so NO_DATE is a large
+    population BY CONSTRUCTION. Were the walk to count only OK, the provider
+    most honest about its dates would read as the one with the least coverage.
+
+    Covered, and contributing no age: both halves matter, and only the pair
+    distinguishes "counted correctly" from "counted as a dated pano".
+    """
+    # shot_date == date_added -> rejected (the rule is >=, not >).
+    undated = [_image("kv1", 44.0500, -121.30, shot_date="2024-06-01", date_added="2024-06-01")]
+    data_dir, _ = _setup(tmp_path, monkeypatch, undated)
+
+    assert collect.run_collect(_args(data_dir)) == 0
+    body = _rows(_walk_csv(data_dir))
+    header, rows = body[0], body[1:]
+    assert "NO_DATE" in "\n".join(rows), "an undated pano must still be recorded as present"
+
+    status_i = header.split(",").index("status")
+    date_i = header.split(",").index("capture_date")
+    no_date_rows = [r.split(",") for r in rows if r.split(",")[status_i] == "NO_DATE"]
+    assert no_date_rows, "fixture should produce at least one NO_DATE row"
+    for r in no_date_rows:
+        assert r[date_i] == "", "a NO_DATE row must carry no capture date"
+
+    conn = db.connect(db.get_default_db_path(data_dir))
+    covered, median_age = conn.execute(
+        "SELECT coverage_pct_by_length, median_covered_age_years FROM street_walks "
+        "WHERE provider = 'kartaview'"
+    ).fetchone()
+    conn.close()
+    # It covers...
+    assert covered > 0
+    # ...and ages nothing: no dated pano exists, so there is no median age.
+    assert median_age is None
+
+
+def test_a_dated_kartaview_pano_reads_OK_and_carries_its_shot_date(tmp_path, monkeypatch):
+    """
+    The other half of the date rule, and the half a NO_DATE-only test misses.
+
+    Found by mutation: replacing the whole capture_dates_for binding with one
+    that returns '' for every row -- i.e. reading the wrong column, or losing
+    KartaView's rule entirely -- left every other test in this file green,
+    because they only ever assert that an UNDATED pano is handled. A provider
+    whose dates all silently vanish would publish a full-coverage walk that ages
+    nothing, and read as a data property rather than a bug.
+
+    So this pins the positive case: shot_date strictly before date_added
+    survives as the capture date, the row is OK, and it reaches the age stat.
+    """
+    dated = [_image("kv1", 44.0500, -121.30, shot_date="2024-05-01", date_added="2024-06-01")]
+    data_dir, _ = _setup(tmp_path, monkeypatch, dated)
+
+    assert collect.run_collect(_args(data_dir)) == 0
+    body = _rows(_walk_csv(data_dir))
+    header = body[0].split(",")
+    status_i, date_i = header.index("status"), header.index("capture_date")
+    ok_rows = [r.split(",") for r in body[1:] if r.split(",")[status_i] == "OK"]
+    assert ok_rows, "a pano dated before its ingest timestamp must read OK, not NO_DATE"
+    assert all(r[date_i] == "2024-05-01" for r in ok_rows), (
+        "the SHOT date must survive to the row, not the ingest date or a blank"
+    )
+
+    conn = db.connect(db.get_default_db_path(data_dir))
+    median_age = conn.execute(
+        "SELECT median_covered_age_years FROM street_walks WHERE provider = 'kartaview'"
+    ).fetchone()[0]
+    conn.close()
+    # A dated pano ages: the complement of the NO_DATE test's `is None`.
+    assert median_age is not None and median_age > 0
+
+
+# ── The census cache is what makes this affordable (#290) ────────────────────
+
+
+def test_the_walk_reads_the_grid_runs_cache_entry(tmp_path, monkeypatch):
+    """
+    The cache path the walk asks for must be the one the GRID run writes:
+    keyed on (provider, city, bbox) with no channel, no variant and no date.
+
+    This is the whole cost argument for the arm. A channel-keyed path would
+    reuse nothing and every walk would re-sweep the city -- silently, since a
+    re-sweep produces the same census, just at full price.
+    """
+    data_dir, calls = _setup(tmp_path, monkeypatch, [_image("kv1", 44.05, -121.30)])
+    assert collect.run_collect(_args(data_dir)) == 0
+
+    conn = db.connect(db.get_default_db_path(data_dir))
+    city = db.resolve_city(conn, CITY_QUERY)
+    conn.close()
+    bbox = grid_bbox(
+        city.center_lat, city.center_lon, city.grid_width_m, city.grid_height_m, city.step_m
+    )
+
+    assert calls["cache_path"] == census_cache_path_for("kartaview", CITY_ID, bbox)
+    # The CHECKPOINT, by contrast, is the walk's own: it carries the channel and
+    # the network type, so the walk can never resume the grid run's sweep into
+    # the wrong ledger.
+    assert calls["checkpoint_channel"] == "kartaview_streets"
+    assert calls["checkpoint_variant"] == "drive"
+    assert "kartaview_streets" in calls["checkpoint_path"]
+
+
+def test_the_walks_variant_reaches_the_fetch(tmp_path, monkeypatch):
+    """
+    --network-type has to arrive at the sweep, not be assumed None.
+
+    'drive' and 'all_public' are different series over the SAME bbox in the SAME
+    channel, and the variant is what reconcile_cache_hit uses to tell a walk's
+    own prior work from the other variant's. Hardcoding None there had the two
+    walks reconcile against each other's checkpoints and inherit each other's
+    holes; the grid run passes None because it genuinely has no variant.
+    """
+    data_dir, calls = _setup(tmp_path, monkeypatch, [_image("kv1", 44.05, -121.30)])
+    assert collect.run_collect(_args(data_dir, **{"network-type": "all_public"})) == 0
+    assert calls["checkpoint_variant"] == "all_public"
+
+
+# ── An unswept sample is not an empty one ───────────────────────────────────
+
+
+def test_a_failed_cell_publishes_request_failed_not_zero_results(tmp_path, monkeypatch):
+    """
+    A cell the sweep never got back leaves its samples UNKNOWN.
+
+    Street coverage is a share of samples, so recording an unswept sample as
+    ZERO_RESULTS publishes an absence we never observed -- into an immutable
+    dated snapshot that understates the city permanently. The grid run has
+    always done this; the walk must too, or the two disagree about the same
+    unswept ground. (Mapillary's walk still has this gap: #259.)
+    """
+    # A SMALL cell over the north end of the long edge, so the run carries both
+    # kinds at once. A whole-city failed cell would be 100% REQUEST_FAILED,
+    # which detect_systemic_failure rejects outright (correctly -- that is a
+    # broken credential, not a coverage measurement), and would prove nothing
+    # about the discrimination this test is actually about. The real sweep
+    # refuses to finalize past MAX_FAILED_AREA_FRACTION for the same reason.
+    failed = [Cell(lat=44.0519, lon=-121.30, size_m=60.0)]
+    images = [_image("kv1", 44.0500, -121.30)]
+    data_dir, _ = _setup(tmp_path, monkeypatch, images, failed_cells=failed)
+
+    assert collect.run_collect(_args(data_dir)) == 0
+    body = _rows(_walk_csv(data_dir))
+    status_i = body[0].split(",").index("status")
+    statuses = [r.split(",")[status_i] for r in body[1:]]
+    assert "REQUEST_FAILED" in statuses, (
+        f"samples under an unswept cell must be REQUEST_FAILED, got {set(statuses)}"
+    )
+    # ...and the rest of the city, which WAS swept, still reads as measured.
+    assert {"ZERO_RESULTS", "OK"} & set(statuses), "only the unswept samples may be REQUEST_FAILED"
+
+
+def test_a_clean_sweep_still_publishes_zero_results(tmp_path, monkeypatch):
+    """
+    The other half of the pair: with no failed cells, an empty bbox is a
+    MEASURED absence and must read ZERO_RESULTS.
+
+    Without this, marking everything REQUEST_FAILED would pass the test above
+    while destroying the ordinary case -- the coverage denominator depends on
+    telling observed emptiness from unobserved ground.
+    """
+    data_dir, _ = _setup(tmp_path, monkeypatch, [], failed_cells=[])
+
+    assert collect.run_collect(_args(data_dir)) == 0
+    body = _rows(_walk_csv(data_dir))
+    statuses = {r.split(",")[body[0].split(",").index("status")] for r in body[1:]}
+    assert statuses == {"ZERO_RESULTS"}
+
+
+# ── Cost is bbox area, not sample count ─────────────────────────────────────
+
+
+def test_cost_is_independent_of_spacing(tmp_path, monkeypatch):
+    """
+    The defining property of a census arm, and the reason its --estimate text
+    says "independent of spacing": halving the spacing doubles the sample points
+    and changes the request count not at all.
+    """
+    images = [_image("kv1", 44.0500, -121.30)]
+    data_dir, calls = _setup(tmp_path, monkeypatch, images, api_requests=9)
+
+    assert collect.run_collect(_args(data_dir, spacing=15)) == 0
+    coarse = calls["n"]
+    assert collect.run_collect(_args(data_dir, spacing=5, force=True)) == 0
+
+    conn = db.connect(db.get_default_db_path(data_dir))
+    # Two collections, each 9 requests -- the sweep is paid per RUN, not per sample.
+    assert db.get_api_usage(conn, date.fromisoformat(RUN_DATE), provider="kartaview_streets") == 18
+    conn.close()
+    assert calls["n"] == coarse + 1

--- a/tests/test_streetwalk_kartaview.py
+++ b/tests/test_streetwalk_kartaview.py
@@ -28,8 +28,12 @@ from shapely.geometry import LineString
 
 from streetscape_metadata_tracker import db
 from streetscape_metadata_tracker.checkpointing import census_cache_path_for
-from streetscape_metadata_tracker.download_common import grid_bbox
-from streetscape_metadata_tracker.download_kartaview import Cell, records_to_census
+from streetscape_metadata_tracker.download_common import SWEEP_INCOMPLETE_EXIT_CODE, grid_bbox
+from streetscape_metadata_tracker.download_kartaview import (
+    Cell,
+    SweepIncompleteError,
+    records_to_census,
+)
 from streetscape_metadata_tracker.naming import (
     generate_streetwalk_filename,
     streetwalk_coverage_filename,
@@ -78,7 +82,9 @@ def _image(image_id, lat, lon, *, is_pano=True, shot_date="2024-05-01", date_add
     }
 
 
-def _setup(tmp_path, monkeypatch, images, *, api_requests=9, failed_cells=None, token=None):
+def _setup(
+    tmp_path, monkeypatch, images, *, api_requests=9, failed_cells=None, token=None, raises=None
+):
     """Data dir + catalog with one city; edges and the sweep served locally."""
     data_dir = str(tmp_path)
     conn = db.connect(db.get_default_db_path(data_dir))
@@ -107,6 +113,9 @@ def _setup(tmp_path, monkeypatch, images, *, api_requests=9, failed_cells=None, 
         calls["checkpoint_channel"] = kwargs.get("checkpoint_channel")
         calls["checkpoint_variant"] = kwargs.get("checkpoint_variant")
         calls["max_requests_per_minute"] = kwargs.get("max_requests_per_minute")
+        calls["max_requests"] = kwargs.get("max_requests")
+        if raises is not None:
+            raise raises
         policy = kwargs.get("census_cache")
         calls["cache_path"] = policy.path if policy else None
         calls["reuse_census"] = policy.reuse if policy else None
@@ -142,6 +151,25 @@ def _args(data_dir, **overrides):
     for k, v in overrides.items():
         argv += [f"--{k}", str(v)] if v is not True else [f"--{k}"]
     return collect.build_parser().parse_args(argv)
+
+
+def _paused_sweep(*, spent):
+    """A sweep that stopped with roots unvisited, as the request cap leaves it.
+
+    `api_requests` is attached by the collector's `spent` helper rather than
+    passed to __init__, so the fixture builds it the same way the real sweep
+    does -- otherwise the ledger assertion would pin a shape the collector
+    never produces.
+    """
+    error = SweepIncompleteError(
+        "stopped at the request cap",
+        checkpoint_path="/checkpoints/kv",
+        roots_done=3,
+        root_count=8,
+    )
+    error.api_requests = spent
+    error.api_requests_total = spent
+    return error
 
 
 def _walk_csv(data_dir, network_type="drive"):
@@ -328,6 +356,59 @@ def test_the_walk_reads_the_grid_runs_cache_entry(tmp_path, monkeypatch):
     assert calls["checkpoint_channel"] == "kartaview_streets"
     assert calls["checkpoint_variant"] == "drive"
     assert "kartaview_streets" in calls["checkpoint_path"]
+
+
+def test_the_request_cap_reaches_the_sweep_rather_than_only_the_budget_gate(tmp_path, monkeypatch):
+    """
+    --daily-budget only GATES: it is priced from estimate_sweep_requests, which
+    the estimator's own docstring calls a geometric FLOOR (measured overhead
+    1.80x; Yogyakarta ran 3.0x). So a gate that passes at 1,800 does not stop
+    the sweep spending 5,400 against a host that meters by IP and sends no
+    Retry-After. The cap is the enforceable half, and it has to reach the
+    sweep -- a flag parsed and dropped bounds nothing.
+
+    Asserted against a value that is not the default, so a call site that
+    hardcoded the default (or dropped the argument) still fails.
+    """
+    data_dir, calls = _setup(tmp_path, monkeypatch, [_image("kv1", 44.05, -121.30)])
+    assert collect.run_collect(_args(data_dir, **{"kartaview-max-requests": 500})) == 0
+    assert calls["max_requests"] == 500
+
+    # ...and unset stays unset, rather than a cap nobody asked for silently
+    # truncating a city's sweep into a permanent hole.
+    data_dir2, calls2 = _setup(tmp_path / "b", monkeypatch, [_image("kv1", 44.05, -121.30)])
+    assert collect.run_collect(_args(data_dir2)) == 0
+    assert calls2["max_requests"] is None
+
+
+def test_a_sweep_that_stops_at_its_cap_exits_83_rather_than_failing(tmp_path, monkeypatch):
+    """
+    Hitting the cap is PROGRESS: the work is checkpointed and the next run
+    resumes from it. Exit 83 is what says so.
+
+    Folding it into 1 would be worse than cosmetic. The scheduler amnesties 83
+    but counts a 1 as a consecutive_failure, and nothing but a success resets
+    that -- so a city too large to sweep in one night, which is exactly the
+    city the checkpoint exists for, would quarantine itself after five nights
+    of making steady progress.
+    """
+    data_dir, _ = _setup(
+        tmp_path,
+        monkeypatch,
+        [_image("kv1", 44.05, -121.30)],
+        raises=_paused_sweep(spent=500),
+    )
+    assert collect.run_collect(_args(data_dir, **{"kartaview-max-requests": 500})) == (
+        SWEEP_INCOMPLETE_EXIT_CODE
+    )
+    assert not os.path.exists(_walk_csv(data_dir)), "a paused sweep publishes nothing"
+
+    # The spend still reaches the ledger, or tomorrow's gate overspends by
+    # whatever a paused night cost.
+    conn = db.connect(db.get_default_db_path(data_dir))
+    spent = db.get_api_usage(conn, date.fromisoformat(RUN_DATE), provider="kartaview_streets")
+    conn.close()
+    assert spent == 500
 
 
 def test_the_walks_variant_reaches_the_fetch(tmp_path, monkeypatch):

--- a/tests/test_streetwalk_mapillary.py
+++ b/tests/test_streetwalk_mapillary.py
@@ -40,8 +40,7 @@ from streetscape_metadata_tracker.naming import (
     generate_streetwalk_filename,
     streetwalk_coverage_filename,
 )
-from streetscape_street_analyzer import collect
-from streetscape_street_analyzer import census_walk
+from streetscape_street_analyzer import census_walk, collect
 from streetscape_street_analyzer import collect_mapillary as cm
 from tests.conftest import stamp_census_cache
 

--- a/tests/test_streetwalk_mapillary.py
+++ b/tests/test_streetwalk_mapillary.py
@@ -41,6 +41,7 @@ from streetscape_metadata_tracker.naming import (
     streetwalk_coverage_filename,
 )
 from streetscape_street_analyzer import collect
+from streetscape_street_analyzer import census_walk
 from streetscape_street_analyzer import collect_mapillary as cm
 from tests.conftest import stamp_census_cache
 
@@ -502,6 +503,13 @@ def test_both_providers_can_walk_the_same_city_on_the_same_night(tmp_path, monke
 
 
 # --- The pure join helper ---------------------------------------------------
+#
+# The join moved to census_walk with #258 (it touches only lon/lat/is_pano, so
+# it was already provider-agnostic) and is addressed there now. The tests stay
+# here, driven by a real MAPILLARY census: the behaviours below -- closest of
+# each kind, chunk-invariance, empty inputs -- are properties of the join, and
+# exercising them against an actual provider census is what makes them evidence
+# rather than a restatement of the implementation.
 
 
 def _ids(census, positions):
@@ -516,7 +524,7 @@ def test_nearest_images_to_samples_picks_the_closest_of_each_kind():
     far_pano = _image("p_far", 44.05015, -121.3000)  # ~17 m away
     near_flat = _image("f_near", 44.050005, -121.3000, is_pano=False)
     census = records_to_census([far_pano, near_pano, near_flat])
-    panos, flats = cm.nearest_images_to_samples(samples, census, 25.0)
+    panos, flats = census_walk.nearest_images_to_samples(samples, census, 25.0)
     assert _ids(census, panos) == ["p_near"]
     assert _ids(census, flats) == ["f_near"]
 
@@ -540,11 +548,13 @@ def test_chunked_join_matches_a_single_shot_join(monkeypatch):
     match_dist = 5.0
     census = records_to_census(images)
 
-    monkeypatch.setattr(cm, "_JOIN_CHUNK_SIZE", 10_000)  # one block
-    whole_panos, whole_flats = cm.nearest_images_to_samples(samples, census, match_dist)
+    monkeypatch.setattr(census_walk, "_JOIN_CHUNK_SIZE", 10_000)  # one block
+    whole_panos, whole_flats = census_walk.nearest_images_to_samples(samples, census, match_dist)
 
-    monkeypatch.setattr(cm, "_JOIN_CHUNK_SIZE", 7)  # boundaries at 7, 14, 21
-    chunked_panos, chunked_flats = cm.nearest_images_to_samples(samples, census, match_dist)
+    monkeypatch.setattr(census_walk, "_JOIN_CHUNK_SIZE", 7)  # boundaries at 7, 14, 21
+    chunked_panos, chunked_flats = census_walk.nearest_images_to_samples(
+        samples, census, match_dist
+    )
 
     assert _ids(census, chunked_panos) == _ids(census, whole_panos)
     assert _ids(census, chunked_flats) == _ids(census, whole_flats)
@@ -556,10 +566,12 @@ def test_chunked_join_matches_a_single_shot_join(monkeypatch):
 
 def test_nearest_images_to_samples_handles_empty_inputs():
     one_image = records_to_census([_image("p", 44.05, -121.3)])
-    no_samples = cm.nearest_images_to_samples([], one_image, 25.0)
+    no_samples = census_walk.nearest_images_to_samples([], one_image, 25.0)
     assert all(len(m) == 0 for m in no_samples)
     # An empty census leaves every sample unmatched rather than raising.
-    no_images = cm.nearest_images_to_samples([(44.05, -121.3, 0, 0)], records_to_census([]), 25.0)
+    no_images = census_walk.nearest_images_to_samples(
+        [(44.05, -121.3, 0, 0)], records_to_census([]), 25.0
+    )
     assert all(list(m) == [-1] for m in no_images)
 
 


### PR DESCRIPTION
Closes #268 and #258. Three commits, in the order the issues require.

#257 — the NO_DATE walk-coverage prerequisite — turned out to be **already closed and complete** (2026-08-25), so the chain was shorter than planned.

> #268 is deliberately first: *"Within a single well-ordered PR that window never opens; if the config arm lands first, alone, or is split across PRs, it does."*

---

## 1. `04f766a` — dispatch made explicit (#268)

`collect.py` branched `if provider == "gsv" ... else` in four places and `else` meant Mapillary every time: the `--estimate` text, the `--daily-budget` pre-flight, the collector dispatch, the summary unit label. A **fifth** arrived with #290's cached-census branch, which the issue predates — it printed `0 Mapillary tile requests` for whichever provider got a cache hit.

Unreachable while `--provider` was gated on two keys; live the instant a third landed — which commit 3 does. Not a crash but a plausible success: the Mapillary collector called with `config["access_token"]`, which for `kartaview_streets` is a **KartaView** token — real traffic to `tiles.mapillary.com` with invalid auth — then published under a `kartaview` filename.

Now a `StreetCostModel` table keyed by the same tokens as `STREET_BUDGET_CHANNELS`, plus `if gsv / elif mapillary / else: raise`. **Mutation-verified**: restoring the Mapillary catch-all fails the test with `an unwired provider's walk reached the MAPILLARY collector`.

## 2. `91ac72b` — the scorer extracted to `census_walk.py`

`build_streetwalk_rows` lived in `collect_mapillary`, whose own comment said it *"is Mapillary-specific and will have to be generalized"*. It is now shared, parameterized by a `CensusWalkSpec`, for the reason `census.py` holds the grid pipeline once: the contracts it enforces are invisible in a review of a second copy.

`nearest_images_to_samples` moved **whole** rather than being parameterized — it touches only `lon`/`lat`/`is_pano`, which every census schema shares.

`CensusWalkSpec` carries exactly three fields. A fourth would be a claim that the *join* differs between providers, which is what the module exists to deny.

No behaviour change: 1872 passed before and after.

## 3. `79d6023` — the KartaView walk (#258)

`--provider kartaview`, metered under `kartaview_streets`. **`streets.html` needs no change** — the page fans out over the providers the manifest carries, so a KartaView walk renders as soon as one exists.

**Why it's affordable.** No per-sample endpoint; it reads the same sweep the grid run reads and joins locally. Since #290 the cache keys on `(provider, city, bbox)` — no channel, no variant, no date — so on a paired night the grid run's sweep *is* this walk's census for **zero requests**, and a second `--network-type` is free on top.

**`checkpoint_variant` threaded through the sweep.** `fetch_city_images_async` didn't expose it and the cache-hit reconcile hardcoded `variant=None`. Right for the grid run, wrong for a walk: `--network-type` is what separates two crawls of one city in one channel, so the `drive` walk would have reconciled against the `all_public` walk's checkpoint and inherited its holes.

**An unswept sample is not an empty one.** The walk passes `_points_in_cells` over `failed_cells`, as the grid run already does. Street coverage is a share of *samples*, so publishing an unswept sample as `ZERO_RESULTS` records an absence never observed into an immutable dated snapshot. This deliberately does **not** inherit the Mapillary walk's #259 gap — and makes #259 a one-liner whenever it's picked up.

**Credential falls back to `KARTAVIEW_ACCESS_TOKEN`**, unlike the two sibling street channels. Those isolate a quota two processes could burn in parallel; here one machine-wide `host_lock(HOST_KARTAVIEW)` serializes every KartaView request in the repo, so there is nothing to isolate — and a paired night spends nothing anyway. `KARTAVIEW_STREETS_ACCESS_TOKEN` still overrides.

## Mutation testing found two quiet tests

Both are in the PR because the suite was green and wrong:

- **Disabling `unmeasured_mask`** (i.e. inheriting #259) had to fail the failed-cell test. My first version used a whole-city failed cell — which `detect_systemic_failure` rightly **rejects** as a broken credential, proving nothing about the discrimination. It now carries both statuses in one run, with a companion test that a clean sweep still says `ZERO_RESULTS`.
- **Replacing the date binding so every date reads as undated passed all eight tests**, because they only asserted the NO_DATE case. A provider whose dates silently vanished would publish a full-coverage walk that ages nothing — and read as a data property, not a bug. The positive case is now pinned.

The #268 guard tests also moved off `kartaview` to a synthetic provider: written against a real one, they went green the moment commit 3 wired that arm. Reaching the dispatch needs `naming.KNOWN_PROVIDERS` widened too, which records that `naming.py` is a second guard firing first.

## Verification

`pytest` **1881 passed** / 1 skipped; `ruff check` and `ruff format --check` clean.

The e2e Playwright job failed on the earlier push with `AssertionError: 0 lit bars` — one of the two known flakes on that advisory job, from a Python-only change touching no frontend code.

## Not in scope

`kartaview_streets` is a **CLI budget channel, not yet a scheduled one** — no `[providers.kartaview_streets]` block, no `CHANNEL_DEFAULT_MEMBERSHIP` / `CHANNEL_HOSTS` entry. Scheduling it is a deliberate follow-up: the grid channel is opt-in (#248) and the walk should pair with it, which is a dueness question rather than a collector one.

🤖 Generated with [Claude Code](https://claude.com/claude-code) — Opus 5 (1M context), claude-opus-5[1m]
