### PR TITLE
Register 14 cities with documented Mapillary 360 capture programs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,7 @@ python -m streetscape_street_analyzer.collect "Seattle, WA" --network-type all_p
 # Worldwide sampling frame (docs/worldwide_sampling.md)
 python scripts/build_worldwide_frame.py
 python scripts/register_frame.py   # dry-run preview; --execute stays disabled until boundary-vetted
+python scripts/register_frame.py --manifest mapillary_360_cities.csv --overlap-km 5 --notes-label "mapillary 360 leaders"
 
 # Publish data/ to the UW Makeability Lab web server (rsync over SSH)
 ./sync_data_to_server.sh --dry-run
@@ -259,4 +260,6 @@ Keep any list a doc enumerates **alphabetical**, so two branches adding an entry
 - Runtime state that must never reach the public web server lives in gitignored siblings of `data/` — `archive/` (#176), `backups/` (#145), `census_cache/` (#290), `checkpoints/` (#239, #256), `locks/` (#208), `logs/` — and the publish rsync only walks `data/`, so anything there is structurally unpublishable.
 - Logs go to `logs/`, never `data/`, in three tiers: the scheduler's own rotating `streetscape_scheduler.log`; a per-attempt `collect_{city_id}_{channel}_{date}.log` holding one collection subprocess's full output (a failed child's last 25 lines are also copied into the scheduler log, whose tail is what the `[alerts]` email sends); and `streetscape_service_console.log`, the unit's `StandardOutput=append:` safety net for anything else.
 - The **worldwide frame** ([`docs/worldwide_sampling.md`](docs/worldwide_sampling.md)) is a stratified curated set (~56 cities: continent × size-band × GSV-coverage-regime) built deterministically from vendored GeoNames data (CC BY 4.0) in `data_sources/` (not rsynced, not git-ignored, unlike `data/`); GeoNames population is used only for binning, never as a reported variable.
+  Cities added for a specific reason (`mapillary_360_cities.csv`) get their OWN manifest in the same format, registered by the same script — never appended to `worldwide_frame.csv`, which must keep tracing to its generator, and never counted as frame cities.
+  Such a batch needs `--notes-label` (or every city claims to be a frame city in `cities.notes`) and `--overlap-km 5`, because the default 25 km reuse radius silently ALIASES a genuine neighbour away instead of registering it.
 - The sync-vs-async duplicate download path was removed in v2; the v1.0.0 tag preserves the old architecture.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,7 @@ python -m streetscape_street_analyzer.collect "Seattle, WA" --network-type all_p
 # Worldwide sampling frame (docs/worldwide_sampling.md)
 python scripts/build_worldwide_frame.py
 python scripts/register_frame.py   # dry-run preview; --execute stays disabled until boundary-vetted
-python scripts/register_frame.py --manifest mapillary_360_cities.csv --overlap-km 5 --notes-label "mapillary 360 leaders"
+python scripts/register_frame.py --manifest mapillary_360_cities.csv --overlap-km 5 --max-center-km 10 --center-from-geonames --notes-label "mapillary 360 leaders"
 
 # Publish data/ to the UW Makeability Lab web server (rsync over SSH)
 ./sync_data_to_server.sh --dry-run
@@ -262,4 +262,5 @@ Keep any list a doc enumerates **alphabetical**, so two branches adding an entry
 - The **worldwide frame** ([`docs/worldwide_sampling.md`](docs/worldwide_sampling.md)) is a stratified curated set (~56 cities: continent × size-band × GSV-coverage-regime) built deterministically from vendored GeoNames data (CC BY 4.0) in `data_sources/` (not rsynced, not git-ignored, unlike `data/`); GeoNames population is used only for binning, never as a reported variable.
   Cities added for a specific reason (`mapillary_360_cities.csv`) get their OWN manifest in the same format, registered by the same script — never appended to `worldwide_frame.csv`, which must keep tracing to its generator, and never counted as frame cities.
   Such a batch needs `--notes-label` (or every city claims to be a frame city in `cities.notes`) and `--overlap-km 5`, because the default 25 km reuse radius silently ALIASES a genuine neighbour away instead of registering it.
+  **Compute each grid BEFORE registering and read the offset from the GeoNames point** — geometry is frozen, and the default 50 km center guard caught none of the four bad matches in that batch (a wrong county 36 km away, and three administrative regions whose bbox midpoint sits 20–35 km off downtown).
 - The sync-vs-async duplicate download path was removed in v2; the v1.0.0 tag preserves the old architecture.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -31,6 +31,15 @@ already gone wrong once:
   The load-bearing pin is `test_run_row_carries_every_runs_column`: `_row_to_run` builds `RunRow(**dict(row))` from a `SELECT *`, so a column without a matching dataclass field is a `TypeError` on every `get_latest_run` against a migrated catalog, not a missing feature.
 - An end-to-end migration test with synthetic fixtures
 
+## City registration manifests (issue #110, and the purposive additions)
+
+`tests/test_register_frame.py` pins the bulk-registration safety rails — overlap reuse, `enabled = 0` until vetted, the GeoNames center guard against a province-centroid geocode, dry-run-by-default writing nothing, idempotent re-runs — with the geocoding seam monkeypatched, so no network.
+It pins `--notes-label` by MUTATING it rather than by asserting the default: a case that only read `cities.notes` after a default run would stay green while the flag was dropped on the floor, and that label is how the vetting and enable steps select one batch out of the catalog.
+
+`tests/test_mapillary_360_cities_manifest.py` IS the provenance of `mapillary_360_cities.csv`.
+The city list is curated, but its values are a GeoNames join keyed by `geonameid` and there is no generator script to name in a `generated_by`, so the test re-runs that join in reverse: city, admin, country, continent, population and coordinates must match the vendored records, and `query_string` must equal what `build_worldwide_frame.query_string` writes, so a query here behaves exactly like a frame query at the geocoder.
+The `city_id`s are pinned as **literals** deliberately — registration freezes them into filenames and published URLs, so a change in `db.derive_city_id` or `naming.sanitize_city_query_str` must break a test instead of quietly renaming a city — and the single deliberate departure from GeoNames' ASCII names (`Malmoe` -> `Malmo`) is a named constant rather than an unexplained mismatch.
+
 ## `--provider` is a channel list (issue #247)
 
 `tests/test_cli_policy.py` pins the grid CLI's `--provider` flag, and (issue #290) the CLI seam of the census cache: the downloader is handed one `CensusCache` policy built by `crawl_store_for` — its path keyed on the PROVIDER (KartaView gets its own, gsv gets none), `reuse` False only under `--refetch-census` and untouched by `--force`, and the run's `run_date` riding along so a backdated snapshot refuses an entry observed after it; the `runs` row records who paid and when, a gsv run leaves both NULL, and a reused census says so in the printed summary.

--- a/docs/worldwide_sampling.md
+++ b/docs/worldwide_sampling.md
@@ -194,6 +194,21 @@ Two things differ from a frame registration:
 The values in a purposive manifest are still a GeoNames join keyed by `geonameid`, not hand-typed coordinates; `tests/test_mapillary_360_cities_manifest.py` re-runs that join and is the file's provenance, since there is no generator script to name.
 It also pins the permanent `city_id`s as literals and records the one deliberate departure from GeoNames' ASCII names (`Malmoe` -> `Malmo`, because the slug outlives the spelling in filenames and published URLs).
 
+**Vet before registering, not after.** For a batch this size the cheapest vetting is to compute the geometry registration *would* freeze — `get_city_location_data` -> `resolve_center` -> `get_search_dimensions` -> `cap_dimensions`, the same four calls `register_frame_city` makes — and read two numbers per city: the grid dimensions, and the distance from the geocoded center to the manifest's GeoNames coordinates.
+That offset is the tell, and on the 2026-08-31 batch it found four cities the `--max-center-km` guard would have waved through at its default of 50 km:
+
+| City | What Nominatim matched | Offset | Fix |
+|---|---|---|---|
+| Sandusky OH | `Sandusky County, Ohio` — a *different* county, ~36 km west of the city (which is in Erie County) | 36.1 km | query override |
+| Melbourne | Greater Melbourne (153x122 km) | 34.7 km | `--center-from-geonames` |
+| Dar es Salaam | Dar es Salaam Region (102x69 km), midpoint offshore-ward | 22.6 km | `--center-from-geonames` |
+| Ottawa | the amalgamated, mostly rural City of Ottawa (87x64 km) | 19.7 km | `--center-from-geonames` |
+
+The nine cities that were fine all sat within 5.5 km, so `--max-center-km 10 --center-from-geonames` separates the two groups exactly: it recenters an over-large administrative match onto the GeoNames downtown point (the grid is clamped to 40 km/side anyway) and leaves every good geocode alone.
+That does NOT fix a *wrong-feature* match, whose dimensions come from the wrong polygon — for those, override the geocode query in the manifest (`Sandusky, Erie County, Ohio, United States`) and keep identity on the GeoNames columns, so the frozen `city_id` is unchanged.
+The same override handles the opposite failure, a match that is too SMALL: "Brussels" resolves to the City of Brussels commune (8.7x13.1 km), about a fifth of the 19-commune Brussels-Capital Region, and `Bruxelles-Capitale, Belgium` resolves to the region (16.8x16.7 km).
+`get_city_location_data` restricts structured search to settlement types, so an override phrased as a region name may match a museum instead — always re-run the four calls on the override before committing it.
+
 Vetting is the same requirement as for the frame, but the full audit chain is disproportionate for a handful of cities: read the registered rectangles back out of `cities`, and for anything that looks wrong render it with `streetscape_tracker.py "<query>" --check-boundary` and correct it with `scripts/resize_city.py` (safe only while the city has no runs).
 The trap for these cities is the opposite of the province centroid the `--max-center-km` guard catches: several have a *tiny* core municipality as their OSM boundary — the City of Brussels and the City of Melbourne LGA are both a few km across inside metros many times larger.
 

--- a/docs/worldwide_sampling.md
+++ b/docs/worldwide_sampling.md
@@ -95,8 +95,8 @@ Running `python scripts/build_worldwide_frame.py` writes (repo root):
 - `cities_worldwide.txt` — `run_cities.py`/`streetscape_tracker.py`-compatible query
   lines (double-quoted so names with apostrophes survive shlex parsing).
 - `worldwide_frame.csv` — the selected frame, one row per city, with
-  `query_string, city, iso2, country, continent, size_band, population,
-  coverage_regime, geonameid, lat, lon`. This is the manifest for the paper and
+  `query_string, city, admin, iso2, country, continent, size_band,
+  population, coverage_regime, geonameid, lat, lon`. This is the manifest for the paper and
   the input to `scripts/register_frame.py`.
 - `worldwide_candidates.csv` — the full ranked eligible-country pool, so a city
   that fails boundary vetting can be swapped for an alternate without
@@ -178,6 +178,24 @@ scheduler host (makelab2), after the merged code is deployed there.
 3. **Enable in the scheduler.** Set the vetted cities `enabled = 1`. Provider
    enablement stays global (both GSV and Mapillary); the scheduler staggers the
    cities over its cycle.
+
+## Purposive additions (non-frame manifests)
+
+The frame is a *stratified sample*, so it deliberately does not contain every city we might want.
+Cities added for a specific reason live in their own manifest in the same format, registered by the same script — never appended to `worldwide_frame.csv`, which is the deterministic output of `build_worldwide_frame.py` and must keep tracing to it.
+
+- `mapillary_360_cities.csv` (2026-08-31, 14 cities) — cities with a documented city-scale Mapillary 360° capture program that the catalog did not already track: BikeOttawa, Kaart in Melbourne, the Lithuanian Road Administration (Vilnius), Ramani Huria (Dar es Salaam), Mapillary's own showcase municipalities (Clovis NM, Johns Creek GA, and Sandusky as the seat of Erie County OH), Mapillary's home city (Malmo), and the CompleteTheMap Europe target cities Prague, Copenhagen, Munich, Milan, Barcelona and Brussels.
+
+Two things differ from a frame registration:
+
+- **Label the batch**: `--notes-label "mapillary 360 leaders"` writes that into `cities.notes`, so the vetting and enable steps can select exactly this batch and a later reader can tell where a city came from. Without it every registered city claims to be a frame city.
+- **Shrink the overlap radius**: `--overlap-km 5`, not the default 25. The default exists to catch one physical city registered twice under different slugs, and at 25 km it also swallows genuine neighbours — Johns Creek sits 16 km from the already-registered Sugar Hill GA, and Sandusky 17 km from Kelleys Island OH, so both would have been *aliased away* instead of registered. Always read the dry run's `reused-existing` count before `--execute`.
+
+The values in a purposive manifest are still a GeoNames join keyed by `geonameid`, not hand-typed coordinates; `tests/test_mapillary_360_cities_manifest.py` re-runs that join and is the file's provenance, since there is no generator script to name.
+It also pins the permanent `city_id`s as literals and records the one deliberate departure from GeoNames' ASCII names (`Malmoe` -> `Malmo`, because the slug outlives the spelling in filenames and published URLs).
+
+Vetting is the same requirement as for the frame, but the full audit chain is disproportionate for a handful of cities: read the registered rectangles back out of `cities`, and for anything that looks wrong render it with `streetscape_tracker.py "<query>" --check-boundary` and correct it with `scripts/resize_city.py` (safe only while the city has no runs).
+The trap for these cities is the opposite of the province centroid the `--max-center-km` guard catches: several have a *tiny* core municipality as their OSM boundary — the City of Brussels and the City of Melbourne LGA are both a few km across inside metros many times larger.
 
 ## Refreshing the frame
 

--- a/mapillary_360_cities.csv
+++ b/mapillary_360_cities.csv
@@ -7,9 +7,9 @@ query_string,city,admin,iso2,country,continent,size_band,population,coverage_reg
 "Munich, Bavaria, Germany",Munich,Bavaria,DE,Germany,EU,,1505005,,2867714,48.13743,11.57549
 "Milan, Lombardy, Italy",Milan,Lombardy,IT,Italy,EU,,1371498,,3173435,45.46427,9.18951
 "Barcelona, Catalonia, Spain",Barcelona,Catalonia,ES,Spain,EU,,1686208,,3128760,41.38879,2.15899
-"Brussels, Belgium",Brussels,Brussels Capital,BE,Belgium,EU,,1019022,,2800866,50.85045,4.34878
+"Bruxelles-Capitale, Belgium",Brussels,Brussels Capital,BE,Belgium,EU,,1019022,,2800866,50.85045,4.34878
 "Malmo, Skane, Sweden",Malmo,Skane,SE,Sweden,EU,,362133,,2692969,55.60587,13.00073
 "Dar es Salaam, Tanzania",Dar es Salaam,Dar es Salaam Region,TZ,Tanzania,AF,,5383728,,160263,-6.82349,39.26951
 "Clovis, New Mexico, United States",Clovis,New Mexico,US,United States,NA,,39480,,5462393,34.4048,-103.20523
 "Johns Creek, Georgia, United States",Johns Creek,Georgia,US,United States,NA,,83335,,6331909,34.02893,-84.19858
-"Sandusky, Ohio, United States",Sandusky,Ohio,US,United States,NA,,25212,,5170691,41.44894,-82.70796
+"Sandusky, Erie County, Ohio, United States",Sandusky,Ohio,US,United States,NA,,25212,,5170691,41.44894,-82.70796

--- a/mapillary_360_cities.csv
+++ b/mapillary_360_cities.csv
@@ -1,0 +1,15 @@
+query_string,city,admin,iso2,country,continent,size_band,population,coverage_regime,geonameid,lat,lon
+"Ottawa, Ontario, Canada",Ottawa,Ontario,CA,Canada,NA,,1017449,,6094817,45.41117,-75.69812
+"Melbourne, Victoria, Australia",Melbourne,Victoria,AU,Australia,OC,,5435590,,2158177,-37.814,144.96332
+"Vilnius, Lithuania",Vilnius,Vilnius,LT,Lithuania,EU,,542366,,593116,54.68916,25.2798
+"Prague, Czechia",Prague,Prague,CZ,Czechia,EU,,1165581,,3067696,50.08804,14.42076
+"Copenhagen, Capital Region, Denmark",Copenhagen,Capital Region,DK,Denmark,EU,,1153615,,2618425,55.67594,12.56553
+"Munich, Bavaria, Germany",Munich,Bavaria,DE,Germany,EU,,1505005,,2867714,48.13743,11.57549
+"Milan, Lombardy, Italy",Milan,Lombardy,IT,Italy,EU,,1371498,,3173435,45.46427,9.18951
+"Barcelona, Catalonia, Spain",Barcelona,Catalonia,ES,Spain,EU,,1686208,,3128760,41.38879,2.15899
+"Brussels, Belgium",Brussels,Brussels Capital,BE,Belgium,EU,,1019022,,2800866,50.85045,4.34878
+"Malmo, Skane, Sweden",Malmo,Skane,SE,Sweden,EU,,362133,,2692969,55.60587,13.00073
+"Dar es Salaam, Tanzania",Dar es Salaam,Dar es Salaam Region,TZ,Tanzania,AF,,5383728,,160263,-6.82349,39.26951
+"Clovis, New Mexico, United States",Clovis,New Mexico,US,United States,NA,,39480,,5462393,34.4048,-103.20523
+"Johns Creek, Georgia, United States",Johns Creek,Georgia,US,United States,NA,,83335,,6331909,34.02893,-84.19858
+"Sandusky, Ohio, United States",Sandusky,Ohio,US,United States,NA,,25212,,5170691,41.44894,-82.70796

--- a/scripts/register_frame.py
+++ b/scripts/register_frame.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """
-Register the worldwide sampling-frame cities in the catalog, freezing each
-city's grid geometry — WITHOUT downloading any imagery.
+Register the cities in a frame manifest, freezing each city's grid geometry
+— WITHOUT downloading any imagery.
 
 This lets the boundary-audit workflow (scripts/audit_city_boundaries.py ->
 build_boundary_review.py -> apply_decisions.py) vet the grids BEFORE the first
@@ -17,7 +17,10 @@ district--colombia". Geometry (center + dimensions) still comes from geocoding;
 this mirrors cli._resolve_geometry's new-city branch (helpers imported below)
 but supplies the identity ourselves.
 
-Reads the manifest produced by scripts/build_worldwide_frame.py. Idempotent —
+Reads a manifest in the format scripts/build_worldwide_frame.py writes: the
+worldwide sampling frame by default, or a purposive list such as
+mapillary_360_cities.csv via --manifest (docs/worldwide_sampling.md).
+Identify the batch in the catalog with --notes-label. Idempotent —
 already-registered cities are skipped, so it is safe to re-run and resumable
 via ``--limit``. Makes ZERO provider API calls (geocoding is rate-limited
 Nominatim, no keys needed). Dry-run by default; pass --execute to write.
@@ -76,6 +79,7 @@ DEFAULT_MANIFEST = os.path.join(
     os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "worldwide_frame.csv"
 )
 
+DEFAULT_NOTES_LABEL = "worldwide frame"
 DEFAULT_OVERLAP_KM = 25.0
 DEFAULT_MAX_CENTER_KM = 50.0
 
@@ -132,9 +136,9 @@ def geocode_queries(row):
     return [query] if fallback == query else [query, fallback]
 
 
-def register_frame_city(conn, row, step, use_geonames_center, max_center_km):
+def register_frame_city(conn, row, step, use_geonames_center, max_center_km, notes_label):
     """
-    Register one frame city with GeoNames ASCII identity + geocoded geometry.
+    Register one manifest city with GeoNames ASCII identity + geocoded geometry.
 
     Mirrors cli._resolve_geometry's new-city branch (center from the OSM bbox,
     dimensions from the boundary, clamped to MAX_GRID_DIM_M) but pins the
@@ -201,7 +205,7 @@ def register_frame_city(conn, row, step, use_geonames_center, max_center_km):
         grid_height_m=grid_height,
         step_m=step,
         enabled=False,
-        notes=f"worldwide frame (geonameid {row['geonameid']}); pending boundary vetting",
+        notes=f"{notes_label} (geonameid {row['geonameid']}); pending boundary vetting",
     )
     # Alias the query slug to the canonical id so `streetscape_tracker.py
     # "<query>"` resolves without geocoding (usually identical, since
