### PR TITLE
Size the Mapillary grid budget for the 40-city night (#286)

### DIFF
--- a/config/scheduler.makelab1.toml
+++ b/config/scheduler.makelab1.toml
@@ -178,7 +178,35 @@ enabled = true
 # multi-day guard exists (#241). Recovery recipe, measured twice: full
 # silence, then one single-request probe; both blocks cleared within ~a day
 # of the last refused request.
-daily_request_budget = 1750
+#
+# 2026-09-05: 1,750 -> 3,500, and this is NOT a softening of the block
+# posture -- it is the sizing #241 left open, finally matched to the night it
+# has to cover. 1,750 was sized for a 20-city night on 2026-08-22;
+# max_cities_per_day went 20 -> 40 in #304 on 09-02 and this figure did not
+# follow, so the cap started binding immediately: 1,736 and 1,723 spent on the
+# first two 40-city nights against four 20-city nights that peaked at 1,241.
+# Per-city cost over 1,398 runs is median 9, p90 81, p99 440, max 870, mean 39.
+# It bound twice in six nights, both on an end-of-night sliver rather than an
+# unaffordable city (New York wanted 484 with 426 left) -- that tail is #318's
+# capped-and-resume, not this raise.
+#
+# THE NUMBER TO QUOTE IS THE PER-IP SUM WITH mapillary_streets, not this line.
+# That channel stays at 1,750 and, since #290, spends 0 on a paired night by
+# reusing the grid census -- 5 of the 6 nights 08-30..09-04 spent exactly 0.
+# So a paired night is 3,500 + 0, the same combined ceiling #241 sanctioned.
+# An un-paired night can reach 5,250: 1.5x that ceiling, the most this host
+# has been configured for since block 2, and the honest cost of this change.
+# Accepted because block 3 (1,938/day, against 26,363 clean on 08-14)
+# falsified daily volume and every accumulation window from 1 to 8 days
+# (#286) -- NOT because volume is known safe here. Nothing about this host is.
+# The structurally right fix is one per-IP pool both channels draw from, which
+# is a scheduler change and is not attempted here.
+#
+# Deliberately deployed AFTER #292's pre-registered jitter window closed
+# (~2026-09-09). Volume is an axis that test holds still, so raising it inside
+# the window would have handed a fourth block two candidate causes where the
+# design went to real trouble to leave one. Cost of waiting: the two skips.
+daily_request_budget = 3500
 # Client-side tile pacing (issue #198). Shared per-IP with mapillary_streets
 # below and with any manual run on this host — the host lock (#208) is what
 # makes this figure the real one rather than a per-process wish.

--- a/config/scheduler.makelab1.toml
+++ b/config/scheduler.makelab1.toml
@@ -81,7 +81,7 @@ max_batch_hours = 12
 #      48k+24k req/min on one quota with nothing serializing them). Record the
 #      project IDs and the date of the check here when it is done.
 #   2. Issue #256 landed — resume for the Mapillary tile census. Until then a
-#      killed child re-spends tiles against the 3,500/day per-IP ceiling.
+#      killed child re-spends tiles against the per-IP ceiling (3,500/day paired, 5,250 un-paired since 2026-09-05).
 # Go to 2 before 3: gsv is the long pole and already overlaps each short channel
 # in turn at 2, for half the blast radius. See docs/scheduler.md.
 max_concurrent_channels = 1
@@ -146,9 +146,10 @@ enabled = true
 #
 # That arithmetic is preserved as written in 2026-08. sleep_between_cities_s
 # became 5 in #306, which raises the ceiling it derives -- but not by much and
-# not in a way anything here depends on: max_cities_per_day = 20 caps a nightly
-# run long before the tile figure binds, and the budget below is 1,750 for
-# unrelated reasons (three per-IP blocks). Left as a dated record of a bet that
+# not in a way anything here depends on: max_cities_per_day (20 when this was
+# written, 40 since #304) caps a nightly run long before the tile figure binds,
+# and the budget below was 1,750 for unrelated reasons (three per-IP blocks) --
+# 3,500 since the 2026-09-05 re-size. Left as a dated record of a bet that
 # later lost, not as a live derivation.
 #
 # BE HONEST ABOUT WHAT THIS IS: 15,000 + mapillary_streets' 5,000 = 20,000/day
@@ -169,23 +170,33 @@ enabled = true
 # both channels read the identical z14 census. SINCE #290 THE WALK NO LONGER
 # RE-READS THOSE TILES: it reuses the grid run's census for 0 requests on a
 # paired night, so mapillary_streets' budget is spent only on nights the two
-# are NOT paired. The values are unchanged — re-sizing them for the lighter
-# load is #286's question. The even split still matters for the un-paired
-# case, where the two budgets deplete in lockstep and a heavy slate defers the
-# same cities on both channels instead of un-pairing them further. A
+# are NOT paired. NOTE (2026-09-05, #286): the values above are the 08-22
+# ones and the even split is HISTORY, not the current state — this channel is
+# now 3,500 and mapillary_streets is still 1,750, so the split is 2:1 and the
+# sum is 3,500 paired / 5,250 un-paired. The lockstep argument went with it:
+# since #290 the walk's estimate is 0 on a paired night, so the two budgets
+# do not deplete together at all. A
 # normal 20-city night (~1,150 tiles per channel) fits; a catch-up-scale
 # burst is impossible by construction, ON PURPOSE -- no `--limit` catch-ups until a rolling
 # multi-day guard exists (#241). Recovery recipe, measured twice: full
 # silence, then one single-request probe; both blocks cleared within ~a day
 # of the last refused request.
 #
-# 2026-09-05: 1,750 -> 3,500, and this is NOT a softening of the block
+# Decided 2026-09-05, deployed only after the 09-09 window (see the timing
+# note at the end of this comment): 1,750 -> 3,500, and NOT a softening of the block
 # posture -- it is the sizing #241 left open, finally matched to the night it
 # has to cover. 1,750 was sized for a 20-city night on 2026-08-22;
 # max_cities_per_day went 20 -> 40 in #304 on 09-02 and this figure did not
 # follow, so the cap started binding immediately: 1,736 and 1,723 spent on the
 # first two 40-city nights against four 20-city nights that peaked at 1,241.
-# Per-city cost over 1,398 runs is median 9, p90 81, p99 440, max 870, mean 39.
+# Per-city cost over the 1,398 runs collected is median 9, p90 81, max 870,
+# mean 39 -- but SIZE ON THE UNBIASED NUMBER, not that one: the gate skips
+# exactly the expensive cities, so the 85 enabled cities with no Mapillary run
+# average a 728.6 km2 grid against 131.6 km2 for the 1,132 that have one. The
+# geometry mean over all enabled cities is 57.8 and the per-city mean over
+# latest runs is 45.2, so a 40-city night demands ~1,800-2,400, not ~1,560 --
+# as 09-03 showed by demanding 2,260 (1,736 spent + 484 + 40 skipped). 3,500
+# is ~1.5x headroom over a normal night, not 2.2x.
 # It bound twice in six nights, both on an end-of-night sliver rather than an
 # unaffordable city (New York wanted 484 with 426 left) -- that tail is #318's
 # capped-and-resume, not this raise.
@@ -195,15 +206,17 @@ enabled = true
 # reusing the grid census -- 5 of the 6 nights 08-30..09-04 spent exactly 0.
 # So a paired night is 3,500 + 0, the same combined ceiling #241 sanctioned.
 # An un-paired night can reach 5,250: 1.5x that ceiling, the most this host
-# has been configured for since block 2, and the honest cost of this change.
+# has been configured for since the 2026-08-22 cut (for ~2 days after block 2
+# it still sat at 15,000 + 5,000), and the honest cost of this change.
 # Accepted because block 3 (1,938/day, against 26,363 clean on 08-14)
 # falsified daily volume and every accumulation window from 1 to 8 days
 # (#286) -- NOT because volume is known safe here. Nothing about this host is.
 # The structurally right fix is one per-IP pool both channels draw from, which
 # is a scheduler change and is not attempted here.
 #
-# Deliberately deployed AFTER #292's pre-registered jitter window closed
-# (~2026-09-09). Volume is an axis that test holds still, so raising it inside
+# Deliberately held until AFTER #292's pre-registered jitter window closed
+# (~2026-09-09); production ran at 1,750 for every night up to that point.
+# Volume is an axis that test holds still, so raising it inside
 # the window would have handed a fourth block two candidate causes where the
 # design went to real trouble to leave one. Cost of waiting: the two skips.
 daily_request_budget = 3500
@@ -259,9 +272,13 @@ spacing_m = 15
 # local spatial join against the tiles. Budgeted in tile
 # requests against the SAME per-IP ceiling as [providers.mapillary] above, not
 # against the per-app cap: different tokens, one address, so the number that
-# matters is the SUM -- 1,750 + 1,750 = 3,500/day as of 2026-08-22; see the
-# issue #241 note in [providers.mapillary]. Split evenly: a road walk reads
-# the identical tile census as the grid run. Since #290 it REUSES that census
+# matters is the SUM -- 3,500/day on a PAIRED night and 5,250 if the pair
+# splits, as of the 2026-09-05 re-size (#286): [providers.mapillary] is 3,500
+# and this channel is 1,750. It was 1,750 + 1,750 = 3,500, split evenly, from
+# 2026-08-22 until then; see the issue #241 and #286 notes in
+# [providers.mapillary]. The even split bought lockstep depletion, which #290
+# had already ended: a road walk reads the identical tile census as the grid
+# run, but now reuses it rather than re-reading it. Since #290 it REUSES that census
 # rather than re-reading it, so on a paired night this channel spends nothing
 # and this budget is drawn on only when the pair is split apart.
 # PAUSED 2026-08-28 with [providers.mapillary] — same IP, same tile CDN, so

--- a/config/scheduler.toml
+++ b/config/scheduler.toml
@@ -249,7 +249,30 @@ enabled = true
 # the entire daily budget"; the mean is 57.8, so 1,750 reaches ~30 cities and
 # the 70,168-tile catalog is one full pass in ~40 nights. The budget — not
 # max_batch_hours — is now what ends a maxed Mapillary night.
-daily_request_budget = 1750
+#
+# 1,750 -> 3,500 on 2026-09-05, and read the reason before reading it as a
+# relaxation of the block posture: 1,750 was sized for a 20-city night, and
+# max_cities_per_day went 20 -> 40 in #304 without it following. The first two
+# 40-city nights spent 1,736 and 1,723 against the 1,750 cap while the four
+# 20-city nights before them never passed 1,241. Per-city cost is median 9,
+# p90 81, p99 440, max 870 over 1,398 runs, so a 40-city night wants ~1,560 on
+# the mean and the cap binds whenever two or three metros land together.
+#
+# The number that matters is still the per-IP SUM with mapillary_streets
+# below, which is left at 1,750. Since #290 the walk reuses the grid run's
+# census for 0 requests on a paired night, so a paired night is 3,500 + 0 --
+# exactly the combined ceiling #241 already sanctioned, not an increase. An
+# UN-PAIRED night can reach 5,250, which is 1.5x that ceiling and the most
+# this host has been configured for since block 2; that is accepted because
+# block 3 falsified daily volume and every 1-8 day window (#286), NOT because
+# volume is known safe. The right fix is one per-IP pool both channels draw
+# from -- a scheduler change, not a config edit. Quote the sum, never this
+# line alone.
+#
+# Timed deliberately after #292's pre-registered jitter window closed
+# (~2026-09-09): raising volume inside it would have given a fourth block two
+# candidate causes where the test was built to leave one.
+daily_request_budget = 3500
 # Client-side pacing for the tile CDN (issue #198). 60/min is a conservative
 # guess; 370 is confirmed too high — and #241 proved 60/min is NOT sufficient
 # on its own (blocked 2026-08-20 while obeying it exactly). The limiter stays

--- a/config/scheduler.toml
+++ b/config/scheduler.toml
@@ -144,7 +144,8 @@ max_batch_hours = 12
 #   * Every provider must be able to RESUME a killed collection — satisfied
 #     since issue #256 landed the Mapillary tile-census checkpoint, so a
 #     deadline or `systemctl stop` killing N children at once no longer
-#     re-spends their tiles against the deliberate 3,500/day per-IP ceiling.
+#     re-spends their tiles against the deliberate per-IP ceiling
+#     (3,500/day paired, 5,250 un-paired since 2026-09-05).
 #   * gsv and gsv_streets hold no per-IP lock, because Google meters per Cloud
 #     PROJECT rather than per IP. Running them together is only safe while the
 #     two keys really do live in separate projects — a console check, since
@@ -217,14 +218,21 @@ enabled = true
 # the experiment works, so it is deliberately not being run. Full analysis,
 # both incidents' numbers, and the staff statements: issue #241.
 #
-# THE NUMBERS BELOW (cut 2026-08-22: 15,000 + 5,000 -> 1,750 + 1,750): the
-# block is per IP, so what is on the line is the SUM — 3,500/day on one
-# address, chosen so any 2-day total stays <= 7,000, at or below the highest
-# value ever observed clean (7,061). Split EVENLY because both channels read
+# THE NUMBERS BELOW (cut 2026-08-22: 15,000 + 5,000 -> 1,750 + 1,750; the
+# grid half re-sized to 3,500 on 2026-09-05, see below): the block is per IP,
+# so what is on the line is the SUM — 3,500/day on one address as this was
+# written, and since 2026-09-05 that is 3,500 on a paired night and 5,250 if
+# the pair splits. The 1,750 + 1,750 was chosen so any 2-day total stayed
+# <= 7,000, at or below the highest value ever observed clean (7,061), and
+# split EVENLY because both channels read
 # the identical z14 census. SINCE #290 THE WALK NO LONGER RE-READS THOSE
 # TILES: it reuses the grid run's census for 0 requests on a paired night, so
 # mapillary_streets' budget is spent only on nights the two are NOT paired
-# (a budget deferral, a filtered run). The values are unchanged — re-sizing
+# (a budget deferral, a filtered run). THE EVEN SPLIT IS HISTORY as of
+# 2026-09-05 (#286): the grid half is 3,500 and the walk half still 1,750, so
+# the split is 2:1 and the lockstep it bought is gone — since #290 the walk
+# prices at 0 on a paired night, so the budgets never deplete together.
+# The values were unchanged here — re-sizing
 # them for the lighter load is #286's question, and #290's goal is strictly
 # less load. The even split still matters for the un-paired case, where the
 # two budgets deplete in lockstep and a heavy slate defers the same cities on
@@ -233,7 +241,9 @@ enabled = true
 # until a rolling multi-day guard exists: these budgets bound any single day,
 # but three consecutive maxed days sum to 10,500 — inside the 3-day
 # uncertainty band above — so only a multi-night catch-up can reach where
-# normal nights cannot.
+# normal nights cannot. (That 10,500 was 1,750 + 1,750; since the 2026-09-05
+# re-size three maxed days are 10,500 paired and 15,750 un-paired, so the
+# raise widens the blast radius of a catch-up if the ban is ever lifted.)
 #
 # RECOVERY, measured twice (#241): the block lifts within ~a day of the LAST
 # refused request — block 1 cleared after ~20.5 h of true silence (silence
@@ -246,31 +256,47 @@ enabled = true
 #
 # Sizing, measured over the 1,214 enabled cities on 2026-08-16: the largest
 # frozen grid is 870 tiles (Moscow), so no city is ever skipped as "exceeds
-# the entire daily budget"; the mean is 57.8, so 1,750 reaches ~30 cities and
-# the 70,168-tile catalog is one full pass in ~40 nights. The budget — not
-# max_batch_hours — is now what ends a maxed Mapillary night.
+# the entire daily budget"; the mean is 57.8, so 1,750 reached ~30 cities and
+# the 70,168-tile catalog was one full pass in ~40 nights, and the budget --
+# not max_batch_hours -- was then what ended a maxed Mapillary night.
+# SUPERSEDED BY THE 2026-09-05 RE-SIZE below: at 3,500 this channel reaches
+# ~60 cities and ~20 nights, and what ends the night is the 40-city cap --
+# every night 09-03..09-08 stopped on it in 6.8-10.6 h against a 12 h
+# max_batch_hours.
 #
-# 1,750 -> 3,500 on 2026-09-05, and read the reason before reading it as a
+# 1,750 -> 3,500, decided 2026-09-05 and deployed only after the 09-09
+# jitter window (below). Read the reason before reading it as a
 # relaxation of the block posture: 1,750 was sized for a 20-city night, and
 # max_cities_per_day went 20 -> 40 in #304 without it following. The first two
 # 40-city nights spent 1,736 and 1,723 against the 1,750 cap while the four
-# 20-city nights before them never passed 1,241. Per-city cost is median 9,
-# p90 81, p99 440, max 870 over 1,398 runs, so a 40-city night wants ~1,560 on
-# the mean and the cap binds whenever two or three metros land together.
+# 20-city nights before them never passed 1,241.
+#
+# SIZE IT ON THE UNBIASED DISTRIBUTION. Over the 1,398 runs collected, cost is
+# median 9, p90 81, max 870, mean 39 -- but that population is biased low
+# because the gate skips exactly the expensive cities: the 85 enabled cities
+# with no Mapillary run average a 728.6 km2 grid vs 131.6 km2 for the 1,132
+# that have one. The unbiased geometry mean is 57.8 (the paragraph above) and
+# the per-city mean over latest runs is 45.2, so a 40-city night demands
+# ~1,800-2,400, not ~1,560. Observation agrees: 09-03 demanded 1,736 spent
+# plus the 484 and 40 it skipped = 2,260. So 3,500 is ~1.5x headroom over a
+# normal night, not 2.2x, and the cap still binds when two or three metros
+# land together.
 #
 # The number that matters is still the per-IP SUM with mapillary_streets
 # below, which is left at 1,750. Since #290 the walk reuses the grid run's
 # census for 0 requests on a paired night, so a paired night is 3,500 + 0 --
 # exactly the combined ceiling #241 already sanctioned, not an increase. An
 # UN-PAIRED night can reach 5,250, which is 1.5x that ceiling and the most
-# this host has been configured for since block 2; that is accepted because
+# this host has been configured for since the 2026-08-22 cut (for ~2 days
+# after block 2 it still sat at 15,000 + 5,000); that is accepted because
 # block 3 falsified daily volume and every 1-8 day window (#286), NOT because
 # volume is known safe. The right fix is one per-IP pool both channels draw
 # from -- a scheduler change, not a config edit. Quote the sum, never this
 # line alone.
 #
 # Timed deliberately after #292's pre-registered jitter window closed
-# (~2026-09-09): raising volume inside it would have given a fourth block two
+# (~2026-09-09), and held at 1,750 in production until it did: raising volume
+# inside the window would have given a fourth block two
 # candidate causes where the test was built to leave one.
 daily_request_budget = 3500
 # Client-side pacing for the tile CDN (issue #198). 60/min is a conservative
@@ -348,9 +374,11 @@ spacing_m = 15
 # the walk is a local spatial join against the tiles. Budgeted in tile requests against the same PER-IP ceiling as the grid
 # channel above (see its comment for the documented limits and how the #214
 # bet resolved), not against the per-app cap: different tokens, one address,
-# so the number that matters is the SUM — 1,750 + 1,750 = 3,500/day as of
-# 2026-08-22 (issue #241), split evenly: a road walk reads the identical
-# tile census as the grid run. Since #290 it REUSES that census rather than
+# so the number that matters is the SUM. That sum is 3,500 on a PAIRED night
+# and 5,250 if the pair splits, as of the 2026-09-05 re-size (#286): the grid
+# channel above is 3,500 and this one is 1,750. It was 1,750 + 1,750 = 3,500,
+# split evenly, from 2026-08-22 (#241) until then — a road walk read the
+# identical tile census as the grid run. Since #290 it REUSES that census rather than
 # re-reading it, so on a paired night this channel spends nothing and this
 # budget is drawn on only when the pair is split apart.
 [providers.mapillary_streets]

--- a/docs/provider-access.md
+++ b/docs/provider-access.md
@@ -92,18 +92,48 @@ The thread carries one lead this repo did not have: it directs commercial or pro
 Nobody has written to them.
 That is a decision rather than a task — it identifies this project to the vendor, and the quota it would ask about is not the one that has ever stopped us.
 
+## The daily budgets, re-sized for the 40-city night (issue #286)
+
+**`[providers.mapillary].daily_request_budget` is 3,500 as of 2026-09-05; `[providers.mapillary_streets]` stays 1,750.**
+The grid channel's figure doubled for a reason that has nothing to do with the block model, and it is worth separating from one: 1,750 was sized on 2026-08-22 (#241) for a **20-city** night, and `max_cities_per_day` went 20 → 40 on 2026-09-02 (#304) without the budget following.
+The ledger shows that seam precisely — the first two 40-city nights pinned the cap, after four 20-city nights that never came close:
+
+| Night | grid | walk | combined | `max_cities_per_day` |
+|---|---|---|---|---|
+| 2026-08-30 | 755 | 0 | 755 | 20 |
+| 2026-08-31 | 950 | 0 | 950 | 20 |
+| 2026-09-01 | 1,241 | 0 | 1,241 | 20 |
+| 2026-09-02 | 1,037 | 0 | 1,037 | 20 |
+| 2026-09-03 | **1,736** | 524 | 2,260 | **40** |
+| 2026-09-04 | **1,723** | 0 | 1,723 | **40** |
+
+Per-city grid cost over 1,398 runs is median **9**, p90 **81**, p99 **440**, max **870**, mean **39**, so a 40-city night wants ~1,560 on the mean and the cap binds on any night that happens to carry two or three metros.
+It bound twice in those six nights, both times on an end-of-night sliver rather than on a city that was ever unaffordable: New York needed 484 with 426 left, and Normal, Illinois needed 40 with 38 left.
+That shape is the argument for the capped-and-resume work in #318 as well as for this raise — the raise fixes the average night, a resumable census fixes the tail.
+
+**What this actually spends.** Since #290 the walk reuses the grid run's census for zero requests on a paired night, and the table above shows `mapillary_streets` spending 0 on five of the six nights.
+The *combined* per-IP load has therefore been running at ~1,750/day against the 3,500 that #241 sanctioned — half of it — so on a paired night 3,500 + 0 restores that sanctioned combined ceiling rather than exceeding it.
+**Be honest about the un-paired case**: nothing enforces the pairing, and a split pair can reach **5,250**, which is 1.5x the #241 ceiling and the most this host has been configured for since block 2.
+That is accepted rather than overlooked, on the ground that block 3 (1,938/day, against 26,363 spent clean on 08-14) falsified daily volume and every accumulation window from 1 to 8 days (#286).
+It is **not** accepted on the ground that volume is safe — nothing about this host's behaviour is known safe, and the even split #241 chose still matters on exactly the nights that reach 5,250.
+The structurally correct fix is a single per-IP pool both channels draw from, which is a scheduler change rather than a config edit and is deliberately not attempted here; until it exists, the sum above is the number to quote, never the grid channel's 3,500 alone.
+
+**Deliberately timed after the jitter window closed.** The #292 restart is a pre-registered test whose read-out condition is "clean through ~2026-09-09", and raising volume inside that window would have handed a fourth block two candidate causes where the design went to real trouble to leave exactly one.
+The cost of waiting was the two skipped cities above.
+The same reasoning applies to the next person who wants to move this number: check what test is in flight before changing an axis it is measuring.
+
 ## SUPERSEDED — the daily budgets encoded a rolling 2–3 day per-IP window (issue #241, superseded by #286)
 
 > **SUPERSEDED by block 3 (2026-08-28); kept in full, not deleted, because the ledger analysis and the staff record below are still the evidence base and because #267 was sized on these bands.**
 > Block 3 arrived at **1,938** combined requests/day while 08-14 had spent **26,363** in one day clean, and **no accumulation window from 1 to 8 days** admits a threshold separating blocked days from clean ones (#286).
 > So the bands quoted below — 2-day (7,061, 10,766], 3-day (10,284, 12,074] — are **dead**, and the ~10,000-per-48 h reading with them.
-> What survives: the budgets themselves stay at 1,750 each, now as a *conservative floor on our exposure* rather than as a threshold anyone believes in; the no-`--limit`-catch-ups rule stays, on the general ground that a multi-night burst is the one shape we know preceded a block; and the **repeat-offender** rival named below is likewise dead, since block 3 did not escalate (≤26.3 h, same as block 2).
+> What survives: the budgets stayed at 1,750 each, no longer as a threshold anyone believes in but as a *conservative floor on our exposure* — and on 2026-09-05 the grid channel's half was re-sized to 3,500 for the 40-city night, which is the section above, not this one; the no-`--limit`-catch-ups rule stays, on the general ground that a multi-night burst is the one shape we know preceded a block; and the **repeat-offender** rival named below is likewise dead, since block 3 did not escalate (≤26.3 h, same as block 2).
 > The live hypothesis is request *shape*, not request *volume* — see the request-jitter section at the end of this file.
 
 **The daily budgets encoded what #241 read as the only constraint fitting the data at n=2: a rolling 2–3 day per-IP window (issue #241, superseding #214's throughput bet).** `[providers.mapillary].daily_request_budget` and `[providers.mapillary_streets]` are **1,750 each** (cut from 15,000 + 5,000 on 2026-08-22, and split evenly because both channels read the **identical z14 tile census** — a road walk re-reads the grid run's tiles
 — so the two budgets deplete in lockstep and a heavy slate defers the same cities on both channels rather than un-pairing them).
 **Since #290 the walk no longer re-reads those tiles: on a paired night it reuses the grid run's census for zero requests**, so `mapillary_streets`' budget is spent only on nights the two channels are *not* paired — which is what a budget deferral or a filtered run produces.
-The budget *values* are unchanged; sizing them for the new load is #286's question, and this issue's goal is strictly less load, never more.
+The budget *values* were unchanged here; sizing them for the new load was #286's question, answered on 2026-09-05 in the section above (grid 1,750 → 3,500). This issue's own goal was strictly less load, never more.
 The block is per **IP**, so the number that matters is the **sum** across the two channels
 — different tokens, one address: **3,500/day**, chosen so any 2-day total stays ≤ 7,000, at or below the **highest value ever observed clean** (7,061).
 
@@ -235,7 +265,7 @@ The parameter did not have to change meaning, because every invariant the unifor
 
 Because the pacer is FIFO under one lock, `connection_limit` concurrency cannot smooth the jitter back out.
 Mapillary tile fetches jitter **by default** (`DEFAULT_TILE_JITTER = 0.6`, `--mapillary-jitter` on both CLIs, `[providers.mapillary*].jitter` in the scheduler config — validated at load by `coerce_jitter`, and passed to the children exactly as `max_requests_per_minute` is), and prod runs **40/min at CV 0.6**: gaps floored at **0.60 s**, mean **1.50 s**, p99 **~4.7 s**, no ceiling.
-The budgets are left at 1,750 because a fourth cut has no mechanism to work through.
+The budgets were left at 1,750 for the restart because a fourth cut has no mechanism to work through — and were deliberately not raised either until the window below closed, since volume is an axis this test is holding still (the grid channel went to 3,500 on 2026-09-05; see the daily-budget section above).
 
 **This is a pre-registered test, not a fix**, and the prediction is recorded in #286 before the restart.
 Each prior block landed **on the 6th active collection night**: 08-13…08-20 and 08-23…08-28 are each a run of six collecting nights ending in the block.
@@ -376,7 +406,7 @@ changing `catalog_backup.py` will actually be reading, in
 **(1) Host affinity is enforced in the parent.**
 The launch pass derives the per-IP hosts its in-flight children hold from `CHANNEL_HOSTS` and defers any channel that intersects them, so Overpass, the Mapillary tile CDN and KartaView each see **at most one talker from this process at a time** — the same as before.
 The child-side cross-process lock (#208) is untouched and still covers the manual runs the parent cannot see.
-**(2) Pacing and budgets are per channel and unchanged**: each child keeps its own limiter, and the combined Mapillary per-IP ceiling stays 3,500/day.
+**(2) Pacing and budgets are per channel and unchanged**: each child keeps its own limiter, and this changes neither. (The combined Mapillary per-IP ceiling read 3,500/day when this was written; since 2026-09-05 it is 3,500 on a paired night and 5,250 if the pair splits — see the daily-budget section above. The argument here never depended on the value.)
 Whatever the binding Mapillary constraint turns out to be, intra-night packing does not move it — a night collects the same cities and spends the same tiles, sooner. (This read "multi-day *volume* (#241)" until block 3 retired that; the argument never depended on which hypothesis was live.)
 **(3) The only observable change is wall clock.**
 The one place this is not free is the pair Google meters per Cloud **project** rather than per IP: `gsv` and `gsv_streets` declare no host, so nothing serializes them, and running them concurrently presents 48k + 24k req/min.

--- a/docs/provider-access.md
+++ b/docs/provider-access.md
@@ -94,7 +94,8 @@ That is a decision rather than a task — it identifies this project to the vend
 
 ## The daily budgets, re-sized for the 40-city night (issue #286)
 
-**`[providers.mapillary].daily_request_budget` is 3,500 as of 2026-09-05; `[providers.mapillary_streets]` stays 1,750.**
+**`[providers.mapillary].daily_request_budget` goes to 3,500; `[providers.mapillary_streets]` stays 1,750.**
+Decided and written 2026-09-05, and deliberately **not deployed** until #292's jitter window closed — production ran at 1,750 every night through 2026-09-09, so read any date before the deploy as the authoring date, not the live configuration.
 The grid channel's figure doubled for a reason that has nothing to do with the block model, and it is worth separating from one: 1,750 was sized on 2026-08-22 (#241) for a **20-city** night, and `max_cities_per_day` went 20 → 40 on 2026-09-02 (#304) without the budget following.
 The ledger shows that seam precisely — the first two 40-city nights pinned the cap, after four 20-city nights that never came close:
 
@@ -107,13 +108,17 @@ The ledger shows that seam precisely — the first two 40-city nights pinned the
 | 2026-09-03 | **1,736** | 524 | 2,260 | **40** |
 | 2026-09-04 | **1,723** | 0 | 1,723 | **40** |
 
-Per-city grid cost over 1,398 runs is median **9**, p90 **81**, p99 **440**, max **870**, mean **39**, so a 40-city night wants ~1,560 on the mean and the cap binds on any night that happens to carry two or three metros.
+Sizing it needs the *unbiased* per-city cost, and there are two distributions in this file that must not be confused.
+Over the 1,398 **runs** actually collected, cost is median **9**, p90 **81**, max **870**, mean **39** (percentiles nearest-rank; the p99 is 440 that way and 420 interpolated, which is why only p90 and max are quoted here) — but that population is biased low by construction, because the budget gate skips exactly the expensive cities: the 85 enabled cities with no Mapillary run at all average a **728.6 km²** frozen grid against **131.6 km²** for the 1,132 that have one, and tile count scales with area.
+The unbiased figures are the **geometry** ones at the top of this file (median 12, mean **57.8**, p90 180, p99 480 over all 1,214 enabled cities), and the per-**city** mean over latest runs is **45.2**.
+So a 40-city night demands roughly **1,800–2,400**, not the ~1,560 the run-weighted mean alone would suggest — and the table above confirms it from observation rather than model: 09-03 demanded 1,736 spent **plus** the 484 and 40 it skipped = **2,260** (56.5/city), and 09-04 spent 1,723 across 29 Mapillary cities (59.4/city).
+3,500 is therefore about **1.5x** headroom over a normal 40-city night, not the 2.2x the run mean implies, and the cap still binds on any night carrying two or three metros.
 It bound twice in those six nights, both times on an end-of-night sliver rather than on a city that was ever unaffordable: New York needed 484 with 426 left, and Normal, Illinois needed 40 with 38 left.
 That shape is the argument for the capped-and-resume work in #318 as well as for this raise — the raise fixes the average night, a resumable census fixes the tail.
 
 **What this actually spends.** Since #290 the walk reuses the grid run's census for zero requests on a paired night, and the table above shows `mapillary_streets` spending 0 on five of the six nights.
-The *combined* per-IP load has therefore been running at ~1,750/day against the 3,500 that #241 sanctioned — half of it — so on a paired night 3,500 + 0 restores that sanctioned combined ceiling rather than exceeding it.
-**Be honest about the un-paired case**: nothing enforces the pairing, and a split pair can reach **5,250**, which is 1.5x the #241 ceiling and the most this host has been configured for since block 2.
+The *combined* per-IP load has therefore been running at 755–2,260/day (six-night mean ~1,330) against the 3,500 that #241 sanctioned — about 38% of it on the mean and 65% at the 09-03 peak — so on a paired night 3,500 + 0 restores that sanctioned combined ceiling rather than exceeding it.
+**Be honest about the un-paired case**: nothing enforces the pairing, and a split pair can reach **5,250**, which is 1.5x the #241 ceiling and the most this host has been configured for since the 2026-08-22 cut (for ~2 days *after* block 2 it still sat at the old 15,000 + 5,000 = 20,000).
 That is accepted rather than overlooked, on the ground that block 3 (1,938/day, against 26,363 spent clean on 08-14) falsified daily volume and every accumulation window from 1 to 8 days (#286).
 It is **not** accepted on the ground that volume is safe — nothing about this host's behaviour is known safe, and the even split #241 chose still matters on exactly the nights that reach 5,250.
 The structurally correct fix is a single per-IP pool both channels draw from, which is a scheduler change rather than a config edit and is deliberately not attempted here; until it exists, the sum above is the number to quote, never the grid channel's 3,500 alone.
@@ -147,11 +152,12 @@ An equally good rival at n=2, and keep them distinct: a **repeat-offender penalt
 Separating them costs a block if the experiment works, so it is deliberately not being run (Jon, 2026-08-22).
 Full analysis, both incidents' numbers, and the staff statements: issue #241.
 
-Consequences, in force until a rolling guard lands: **(1) no `--limit` catch-ups.** The daily budgets bound any single day, but three consecutive maxed days sum to 10,500 — inside the 3-day uncertainty band
+Consequences, in force until a rolling guard lands: **(1) no `--limit` catch-ups.** The daily budgets bound any single day, but three consecutive maxed days sum to 10,500 (that figure is 1,750 + 1,750; since the 2026-09-05 re-size it is 10,500 paired and **15,750** un-paired, so the raise widens what a catch-up could spend if the ban is ever lifted) — inside the 3-day uncertainty band
 — so a multi-night catch-up can reach where normal ~2–3k nights cannot.
 The guard itself is a query change, not a schema change (`api_usage` is keyed (usage_date, provider) and already holds the history) — #241 item 3.
-**(2) The budget, not `max_batch_hours`, now ends a maxed Mapillary night**: 3,500 is ~1 h of paced fetching against the ~17,000-tile deadline ceiling.
-At the 57.8-tile mean each channel reaches ~30 cities/night and the 70,168-tile catalog is one full pass in **~40 nights**, not ~5; no city is ever skipped as over-budget (largest grid 870 < 1,750).
+**(2) The budget, not `max_batch_hours`, ended a maxed Mapillary night** while both channels sat at 1,750: that was ~1 h of paced fetching against the ~17,000-tile deadline ceiling, ~30 cities/night at the 57.8-tile mean, and one 70,168-tile catalog pass in **~40 nights**, not ~5.
+Since the 2026-09-05 re-size the grid channel's 3,500 reaches ~60 cities and ~20 nights, and it is the **40-city cap** that ends the night — every night 09-03..09-08 stopped on it in 6.8–10.6 h against `max_batch_hours = 12`.
+No city has ever been skipped as over-budget in either regime (largest grid 870).
 **(3) If a block ever arrives under this cap**, that is strong evidence for the repeat-offender reading over the fixed window
 — capture the day's `api_usage` row, the elapsed hours from the `run-due` summary line (the `[alerts]` email carries it; nothing else records time-under-load), AND the trailing 3 days' ledger before changing anything.
 

--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -163,7 +163,7 @@ A multi-hour KartaView sweep is that channel: last, exactly one channel eats the
 `mapillary` (rank 2) launches before `mapillary_streets` (rank 3), so within a city the grid run pays for the shared z14 census and the walk reads it for zero requests; `kartaview` (4) and `kartaview_streets` (5) are the same pair over the radius sweep, wired in #258.
 Measured on the first KartaView walk (Krabi, 2026-08-31): 87 sweep requests un-paired, against the 18,851 that same walk costs on `gsv_streets` at one request per on-street sample — and 0 on any night the grid run got there first.
 That is a consequence of the existing ranking rather than a new constraint on it — reversing the pair would simply move which channel's ledger carries the spend, and `census_fetched_by` would record that faithfully either way — but it is why the two are ranked adjacently and why nothing should separate them.
-Nothing else here has that (Mapillary's checkpoint is #256, and a truncated tile census re-spends against a 3,500/day per-IP ceiling).
+Nothing else here has that (Mapillary's checkpoint is #256, and a truncated tile census re-spends against the per-IP ceiling — 3,500/day on a paired night, 5,250 un-paired since the 2026-09-05 re-size, see docs/provider-access.md).
 **Cheapest is not free, in two ways that both matter.**
 No channel keeps its ledger row through a SIGKILL, whatever its provider.
 And a SIGKILL still counts a `consecutive_failure` — only a *deliberate* pause (exit `SWEEP_INCOMPLETE_EXIT_CODE`) is amnestied — so the resumption that justifies this ranking is itself bounded at five nights.
@@ -277,7 +277,7 @@ Dividing makes the knob a no-op at 1 and bounded above it; the trade is that a c
 **Two things gated raising it in production. The first is now satisfied; the second is still outside this repo.**
 (1) **Resume for every provider**, because a deadline or a `systemctl stop` now kills up to N children at once instead of 1.
 This is **met as of #256**: GSV grid (`.downloading` sibling), the GSV road walk (same `collect_points_async` engine), KartaView (`checkpoints/`, #239) and both Mapillary channels (`checkpoints/`, #256) all resume,
-so a killed child costs the tiles it had not yet fetched rather than the ones it had — which mattered here because a re-spend lands against the deliberate 3,500/day per-IP ceiling, i.e. ban risk under #241 rather than merely lost time.
+so a killed child costs the tiles it had not yet fetched rather than the ones it had — which mattered here because a re-spend lands against the deliberate per-IP ceiling — 3,500/day paired and 5,250 un-paired since 2026-09-05 (#286) — i.e. ban risk rather than merely lost time.
 A killed child still records no `api_usage` at all (#238), and that loss multiplies by N — unchanged by the checkpoint, since it is the parent that never sees the number.
 (2) **`gsv` and `gsv_streets` hold no per-IP lock**, because Google meters per Cloud *project* rather than per IP — so running them together is only safe while `GMAPS_API_KEY` and `GMAPS_STREETS_API_KEY` really do live in **separate projects**.
 Nothing in this repo records which project either key belongs to; it is a console check, and a shared project must be fixed by splitting the keys, never by inventing a fake `CHANNEL_HOSTS` entry (that would couple the night-level breaker to a condition that is not a host refusal).

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1068,9 +1068,12 @@ def test_makelab1_production_config_is_wired():
         assert pc.enabled, f"{channel} resumed under #292"
         assert pc.max_requests_per_minute == 40
         assert pc.jitter == pytest.approx(0.6)
-    # The restart is about the mechanism, not the sizing — the budgets stay at the
-    # values #241/#267 argued for; a fourth cut has no mechanism to work through.
-    assert cfg.providers["mapillary"].daily_request_budget == 1_750
+    # The #292 restart was about the mechanism, not the sizing, and shipped at the
+    # 1,750 both channels had carried since #241. The grid channel moved to 3,500 on
+    # 2026-09-05, once the pre-registered jitter window closed — a 20-city budget
+    # meeting the 40-city night #304 created, not a relaxation of the block posture.
+    # The walk channel is unchanged: since #290 it spends 0 on a paired night.
+    assert cfg.providers["mapillary"].daily_request_budget == 3_500
     assert cfg.providers["mapillary_streets"].daily_request_budget == 1_750
     # kartaview was turned on in production on 2026-08-28, the separate deploy
     # decision this assertion previously withheld (#248). Enabling the CHANNEL
@@ -1161,13 +1164,31 @@ def test_makelab1_production_config_is_wired():
     # decision someone made on purpose.
     mly = cfg.providers["mapillary"].daily_request_budget
     mly_streets = cfg.providers["mapillary_streets"].daily_request_budget
-    assert mly == 1_750
+    assert mly == 3_500
     assert mly_streets == 1_750
-    assert mly + mly_streets == 3_500, (
-        "the tile block is per IP, so the two channels' budgets SUM — the "
-        "2026-08-22 cut keeps any 2-day total at <= 7,000, at or below the "
-        "highest value ever observed clean (7,061), because only a rolling "
-        "2-3 day window fits both blocks (issue #241, see CLAUDE.md)"
+    # The sum is still the figure that matters, because the block is per IP and
+    # these are two tokens at one address. What changed on 2026-09-05 is the
+    # BASIS for it, not the fact that it binds. #241 sized 1,750 + 1,750 so any
+    # 2-day total stayed under 7,000; block 3 retired that window entirely
+    # (#286), and #304 then doubled max_cities_per_day without the budget
+    # following, so the grid channel pinned its cap on the first two 40-city
+    # nights. Asserted as a RANGE with both ends named, because the two ends are
+    # different facts and a single number would hide the second:
+    assert mly + mly_streets == 5_250, (
+        "an UN-PAIRED night is the worst case and it is 1.5x the ceiling #241 "
+        "sanctioned — the honest cost of the 2026-09-05 raise, accepted only "
+        "because block 3 falsified daily volume and every 1-8 day window "
+        "(#286), never because volume is known safe (issue #286, "
+        "docs/provider-access.md)"
+    )
+    # ...but the night the scheduler actually produces is the PAIRED one, where
+    # #290's census reuse means the walk spends 0 and the combined load is just
+    # the grid channel's 3,500 — exactly the ceiling #241 already sanctioned.
+    # Pinned so that a future change to mapillary_streets' budget has to argue
+    # with the paired case rather than silently doubling the un-paired one.
+    assert mly == 3_500, (
+        "on a paired night (#290 census reuse) this IS the combined per-IP "
+        "spend, and it is the 3,500 #241 sanctioned"
     )
     # The per-minute pace is still pinned — an unpaced burst (~370/min) is
     # confirmed harmful — but per #241 it is NOT sufficient on its own, and per

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1154,11 +1154,15 @@ def test_makelab1_production_config_is_wired():
     # per app, at 21% and 10% of it, 302 not 4xx). #214's bet that the 60/min
     # pace was the real protection was FALSIFIED on 2026-08-20 (issue #241:
     # blocked while obeying it exactly, at 5,013/day the day after 5,753 ran
-    # clean), and only a rolling 2-3 day per-IP window fits both incidents
-    # (2-day threshold in (7,061, 10,766]). Split EVENLY because both channels
+    # clean), and #241 read that as a rolling 2-3 day per-IP window fitting
+    # both incidents (2-day threshold in (7,061, 10,766]). SUPERSEDED: block 3
+    # retired that window and every other 1-8 day accumulation band (#286, and
+    # see the note below) -- it is kept here as the derivation the numbers came
+    # from, not as a live hypothesis. The EVEN split it chose (both channels
     # read the identical z14 tile census, so the budgets deplete in lockstep
     # and a heavy slate defers the same cities on both channels rather than
-    # un-pairing them. Pinned exactly, not bounded
+    # un-pairing them) is likewise history: #290 made the walk price at 0 on a
+    # paired night, and 2026-09-05 made the split 2:1. Pinned exactly, not bounded
     # loosely: this is the sort of number that drifts upwards one "just a bit
     # more" at a time, and the whole point is that a change to it is a
     # decision someone made on purpose.
@@ -1172,23 +1176,21 @@ def test_makelab1_production_config_is_wired():
     # 2-day total stayed under 7,000; block 3 retired that window entirely
     # (#286), and #304 then doubled max_cities_per_day without the budget
     # following, so the grid channel pinned its cap on the first two 40-city
-    # nights. Asserted as a RANGE with both ends named, because the two ends are
-    # different facts and a single number would hide the second:
+    # nights. Both ends are named in the MESSAGE rather than in a second
+    # assertion: the un-paired sum is the only one of the two that this line
+    # can actually constrain, because the paired figure IS the grid channel's
+    # own budget (mly_streets prices at 0 under #290's census reuse) and is
+    # already pinned at mly == 3_500 above. A second `assert mly == 3_500`
+    # here would restate that line while touching nothing about mly_streets,
+    # so it is deliberately not written.
     assert mly + mly_streets == 5_250, (
         "an UN-PAIRED night is the worst case and it is 1.5x the ceiling #241 "
         "sanctioned — the honest cost of the 2026-09-05 raise, accepted only "
         "because block 3 falsified daily volume and every 1-8 day window "
-        "(#286), never because volume is known safe (issue #286, "
+        "(#286), never because volume is known safe. The PAIRED night is "
+        "3,500 + 0, the ceiling #241 already sanctioned; moving EITHER "
+        "channel's budget has to argue with both numbers (issue #286, "
         "docs/provider-access.md)"
-    )
-    # ...but the night the scheduler actually produces is the PAIRED one, where
-    # #290's census reuse means the walk spends 0 and the combined load is just
-    # the grid channel's 3,500 — exactly the ceiling #241 already sanctioned.
-    # Pinned so that a future change to mapillary_streets' budget has to argue
-    # with the paired case rather than silently doubling the un-paired one.
-    assert mly == 3_500, (
-        "on a paired night (#290 census reuse) this IS the combined per-IP "
-        "spend, and it is the 3,500 #241 sanctioned"
     )
     # The per-minute pace is still pinned — an unpaced burst (~370/min) is
     # confirmed harmful — but per #241 it is NOT sufficient on its own, and per


### PR DESCRIPTION
## What and why

`[providers.mapillary].daily_request_budget` **1,750 → 3,500**. `mapillary_streets` stays at 1,750.

This is the sizing question #286 left open, and it is **not** a relaxation of the block posture. 1,750 was sized on 2026-08-22 (#241) for a **20-city** night. `max_cities_per_day` went 20 → 40 in #304 on 09-02 and this figure did not follow, so the cap began binding on the first 40-city night:

| Night | grid | walk | combined | `max_cities_per_day` |
|---|---|---|---|---|
| 2026-08-30 | 755 | 0 | 755 | 20 |
| 2026-08-31 | 950 | 0 | 950 | 20 |
| 2026-09-01 | 1,241 | 0 | 1,241 | 20 |
| 2026-09-02 | 1,037 | 0 | 1,037 | 20 |
| 2026-09-03 | **1,736** | 524 | 2,260 | **40** |
| 2026-09-04 | **1,723** | 0 | 1,723 | **40** |

It bound twice in those six nights, both on an end-of-night sliver rather than a city that was ever unaffordable:

```
new-york--new-york--united-states [mapillary] (~484 req) doesn't fit remaining budget (426 left); skipping.
normal--illinois--united-states [mapillary] (~40 req) doesn't fit remaining budget (38 left); skipping.
```

That tail is #318 (capped-and-resume); this PR is the average night.

## Sizing it on the unbiased distribution

**Corrected after review — the first version of this PR sized the night on a biased population.** Cost over the 1,398 *runs* collected is median 9, p90 81, max 870, mean 39, but the budget gate skips exactly the expensive cities, so that population is biased low by construction: the 85 enabled cities with **no Mapillary run at all** average a **728.6 km²** frozen grid against **131.6 km²** for the 1,132 that have one, and tile count scales with area.

The unbiased figures were already in `docs/provider-access.md` 80 lines above the new section — geometry over all 1,214 enabled cities: median 12, **mean 57.8**, p90 180, p99 480 — and the per-*city* mean over latest runs is **45.2**.

So a 40-city night demands roughly **1,800–2,400**, not the ~1,560 the run mean implied, and the table above confirms it from observation rather than model: 09-03 demanded 1,736 spent **plus** the 484 and 40 it skipped = **2,260** (56.5/city); 09-04 spent 1,723 across 29 Mapillary cities (59.4/city). **3,500 is ~1.5x headroom over a normal 40-city night, not 2.2x.**

## The honest cost

**Quote the per-IP sum, not the grid channel alone.** Since #290 the walk reuses the grid run's census for 0 requests on a paired night — it spent exactly 0 on five of those six nights — so:

- **Paired night: 3,500 + 0 = 3,500.** Exactly the combined ceiling #241 already sanctioned. Combined load has been running at 755–2,260/day (six-night mean ~1,330), i.e. ~38% of it.
- **Un-paired night: 3,500 + 1,750 = 5,250.** 1.5x that ceiling, and the most this host has been configured for since the 2026-08-22 cut (for ~2 days *after* block 2 it still sat at the old 15,000 + 5,000 = 20,000).

The un-paired case is accepted because block 3 (1,938/day, against 26,363 spent clean on 08-14) falsified daily volume and every accumulation window from 1 to 8 days (#286) — **not** because volume is known safe here. Nothing about this host's behaviour is known safe. The structurally correct fix is a single per-IP pool both channels draw from, which is a scheduler change rather than a config edit and is deliberately out of scope.

The 2:1 split creates no un-pairing regression: a cache hit prices the walk at 0, so its budget only pays for cities the grid skipped, and the raise means the grid skips fewer. If anything it improves pairing.

## Timing

Deliberately **held until after #292's pre-registered jitter window closed (~2026-09-09)**. Volume is an axis that test holds still, so raising it inside the window would have handed a fourth block two candidate causes where the design went to real trouble to leave one. Night 6 (09-04) — the predicted fourth-block night — already ran clean, as has every night 08-30..09-09.

Production ran at 1,750 every night through 09-09, so every date in the configs is now stamped by **decision** rather than deploy — a doc that says "3,500 as of 09-05" would assert a live state that never existed.

## Tests

Both pinning sites in `tests/test_scheduler.py` are **updated, not loosened** — that guardrail exists so this number can only move on purpose. Mutation-verified after the review fixes: moving *either* channel's budget still fails the test.

## Review

Deep-reviewed by three independent reviewers (Opus 5; agy's Gemini 3.1 Pro and 3.8 Flash). All historical numbers reproduce against prod; budget semantics confirmed per-channel, per-date, a skip rather than a truncation, with nothing derived moving. [Findings and dispositions](https://github.com/jonfroehlich/streetscape-tracker/pull/319#issuecomment-5605688654) — nine acted on in `e6600a6`, chiefly the biased sizing mean above, eight sites still quoting the old per-IP sum, and a third pinning assertion that duplicated one 22 lines above it while claiming a guard it could not provide.

One suspected defect was raised and **disproven** rather than shipped: raising the budget does not inflate a resumable child's timeout, since `timeout_s` is computed independently and `request_cap = min(remaining, affordable)`.

Full suite green: 2,017 passed, 1 skipped. `ruff check` and `ruff format --check` clean.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) — Opus 5 (1M context), claude-opus-5[1m]