@@ -255,6 +259,12 @@ def parse_args(argv=None):
         action="store_true",
         help="when the geocoded center fails the --max-center-km guard, fall "
         "back to the GeoNames coordinates instead of skipping the city",
+    )
+    p.add_argument(
+        "--notes-label",
+        default=DEFAULT_NOTES_LABEL,
+        help="batch label written into cities.notes, so a later reader can tell "
+        "which manifest a city came from (default: %(default)s)",
     )
     p.add_argument(
         "--db-path", default=None, help="catalog path (default: the standard data-dir DB)"
@@ -319,7 +329,12 @@ def main(argv=None):
                 continue
             try:
                 city_row = register_frame_city(
-                    conn, row, args.step, args.center_from_geonames, args.max_center_km
+                    conn,
+                    row,
+                    args.step,
+                    args.center_from_geonames,
+                    args.max_center_km,
+                    args.notes_label,
                 )
                 print(
                     f"{prefix} -> registered {city_row.city_id} "

--- a/tests/test_mapillary_360_cities_manifest.py
+++ b/tests/test_mapillary_360_cities_manifest.py
@@ -40,6 +40,20 @@ DATA_SOURCES = REPO_ROOT / "data_sources"
 # display name and a URL, and the slug is permanent.
 ASCII_SPELLING_OVERRIDES = {"2692969": "Malmo"}
 
+# Two cities whose GeoNames-derived query matches the WRONG OSM feature, caught
+# before registration by comparing each geocoded center against the GeoNames
+# coordinates (the 50 km --max-center-km guard sees neither):
+#   Sandusky -> "Sandusky County, Ohio", a different county ~36 km west of the
+#     city, which is in Erie County.
+#   Brussels -> the City of Brussels commune (8.7x13.1 km), about a fifth of the
+#     19-commune Brussels-Capital Region the coverage number is meant to describe.
+# An override changes only the GEOCODE query. Identity — and so the frozen
+# city_id — still comes from the GeoNames city/admin/country columns.
+QUERY_OVERRIDES = {
+    "5170691": "Sandusky, Erie County, Ohio, United States",
+    "2800866": "Bruxelles-Capitale, Belgium",
+}
+
 # Permanent slugs, frozen at registration. Order matches the manifest.
 EXPECTED_CITY_IDS = {
     "6094817": "ottawa--ontario--canada",
@@ -114,16 +128,25 @@ def test_query_strings_are_what_the_frame_generator_would_write(manifest_rows, g
     """
     Same "City, Admin, Country" construction as the worldwide frame, including
     effective_admin dropping an admin that just repeats the city name — so a
-    Nominatim query here behaves exactly like a frame query.
+    Nominatim query here behaves exactly like a frame query, except for the
+    declared QUERY_OVERRIDES.
     """
     for row in manifest_rows:
-        city = geonames.cities[row["geonameid"]]
+        gid = row["geonameid"]
+        city = geonames.cities[gid]
         record = SimpleNamespace(
             city=city._replace(name=row["city"]),
             iso2=city.iso2,
             country=row["country"],
         )
-        assert row["query_string"] == query_string(record, geonames.admin), row["geonameid"]
+        generated = query_string(record, geonames.admin)
+        if gid not in QUERY_OVERRIDES:
+            assert row["query_string"] == generated, gid
+            continue
+        assert row["query_string"] == QUERY_OVERRIDES[gid], gid
+        # An override that matches what the generator would write anyway is a
+        # lie about why it exists — and would silently stop being tested.
+        assert QUERY_OVERRIDES[gid] != generated, gid
 
 
 def test_city_ids_are_the_pinned_permanent_slugs(manifest_rows):

--- a/tests/test_mapillary_360_cities_manifest.py
+++ b/tests/test_mapillary_360_cities_manifest.py
@@ -1,0 +1,149 @@
+"""
+The Mapillary-360 city manifest (mapillary_360_cities.csv, registered with
+scripts/register_frame.py --manifest).
+
+The manifest is a hand-curated list — cities with documented Mapillary 360°
+capture programs — but its *values* are not hand-typed: every row is a join
+against the vendored GeoNames data, keyed by geonameid. These tests are that
+join, run in reverse, and they are the file's provenance: there is no generator
+script to point at, so a row whose coordinates, admin name or spelling drifted
+away from GeoNames fails here rather than silently freezing a wrong grid.
+
+The city_ids are pinned as literals on purpose. Registration freezes them
+forever (filenames and published URLs depend on them), so a change in
+db.derive_city_id or naming.sanitize_city_query_str must break a test rather
+than quietly rename a city.
+"""
+
+import csv
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from scripts.build_worldwide_frame import (
+    _MANIFEST_HEADER,
+    load_admin1,
+    load_cities,
+    load_countries,
+    query_string,
+)
+from scripts.register_frame import frame_identity
+from streetscape_metadata_tracker import db
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MANIFEST = REPO_ROOT / "mapillary_360_cities.csv"
+DATA_SOURCES = REPO_ROOT / "data_sources"
+
+# GeoNames' asciiname is the identity rule (docs/worldwide_sampling.md), and
+# this is the one place we depart from it: "Malmoe" reads as a typo in a
+# display name and a URL, and the slug is permanent.
+ASCII_SPELLING_OVERRIDES = {"2692969": "Malmo"}
+
+# Permanent slugs, frozen at registration. Order matches the manifest.
+EXPECTED_CITY_IDS = {
+    "6094817": "ottawa--ontario--canada",
+    "2158177": "melbourne--victoria--australia",
+    "593116": "vilnius--lithuania",
+    "3067696": "prague--czechia",
+    "2618425": "copenhagen--capital-region--denmark",
+    "2867714": "munich--bavaria--germany",
+    "3173435": "milan--lombardy--italy",
+    "3128760": "barcelona--catalonia--spain",
+    "2800866": "brussels--belgium",
+    "2692969": "malmo--skane--sweden",
+    "160263": "dar-es-salaam--tanzania",
+    "5462393": "clovis--new-mexico--united-states",
+    "6331909": "johns-creek--georgia--united-states",
+    "5170691": "sandusky--ohio--united-states",
+}
+
+
+@pytest.fixture(scope="module")
+def manifest_rows():
+    with open(MANIFEST, encoding="utf-8") as f:
+        return list(csv.DictReader(f))
+
+
+@pytest.fixture(scope="module")
+def geonames():
+    """The vendored GeoNames join: cities by id, admin-1 names, countries."""
+    cities = {c.geonameid: c for c in load_cities(DATA_SOURCES / "cities15000.txt")}
+    return SimpleNamespace(
+        cities=cities,
+        admin=load_admin1(DATA_SOURCES / "admin1CodesASCII.txt"),
+        countries=load_countries(DATA_SOURCES / "countryInfo.txt"),
+    )
+
+
+def test_header_is_the_frame_manifest_format(manifest_rows):
+    """register_frame.py reads this file, so the columns must be its columns."""
+    assert list(manifest_rows[0]) == _MANIFEST_HEADER
+
+
+def test_rows_are_unique_and_complete(manifest_rows):
+    ids = [row["geonameid"] for row in manifest_rows]
+    assert len(ids) == len(set(ids))
+    assert set(ids) == set(EXPECTED_CITY_IDS)
+
+
+@pytest.mark.parametrize("field", ["query_string", "city", "iso2", "country", "geonameid"])
+def test_required_columns_are_populated(manifest_rows, field):
+    assert all(row[field] for row in manifest_rows)
+
+
+def test_every_row_matches_its_vendored_geonames_record(manifest_rows, geonames):
+    """The join, in reverse: nothing in a row may drift from GeoNames."""
+    for row in manifest_rows:
+        gid = row["geonameid"]
+        city = geonames.cities[gid]
+        country = geonames.countries[city.iso2]
+        expected_name = ASCII_SPELLING_OVERRIDES.get(gid, city.name)
+
+        assert row["city"] == expected_name, gid
+        assert row["iso2"] == city.iso2, gid
+        assert row["country"] == country.name, gid
+        assert row["continent"] == country.continent, gid
+        assert int(row["population"]) == city.population, gid
+        assert float(row["lat"]) == pytest.approx(city.lat), gid
+        assert float(row["lon"]) == pytest.approx(city.lon), gid
+        assert row["admin"] == geonames.admin.get(f"{city.iso2}.{city.admin1}", ""), gid
+
+
+def test_query_strings_are_what_the_frame_generator_would_write(manifest_rows, geonames):
+    """
+    Same "City, Admin, Country" construction as the worldwide frame, including
+    effective_admin dropping an admin that just repeats the city name — so a
+    Nominatim query here behaves exactly like a frame query.
+    """
+    for row in manifest_rows:
+        city = geonames.cities[row["geonameid"]]
+        record = SimpleNamespace(
+            city=city._replace(name=row["city"]),
+            iso2=city.iso2,
+            country=row["country"],
+        )
+        assert row["query_string"] == query_string(record, geonames.admin), row["geonameid"]
+
+
+def test_city_ids_are_the_pinned_permanent_slugs(manifest_rows):
+    """
+    What register_frame.py will freeze into the catalog. ASCII, comma-free and
+    unchanging: these become filenames and published URLs.
+    """
+    for row in manifest_rows:
+        city_id = db.derive_city_id(*frame_identity(row))
+        assert city_id == EXPECTED_CITY_IDS[row["geonameid"]]
+        assert city_id.isascii()
+
+
+def test_frame_only_columns_are_blank(manifest_rows):
+    """
+    size_band and coverage_regime are stratification variables of the sampling
+    frame (docs/worldwide_sampling.md); this list is purposive, so they carry no
+    meaning here and are left empty rather than half-filled. register_frame.py
+    reads neither.
+    """
+    for row in manifest_rows:
+        assert row["size_band"] == ""
+        assert row["coverage_regime"] == ""

--- a/tests/test_register_frame.py
+++ b/tests/test_register_frame.py
@@ -171,6 +171,46 @@ def test_execute_registers_new_city_disabled(tmp_path, catalog, fake_geocode):
     conn.close()
 
 
+def test_notes_label_identifies_the_manifest_batch(tmp_path, catalog, fake_geocode):
+    """
+    cities.notes carries the batch label, so a later reader (and the enable
+    step) can tell which manifest a registered city came from. Asserting the
+    default alone would pass even if the flag were dropped on the floor, so
+    both the default and an override are exercised.
+    """
+    manifest = tmp_path / "frame.csv"
+    write_manifest(manifest, [frame_row()])
+    assert rf.main(["--manifest", str(manifest), "--db-path", catalog, "--execute"]) == 0
+
+    other = tmp_path / "other.csv"
+    write_manifest(
+        other,
+        [frame_row(query_string="Newville, Testland", city="Newville", lat="50.0", lon="60.0")],
+    )
+    fake_geocode["center_by_query"] = {"Newville, Testland": (50.0, 60.0)}
+    assert (
+        rf.main(
+            [
+                "--manifest",
+                str(other),
+                "--db-path",
+                catalog,
+                "--execute",
+                "--notes-label",
+                "mapillary 360 leaders",
+            ]
+        )
+        == 0
+    )
+
+    conn = db.connect(catalog)
+    assert db.resolve_city(conn, "Testville, Testland").notes.startswith("worldwide frame (")
+    assert db.resolve_city(conn, "Newville, Testland").notes.startswith(
+        "mapillary 360 leaders (geonameid 42)"
+    )
+    conn.close()
+
+
 def test_center_guard_rejects_far_geocode(tmp_path, catalog, fake_geocode, capsys):
     fake_geocode["center"] = (11.0, 20.0)  # ~111 km from the GeoNames coords
     manifest = tmp_path / "frame.csv"


### PR DESCRIPTION
## Why

A survey of Mapillary's own [showcase/case studies](https://www.mapillary.com/showcase), the [CompleteTheMap 2026 Europe](https://blog.mapillary.com/update/2026/07/28/complete-the-map-2026-europe-with-here) target list and the [Be Group](https://blog.mapillary.com/update/2024/05/16/Be-Group-Vietnam-Mapillary-Imagery.html) / [Amsterdam](https://blog.mapillary.com/community/2017/06/28/amsterdam-in-360-from-imagery-to-map-data-in-seven-days.html) / [Detroit](https://detroitmi.gov/departments/department-innovation-and-technology/detroit-street-view) programs against the prod catalog found that we already track most of the world's documented 360 leaders — Detroit, HCMC, Hanoi, Amsterdam, Berlin, Bogota, Budapest, Braga, Morgantown — but not these 14:

| City | Program |
|---|---|
| Ottawa | BikeOttawa — 450k images / 2,000 km |
| Melbourne | Kaart capture program |
| Vilnius | Lithuanian Road Administration — 21,244 km |
| Dar es Salaam | Ramani Huria community mapping |
| Clovis NM, Johns Creek GA, Sandusky OH | Mapillary showcase municipal programs |
| Malmo | Mapillary's home city |
| Prague, Copenhagen, Munich, Milan, Barcelona, Brussels | CompleteTheMap Europe 2026 targets |

Their US namesakes (Milan MI, Prague OK, Melbourne FL, Brussels WI) are not in the catalog either, so nothing collides.

**Erie County, OH is registered as Sandusky**, its county seat: the catalog registers cities as a frozen rectangle, and a county-scale one would measure Lake Erie and farmland rather than a city.

## What this does

`scripts/register_frame.py` already does bulk registration with the guards that matter — the GeoNames center guard, overlap reuse, `MAX_GRID_DIM_M` clamping, `enabled = 0` until boundary-vetted, dry-run by default — and it takes `--manifest`. So this adds a **second manifest**, not a second script.

Two things a purposive manifest needs that the frame did not:

- **`--notes-label`** (new flag, default `worldwide frame`). The `cities.notes` string was hardcoded, so all 14 would have claimed to be frame cities. The label is also how the vetting and enable steps select this batch out of 1,216 cities.
- **`--overlap-km 5` at the call site**, not the default 25. Checked against all 1,216 catalog centers: Johns Creek is 16 km from the registered `sugar-hill--georgia` and Sandusky 17 km from `kelleys-island--ohio` (pop ~300, an island), so both would have been silently **aliased away instead of registered**.

The manifest is curated but not hand-typed — every value is a GeoNames join keyed by `geonameid`. `tests/test_mapillary_360_cities_manifest.py` re-runs that join in reverse and is the file's provenance, since there is no generator script to name. It pins the permanent `city_id`s as literals (registration freezes them into filenames and published URLs) and records the two deliberate departures from the GeoNames-derived values.

**No provider API calls anywhere in this change.** Registration geocodes against rate-limited Nominatim only.

## Boundaries were vetted before registering, not after

Geometry is frozen at registration, so the second commit computes what registration *would* freeze for all 14 — the same `get_city_location_data` → `resolve_center` → `get_search_dimensions` → `cap_dimensions` chain `register_frame_city` runs — and reads the offset from each geocoded center to the manifest's GeoNames coordinates. **Four were wrong, and the `--max-center-km` guard at its default of 50 km would have waved every one through:**

| City | What Nominatim matched | Offset | Fix |
|---|---|---|---|
| Sandusky OH | `Sandusky County, Ohio` — a *different* county ~36 km west of the city, which is in Erie County | 36.1 km | query override |
| Melbourne | Greater Melbourne (153×122 km) | 34.7 km | `--center-from-geonames` |
| Dar es Salaam | Dar es Salaam Region (102×69 km), midpoint seaward | 22.6 km | `--center-from-geonames` |
| Ottawa | the amalgamated, mostly rural City of Ottawa (87×64 km) | 19.7 km | `--center-from-geonames` |

The nine good ones all sat within 5.5 km, so the two failure modes separate cleanly and neither needed new code:

- An **over-large administrative match** keeps its (40 km clamped) grid and is recentered on the GeoNames downtown point — `--max-center-km 10 --center-from-geonames` at the call site moves exactly those three and leaves the other eleven untouched.
- A **wrong-feature match** takes its dimensions from the wrong polygon, so recentering cannot save it. Those get a geocode-query override in the manifest; identity still comes from the GeoNames columns, so the frozen `city_id` is unchanged.

The same override handles the opposite failure: `Brussels` resolved to the City of Brussels commune (8.7×13.1 km), about a fifth of the 19-commune Brussels-Capital Region, and `Bruxelles-Capitale, Belgium` resolves to the region at 16.8×16.7 km. `get_city_location_data` restricts structured search to settlement types, so an override phrased as a region name can match a museum — both overrides here were re-run through the real registration path before being committed.

Final verified geometry: Sandusky 14.3×8.7 km on the city (0.9 km off), Brussels 16.8×16.7 km on the region, Ottawa / Melbourne / Dar es Salaam 40×40 km on downtown, the other nine unchanged. Dar es Salaam is coastal, so its 40×40 box is substantially water and its **grid** coverage will read low for that reason — same as Cape Town and Lagos already do; street coverage is the honest number there.

## Rollout (not part of this PR)

1. Deploy, then dry-run on prod:
   `python scripts/register_frame.py --manifest mapillary_360_cities.csv --overlap-km 5 --max-center-km 10 --center-from-geonames --notes-label "mapillary 360 leaders"` — expect `newly-registered=14 reused-existing=0`.
2. `--execute`, then read the 14 frozen rectangles back out of `cities` and confirm they match the verified geometry above.
3. Enable (`UPDATE cities SET enabled = 1 WHERE notes LIKE 'mapillary 360 leaders%'`) **after ~2026-09-05**, once the #292 jitter window closes — enabling is all-or-nothing across channels, so these join gsv, gsv_streets and mapillary at once.

## Testing

`pytest` (1915 passed, 1 skipped), `ruff check`, `ruff format --check` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code) — Opus 5 (1M context), claude-opus-5[1m], effort: xhigh