### PR TITLE
Panoramax collector: a fourth provider, credential-free, hand-collectable (#316)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,8 @@ It is a **router**: each section carries the short, mistake-preventing rules and
 ## What this project is
 
 Streetscape Tracker analyzes street-level imagery coverage and temporal patterns in cities **over time**.
-Three providers are collectable — Google Street View (GSV, the default), Mapillary (360° panos only), and KartaView.
+Four providers are collectable — Google Street View (GSV, the default), Mapillary (360° panos only), KartaView, and Panoramax.
+Panoramax is the newest and the only credential-free one; it is collectable by hand but **not yet a scheduler channel** (#316 phase 2, `UNWIRED_CHANNELS`).
 GSV and Mapillary run nightly over **every enabled city**; KartaView is a scheduler channel too but **opt-in**, collecting only the cities an operator enrolled with `scheduler enroll-city` (#248), because one whole-catalog pass prices at ~205,000 requests ≈ 215 h at the configured 16/min.
 The tool samples a geographic grid around a city center, queries each provider's metadata API, and produces immutable dated snapshots per (city, provider), run-to-run change summaries (panos added/removed, capture-date changes, coverage deltas), and interactive map visualizations.
 
@@ -22,6 +23,7 @@ The tool samples a geographic grid around a city center, queries each provider's
 | GSV | [Street View Static API usage & billing](https://developers.google.com/maps/documentation/streetview/usage-and-billing) + the API's own docs | Google Maps Platform issue tracker; Stack Overflow `google-street-view` tag |
 | KartaView | No developer portal: the single documented figure (100/h anonymous, 1,000/h authenticated) sits in a JS-SPA FAQ, restated by [Bellingcat's toolkit](https://bellingcat.gitbook.io/toolkit/more/all-tools/kartaview) | **None exists** — the `kartaview/openstreetcam.org` tracker is unstaffed, so for this provider there is no early warning at all; pace on the documented number and stage volume changes |
 | Mapillary | [API documentation](https://www.mapillary.com/developer/api-documentation), incl. its rate-limits section | [forum.mapillary.com](https://forum.mapillary.com) — **not optional**: Mapillary's real operational limits are undocumented and described only there |
+| Panoramax | [API docs](https://panoramax.fr) and the OpenAPI spec at `api.panoramax.xyz/openapi.json` — **neither documents any rate limit**, and no `X-RateLimit-*`/`Retry-After` header comes back | [forum.geocommuns.fr](https://forum.geocommuns.fr) and the [OSM community forum](https://community.openstreetmap.org/), both staffed by core developers — so unlike KartaView the pacing question CAN be asked; it has not been (#316), which is why the pace is deliberately half Mapillary's |
 
 **The documented limit is not necessarily the binding one, and the forum is where you learn that.**
 The 2026-08-12 case study: an undocumented per-IP throttle (302 → login) blocked both our Mapillary apps at ~21% of the documented per-app daily cap, and a forum thread had already described that exact failure, its per-IP scope, and its retry hazard before we sustained 370 req/min into it.
@@ -40,6 +42,7 @@ python streetscape_tracker.py "Seattle, WA"
 python streetscape_tracker.py "Seattle, WA" --provider mapillary
 python streetscape_tracker.py "Seattle, WA" --force --run-date 2026-07-02
 python streetscape_tracker.py "Seattle, WA" --provider mapillary --refetch-census  # ignore the shared census cache (#290)
+python streetscape_tracker.py "Des Moines, Iowa" --provider panoramax   # no credential; z15 tile census (#316)
 python streetscape_tracker.py "Seattle, WA" --check-boundary        # preview search area only
 python run_cities.py cities.txt --continue-on-error                 # batch
 
@@ -110,14 +113,16 @@ Credentials live in `.env`, loaded per channel by `streetscape_metadata_tracker/
 | `gsv_streets` | `GMAPS_STREETS_API_KEY` | Isolated street-collection key (#99) with its own `api_usage` string, so street experiments can't exhaust production quotas; **live** |
 | `kartaview_streets` | `KARTAVIEW_STREETS_ACCESS_TOKEN` | The one street channel that **falls back to `KARTAVIEW_ACCESS_TOKEN`** rather than requiring its own: one machine-wide `host_lock(HOST_KARTAVIEW)` serializes every KartaView request, so there is no parallel burn to isolate. Scheduled and **opt-in**, enrolled SEPARATELY from `kartaview` (#258) |
 | `mapillary_streets` | `MAPILLARY_STREETS_ACCESS_TOKEN` | Same isolation; **dormant** |
+| `panoramax` | none — unauthenticated read | The only credential-free channel (#316): `CHANNEL_ENV_VARS["panoramax"]` is an **empty tuple**, not a missing row, and `load_config` returns `{"access_token": None}` rather than raising — a channel that raised for a key it does not have would take down every other provider in the same `--provider all` invocation |
 
 A run requires EVERY named provider's key up-front, `--provider all` included (fail-fast so the series can't drift); a single-provider run needs only its own key.
+A credential-free channel is the one exception and is declared rather than special-cased (`config.CREDENTIAL_FREE_CHANNELS`, derived from the table above).
 
 Three `--provider` flags exist with **different vocabularies** — never conflate them:
 
 | Surface | Accepts | Shape |
 |---|---|---|
-| `streetscape_tracker.py --provider` | `gsv`, `mapillary`, `kartaview`, `all`; the retired `both` still works, with a notice (#247) | Comma-separated list; default `gsv,mapillary` |
+| `streetscape_tracker.py --provider` | `gsv`, `mapillary`, `kartaview`, `panoramax`, `all`; the retired `both` still works, with a notice (#247) | Comma-separated list; default `gsv,mapillary` |
 | `scheduler run-due --provider` | The six scheduled channels: `gsv`, `gsv_streets`, `kartaview`, `kartaview_streets`, `mapillary`, `mapillary_streets` | Repeatable or comma-separated; no `all` or `both` |
 | `scheduler assess-city --provider` | `gsv_streets`, `mapillary`, `mapillary_streets` — the GSV grid run is never part of it | Repeatable or comma-separated |
 
@@ -149,6 +154,14 @@ The out-of-band GSV capture-history harvester (#2) is documented there too.
 The census pipeline — record → rows → grid assignment → written CSV — lives **once** in `census.py`, parameterized per provider; never copy it into a provider module, because the contracts it enforces are invisible in a review of the second copy.
 It is columnar (a memory contract, #157), pinned byte-identical by a golden fixture (a formatting drift reads as phantom imagery churn in every diff), and the `image_columns` contract is enforced rather than documented.
 `is_pano` is read through `census.census_is_pano`, never as a raw array; imagery-type stratification (#116) yields **two** coverage numbers — 360° and any-imagery — which are never conflated.
+Three Panoramax rules that must survive without a read (#316):
+
+- **The census is the v1 `pictures` layer at z15, never `/api/search`** — search does not paginate, reports no `numberMatched` and SILENTLY IGNORES its own `datetime` filter (measured: 5,045 pictures that the requested windows should have excluded all came back), so an incremental fetch built on it would re-read the whole history and report it as new.
+  z15 is the coarsest zoom that serves the layer at all, so a bbox costs ~4x Mapillary's tiles; the shared `tiles_for_bbox` therefore takes zoom as a REQUIRED argument and each provider re-exposes it with its own default.
+- **A 403 or 429 is a per-IP refusal, and a 404 is an EMPTY TILE** — there is no credential, so 403 cannot mean a rejected token; and an empty area answers 200 with no layer, so a 404 means the tile holds nothing.
+  A lattice where EVERY tile 404s is therefore a moved endpoint, and is refused rather than published as a city that lost all its imagery.
+- **`type` is two-state and `is_pano` is non-nullable** — the search response's absent field-of-view is an EXIF artifact, not a third imagery state; the raw `type` is published as `image_type` anyway, so a value Panoramax has never served would appear in the data rather than being folded into flat.
+
 Four KartaView rules that must survive without a read:
 
 - **BOTH KartaView channels are scheduler channels (#248, #258), and they are the OPT-IN ones** — declaring `[providers.kartaview]` or `[providers.kartaview_streets]` enrolls nobody; each nightly queue is exactly the cities an operator ran `enroll-city` on for THAT channel, because a whole-catalog pass is ~205,000 requests ≈ 215 h at 16/min (and both channels share ONE host lock, so that rate is their combined ceiling, never each).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -195,8 +195,8 @@ This is what READ THIS FIRST points at; read it before changing any pacing, retr
 
 | Family | Codes | Meaning |
 |---|---|---|
-| Blocked | 75 / 76 / 81 | The third party refused this IP — trips the night-level breaker |
-| Busy | 79 / 80 / 82 | Another local process holds the host lock |
+| Blocked | 75 / 76 / 81 / 84 | The third party refused this IP — trips the night-level breaker |
+| Busy | 79 / 80 / 82 / 85 | Another local process holds the host lock |
 | Sweep incomplete | 83 | A checkpointed partial sweep (#239) — the budget or deadline ran out, not a host condition; amnestied beside the host conditions (#238), while a SIGKILL has no exit code and still counts a failure, so kill-and-resume is bounded at five nights |
 
 - A blocked or busy night still publishes, alerts unconditionally, and exits nonzero.

--- a/docs/capture-dates.md
+++ b/docs/capture-dates.md
@@ -12,9 +12,11 @@ An edit that changes a rule belongs in both files; anything written since the sp
 **The capture-date columns describe official Google imagery, and only dates that can be true (issue #213).** `analysis.dated_unique_panos` is the single seam every date-derived statistic reads
 — age stats, the capture-year histogram, the daily histogram, in both the catalog and the per-run JSON — and it drops two populations.
 **(1) Impossible dates.** Contributor photospheres arrive with corrupt EXIF, and because `oldest/newest_capture_date` are a min and a max, *one* pano owns them: 22 production runs read 2611–2612 and 75 predated Street View, off 1–22 bad panos in cities of 175k–334k.
-`EARLIEST_PLAUSIBLE_CAPTURE` is per provider (gsv 2007, mapillary **2004**
-— deliberately looser than its 2013 founding, matching the identical rule `download_mapillary.captured_at_to_iso_date` already applies at decode, because contributors upload genuinely old photographs) and the ceiling is the observation date itself, inclusive
+`EARLIEST_PLAUSIBLE_CAPTURE` is per provider (gsv 2007, mapillary **2004**, kartaview **2004**, panoramax **2004**
+— each of the three community providers deliberately looser than its own founding, matching the identical rule each decoder applies at decode, because contributors upload genuinely old photographs) and the ceiling is the observation date itself, inclusive
 — nothing is captured after the query that saw it, and GSV's month-precision dates are pinned to the 1st so they can only round toward the past.
+Each provider's floor also catches a SENTINEL that provider actually serves, which is what makes the number worth measuring rather than choosing: Mapillary's is an epoch-zero device clock, and Panoramax's is a literal `1970-01-01` timestamp — two Paris pictures, found in issue #316's phase-1 survey.
+A sentinel is not a null and no null check catches it; what it hands you is a well-formed, entirely plausible-looking timestamp, and the floor is the only thing between it and every date statistic the city has.
 **(2) For gsv, third-party imagery.** Not merely defensive: the site has always *displayed* the Google-filtered figures (`adaptCityRecord` reads the per-run JSON's `google_panos` block), so an all-panos catalog column published under the same name as the map's "median age" was two different numbers wearing one label
 — the driving page showed one and the overview map the other.
 Empirically the copyright filter alone repaired every affected run on a 1,171-JSON catalog (zero `© Google` panos carried a bad date), and the date bound is what fixes the published **`all_panos`** block, which by definition the copyright filter cannot.

--- a/docs/census.md
+++ b/docs/census.md
@@ -395,3 +395,59 @@ The one input it cannot share is the deadline clamp — a preview has no night i
 
 The road walk is no longer absent: #258 generalized `collect_mapillary.build_streetwalk_rows` into the shared `census_walk.py` scorer and added `collect_kartaview.py`, and #299 made `kartaview_streets` the sixth scheduler channel — opt-in, like the grid channel it pairs with.
 It reads the same census by the same radius sweep, so it inherits the grid channel's cost arms wholesale: the same 1.80x overhead, the same geometric-floor estimate, and the same request cap, which is why both KartaView channels are `CHANNEL_RESUMABLE`.
+
+## Panoramax is the third census provider, and its primitive is Mapillary's with three differences (issue #316)
+
+**`download_panoramax.py` is shaped on `download_mapillary.py`, not on `download_kartaview.py`**, because the primitive is the same: a lattice of vector tiles fetched concurrently behind a semaphore, rather than a serial radius sweep whose next question depends on the last answer.
+Everything that follows from that shape is inherited rather than re-decided — `(x, y)`-keyed checkpoint parts, reassembly recomputed from `tiles_for_bbox` rather than stored, only-successful-tiles-commit, a zero-row tile getting a record and no file, checkpointing that fails OPEN, and promotion into the #290 cache as the last statement before the success return.
+Read the Mapillary sections above for all of it; this section is only what differs, and each difference is something a reader coming from that module will otherwise assume away.
+
+**The tile math moved down to `download_common.py` rather than being imported across providers.**
+`lonlat_to_tile_frac`, `tile_frac_to_lonlat`, `tiles_for_bbox` and `points_in_tiles` lived in `download_mapillary` until a second tile census needed them, and they moved for exactly the reason `grid_bbox` and `assign_to_grid` did one refactor earlier: pure geometry that merely happened to sit in the first provider that wanted it, with the alternative being one provider module importing another's.
+The shared `tiles_for_bbox` takes the zoom as a **required** argument — a lattice helper serving two providers at two zooms has no default to be right about — and each provider re-exposes it as a one-line wrapper carrying its own default, so no call site moved and `download_mapillary.tiles_for_bbox(*bbox)` still means z14.
+
+### 1. The census is the z15 `pictures` layer, and `/api/search` can never be it
+
+`/api/search` is the obvious instrument and it cannot count.
+It **does not paginate** — `links` comes back empty at `limit=1`, `limit=1000` and `limit=10000` alike, there is no `next`, and the response carries no `numberMatched` — so a bbox holding more pictures than `limit` is indistinguishable from one holding exactly `limit`, which is the one distinction a coverage census is made of.
+It **silently ignores its own `datetime` filter**: across 20 cities the requested windows should have excluded 5,045 baseline pictures and all 5,045 came back, so an incremental "everything since the last run" fetch would re-read the whole history and report every row as new.
+And it is enormous, because every feature embeds a ~90-key EXIF blob: 1,000 features is 7.7 MB and 10,000 is 75 MB.
+
+So the census is the v1 map endpoint's `pictures` layer, which starts at **z15** — the coarsest zoom that serves it at all, and therefore the cheapest.
+That is not a tunable and getting it wrong is silent rather than loud: below z15 the layer is absent entirely, so every tile would decode to nothing and the run would publish a city holding no imagery rather than failing.
+The cost that follows is a real difference from Mapillary and not a rounding one: the same bbox is ~4x the tiles, a catalog p50 of 35 against Mapillary's 12, and over the cities actually worth enrolling a p50 of 414 tiles, p90 2,400 and max 3,132 (~104 minutes at the shipped pace).
+`estimate_tile_count` counts that lattice exactly, offline and free, so unlike KartaView's sweep there is no observed-versus-geometric correction to carry.
+
+The v2 endpoint's H3 `grid` layer — aggregated counters rather than rows — is the *screen* instrument phase 1 used to price the whole catalog for 113 requests, and it is not read by the collector at all.
+
+### 2. A 403 or 429 is a per-IP refusal, and a 404 is an empty tile
+
+**There is no credential**, which changes what a 4xx can mean.
+On Mapillary and KartaView a 403 is a rejected token and is deliberately typed as a plain `DownloadError` scoped to the credential; here it cannot be, so **403 and 429 are both `HostBlockedError` at the first request** — stop, never retry, and let the scheduler's night-level breaker see it.
+`HOST_PANORAMAX` is the fourth locked host, with exit codes **84 blocked / 85 busy**, continuing past 83 rather than filling the 77/78 gap that stays open because those are `EX_NOPERM`/`EX_CONFIG`.
+
+**A 404 is an ANSWER, not a failure** — the opposite of Mapillary's reading, and measured rather than assumed: phase 1 saw 0 empty tiles across 3,321 requests *including 20 cities that hold no imagery at all*, because an empty area answers 200 with no picture layer.
+That reading needs a guard, and it is the one piece of this module with no Mapillary counterpart: **a lattice where every tile 404s is refused**.
+An empty city answers 200, so a whole lattice of 404s is what a moved or renamed endpoint looks like — and without the guard the run would finalize 0 panos and `diff.py` would report every pano in the city removed, into an immutable dated snapshot.
+
+### 3. `type` is two-state, and the raw value is published anyway
+
+Issue #316 read the 10–34% of `/api/search` results carrying no `pers:interior_orientation.field_of_view` as a third imagery state.
+It is not: every one of the 2,136 EXIF-less search pictures that could be looked up is `flat` in the tile layer, whose `type` has no absent state at all (federation-wide, 119,362,642 pictures = 52,128,373 `equirectangular` + 67,234,269 `flat` + 0 unclassified), and not one of the 1,345,143 pictures phase 1 read off this layer carried an absent type.
+That is what lets the census schema declare `is_pano` a **non-nullable `"bool"`** — the honest declaration, and the one `census.census_is_pano` documents at length the alternatives to.
+
+The raw string is published as `image_type` regardless, beside the boolean it produces.
+A run file records what the provider said, so a third `type` value Panoramax has never yet served appears in the data as itself rather than being counted as flat by the decoder and never seen again.
+The rest of the run schema is deliberately thin — `account_id`, `sequence_id`, `is_pano`, `image_type` — because that is what a tile carries: `license`, `geovisio:producer` and `quality:horizontal_accuracy` exist only in `/api/search`, so `copyright_info` names the contributor (the parity convention Mapillary's `creator_id` and KartaView's `username` already follow) rather than the licence.
+
+**The decoder reads `id` from the layer's properties ONLY, with no fall back to the MVT feature id** — which `download_mapillary`'s does have, and which would be a defect here.
+An MVT feature id is numbered per tile, so the fallback mints id `0` in every tile of the city, and `dedupe_census` factorizes on `id`: those collisions would silently collapse distinct pictures into one across the whole city.
+A picture the layer does not name is dropped instead.
+
+**Pacing is 30/min with jitter 0.6**, half the Mapillary channels' configured rate against a host with strictly less published guidance — nothing documents a limit anywhere found, and no `X-RateLimit-*` or `Retry-After` header comes back.
+The jitter is adopted before any incident rather than after three; see [`provider-access.md`](provider-access.md) for the full access survey and for what has and has not been asked.
+
+**Collectable by hand, not scheduled.**
+`streetscape_tracker.py --provider panoramax` collects a city, and `naming.KNOWN_PROVIDERS` carries the token so the run reads back under its own schema.
+But `scheduler.UNWIRED_CHANNELS` still holds `panoramax`, so a `[providers.panoramax]` block is dropped with an error rather than run: `estimate_requests`, `city_timeout_seconds`, the `enabled_providers` rank and the `_run_one_city` pacing flag have no arm for it yet, and each of those fails OPEN in the way #238 records.
+`CHANNEL_DEFAULT_MEMBERSHIP["panoramax"]` is already `False`, on a measurement rather than a cost argument: 730 of 1,144 enabled cities screen to a conclusive zero, so a default-membership channel would spend most of its slots confirming absence.

--- a/docs/experiments/panoramax-feasibility.md
+++ b/docs/experiments/panoramax-feasibility.md
@@ -17,7 +17,8 @@ The 20 richest screened cities hold between 15,907 and 1,118,155 pictures each �
 Des Moines holds 548,451 360° pictures on Panoramax against 352,570 in Mapillary's census of the identical frozen bbox; Ames holds 135,501 against 83,424.
 
 So the recommendation is the KartaView shape, not the Mapillary shape: **an opt-in channel** ([#248](https://github.com/jonfroehlich/streetscape-tracker/issues/248)) enrolled city by city where the screen says there is something to collect, never a default-membership channel that would spend a nightly slot on the 63.8% of cities known to hold nothing.
-The census cost is Mapillary's — the same z14 tiles, a median of 12 per city — with no credential and no per-app quota, so the cost of building it is the collector, not the running.
+The screen is Mapillary-cheap — the same z14 tiles, a median of 12 per city — but the per-picture census is the z15 `pictures` layer, a median of 35 tiles over the same frozen grids (§3 below), so a bbox costs roughly four times Mapillary's.
+Either way there is no credential and no per-app quota, so the cost of building this is the collector, not the running.
 Whether that collector is worth writing for roughly 20–60 cities is a judgement, not a measurement, and this study stops at the measurement.
 
 ## The question
@@ -282,6 +283,11 @@ Panoramax gained instances and pictures throughout 2026 — the newest hex date 
 A re-run is 113 requests for the screen; that is the number to re-check before treating any verdict here as still current.
 
 ## Replicating
+
+**The per-picture decoder moved after this record was produced.**
+Phase 2's collector ([#316](https://github.com/jonfroehlich/streetscape-tracker/issues/316)) owns `pictures_from_tile` now and this script imports it, rather than keeping the copy that produced the numbers below.
+The one behavioural difference is deliberate: the copy here fell back to the MVT feature id when the `pictures` layer did not name a picture, and the collector does not, because those ids are numbered per tile and would collide across a city.
+Finding 4 measured zero pictures without a named id over 1,345,143 rows, so a re-run should reproduce this record exactly — but that is this study's own claim being trusted, not a re-run that has been done.
 
 ```bash
 python scripts/panoramax_feasibility.py --stage screen        # 113 requests, whole catalog

--- a/docs/imagery-providers.md
+++ b/docs/imagery-providers.md
@@ -49,7 +49,7 @@ Kept **alphabetical**, so two branches adding a provider usually insert at diffe
 | Mappls RealView | Yes | **Viewer only** | OAuth2, paid | India | Ruled out — no metadata API |
 | Mapy.cz Panorama | Yes | Unofficial (`streetlevel`) | None | Czechia, Slovakia | Ruled out — scope |
 | Naver Street View | Yes | Unofficial (`streetlevel`) | None | South Korea | Ruled out — scope |
-| Panoramax | Mixed | Official (STAC) | **None** | FR-heavy, growing | **Open — [#316](https://github.com/jonfroehlich/streetscape-tracker/issues/316)** |
+| Panoramax | Mixed | Official (STAC) | **None** | FR-heavy, growing | **Integrated** (collector only; not yet scheduled — [#316](https://github.com/jonfroehlich/streetscape-tracker/issues/316)) |
 | Tencent Street View | Yes | Official (CN) | Key, CN entity | China | Ruled out — scope |
 | Yandex Panorama | Yes | Unofficial (`streetlevel`) | None | RU, TR, CIS | Ruled out — scope |
 
@@ -191,7 +191,9 @@ That is the largest provider gap anywhere in the catalog, and it has no open sol
 
 ### Panoramax
 
-**Status: phase 1 measured — tracked in [#316](https://github.com/jonfroehlich/streetscape-tracker/issues/316), writeup in [`experiments/panoramax-feasibility.md`](experiments/panoramax-feasibility.md).**
+**Status: COLLECTOR SHIPPED, channel not yet — tracked in [#316](https://github.com/jonfroehlich/streetscape-tracker/issues/316), phase-1 writeup in [`experiments/panoramax-feasibility.md`](experiments/panoramax-feasibility.md).**
+`streetscape_tracker.py --provider panoramax` collects a city today; `scheduler.UNWIRED_CHANNELS` still refuses a `[providers.panoramax]` block until the cost, timeout, rank and pacing arms land.
+The mechanism and the three ways it differs from the Mapillary census it is modelled on are in [`census.md`](census.md).
 The median tracked city holds nothing (730 of 1,144 screen to a conclusive zero), but ~20 cities hold 16k–1.1M pictures and Des Moines has more 360° pictures on Panoramax than in Mapillary's census of the same bbox — so the recommendation is an **opt-in** channel on the KartaView pattern, never a default-membership one.
 
 A federated open imagery commons founded by IGN and OpenStreetMap France, licensed per picture, with **25 registered instances** and ~100 M pictures.
@@ -200,8 +202,10 @@ Two instances hold ~99% of them — IGN at 58.0 M and OSM-FR at 54.0 M — with 
 **The federation is not our problem.** [`api.panoramax.xyz/api`](https://api.panoramax.xyz/api) is a meta-catalog that harvests metadata from every registered instance, so we query **one host** no matter how many instances join.
 That means one entry in `host_lock.py`, not 25.
 
-**It is a STAC API**, unauthenticated for read.
-`/api/search?bbox=…&limit=…` works with no credential, and a vector-tile endpoint `/api/map/{z}/{x}/{y}.mvt` exists — structurally the same shape as Mapillary's tile census, so `census.py`, `checkpointing.py` and the [#290](https://github.com/jonfroehlich/streetscape-tracker/issues/290) cache would parameterize onto it rather than needing a new pipeline.
+**It is a STAC API**, unauthenticated for read — the only provider here with no credential at all, which is why `config.CHANNEL_ENV_VARS["panoramax"]` is an empty tuple rather than a missing row.
+The vector-tile endpoint `/api/map/{z}/{x}/{y}.mvt` is the census and `census.py`, `checkpointing.py` and the [#290](https://github.com/jonfroehlich/streetscape-tracker/issues/290) cache parameterized onto it as expected.
+`/api/search` did **not**: it cannot count (no pagination, no `numberMatched`) and silently ignores its own `datetime` filter, both measured in phase 1.
+The one surprise in the cost was the zoom — the per-picture layer starts at **z15**, not Mapillary's z14, so the same bbox is ~4x the tiles.
 
 Per-picture metadata is **richer than either census provider we have**: `datetime` (capture), `created`/`updated` (ingest — so KartaView's `shot_date >= date_added` guard comes from real fields rather than inference), `license`, `geovisio:producer`, `quality:horizontal_accuracy`, `pers:interior_orientation.field_of_view`, and a `via` link naming the source instance.
 
@@ -221,10 +225,15 @@ The consequence for a collector is that Panoramax must report **both** coverage 
 "Field absent" is **not** a third state: the phase-1 study looked 2,136 EXIF-less search pictures up in the tile `pictures` layer, whose `type` has no absent state, and every one is `flat` — the absence is the search endpoint's EXIF passthrough, and a tile-based collector never sees it.
 
 **Rate limits are not documented** anywhere found, including the OpenAPI spec, and a single read-only probe returned no rate-limit headers.
-Unlike KartaView, though, **a staffed community exists** — [forum.geocommuns.fr](https://forum.geocommuns.fr) and the [OSM community forum](https://community.openstreetmap.org/), with core developers answering within days — so the standing rule's "read the forum first" has an object here, and the pacing question can simply be *asked* before any collector is written.
+Unlike KartaView, though, **a staffed community exists** — [forum.geocommuns.fr](https://forum.geocommuns.fr) and the [OSM community forum](https://community.openstreetmap.org/), with core developers answering within days — so the standing rule's "read the forum first" has an object here.
+It was read and not asked: the collector paces at 30/min, half the Mapillary channels', chosen rather than measured. [`provider-access.md`](provider-access.md) carries that decision and the two questions still worth posting.
 
-**One open risk.** Coverage against the catalog is now measured (above).
-But there is active work on migrating sequences between instances, so picture identity across instance moves needs an answer before we build diffs — if an image can change instance and identity, "removed" in a run-to-run diff could mean "migrated", which would corrupt the one statistic this project exists to produce.
+**One open risk, still open.** Coverage against the catalog is now measured (above) and the collector is written.
+But there is active work on migrating sequences between instances, so picture identity across instance moves is unanswered — if an image can change instance and identity, "removed" in a run-to-run diff could mean "migrated", which would corrupt the one statistic this project exists to produce.
+It is recorded as a standing caveat on every Panoramax diff rather than resolved.
+
+**A second, smaller one found while wiring the frontend:** the meta-catalog hosts no picture viewer (its root is a marketing page), and the tile layer carries no instance, so a run row cannot name which of the 23 instances owns a picture.
+What resolves federation-wide from the id alone is the asset route — `/api/pictures/{id}/sd.jpg` answers 308 to the owning instance — so `vis.PROVIDER_DISPLAY` links the PICTURE rather than a viewer, deliberately, rather than guessing an instance.
 
 ### Tencent Street View
 

--- a/docs/provider-access.md
+++ b/docs/provider-access.md
@@ -328,9 +328,17 @@ A read-only probe returned **no `X-RateLimit-*` header, no `Retry-After`, and no
 Per the standing rule that is **unknown, not unlimited**.
 
 **Unlike KartaView, the second half of the rule has an object.** [forum.geocommuns.fr](https://forum.geocommuns.fr) and the [OSM community forum](https://community.openstreetmap.org/) both carry Panoramax traffic answered by core developers within days.
-That is a materially better access position than KartaView's empty room, and it means **the pacing question can be asked rather than inferred** — which is the intended first step of phase 2 and has not been taken yet.
-Two questions belong in that post: what sustained rate the meta-catalog is comfortable with, and whether a picture's identity survives a sequence being migrated between instances.
-The second one is not a courtesy question: there is active work on inter-instance migration, and if an id can change under a move then "removed" in a run-to-run diff can mean "moved", which would corrupt the one statistic this project exists to produce.
+That is a materially better access position than KartaView's empty room, and it means **the pacing question can be asked rather than inferred**.
+
+**It has NOT been asked, and that is a decision rather than an oversight (2026-09-06).**
+Phase 2's collector shipped without a forum post, on the reading that CLAUDE.md's standing rule is to READ a provider's docs and community before changing how we call it — which phase 1's survey did, and which this section is the record of — while *posting* a question was #316's own addition rather than the rule's.
+What that leaves is a pace chosen from nothing the provider said, which is exactly why it is conservative: 30/min, half the Mapillary channels', against the one host here that publishes no number at all.
+Re-read both forums before any change that raises volume, rate or concurrency, and treat a reply there as outranking the number in `config/scheduler.toml`.
+
+**Two questions still belong in a post, and the second is not a courtesy question.**
+What sustained rate the meta-catalog is comfortable with; and whether a picture's identity survives a sequence being migrated between instances.
+There is active work on inter-instance migration, and if an id can change under a move then "removed" in a run-to-run diff can mean "moved" — which would corrupt the one statistic this project exists to produce.
+Until that is answered it is a **known caveat on every Panoramax diff**, not a settled question, and it is recorded here rather than assumed away.
 
 **What the phase-1 study paced at, and why.** 30 requests/minute with jittered gaps at CV 0.6 — the same shifted-exponential shape [#292](https://github.com/jonfroehlich/streetscape-tracker/issues/292) put on the Mapillary channels, imported from `download_common.spaced_gap_seconds` rather than re-derived, so the two cannot drift into different distributions.
 That is roughly half the Mapillary channels' configured rate against a host with strictly less published guidance, which is the intended direction of the asymmetry.
@@ -346,6 +354,13 @@ So an incremental "everything since the last run" fetch would re-read the whole 
 The window is derived per city rather than fixed for a reason worth carrying to the next provider probe: a fixed cutoff cannot distinguish an honoured filter from an ignored one in a city whose imagery lies entirely inside it, and the original fixed `2026-01-01T00:00:00Z` had quietly stopped being in the future, so Boise was being counted as evidence while being none.
 And **`filter=field_of_view=360` returns none of the EXIF-less pictures** (17 of the 17 cities whose sample held one); those pictures are `flat` in the tile layer without exception, so the filter loses nothing a 360° collector wants, but a collector counting "absent" as possibly-360 would overstate coverage in every such city.
 The tile layers are the answer to all three: they carry a `type` field with no absent state, and they are the instrument [`experiments/panoramax-feasibility.md`](experiments/panoramax-feasibility.md) actually uses.
+
+**What the COLLECTOR does, as shipped (#316 phase 2).**
+Same 30/min and the same CV-0.6 jitter as the probe, from `download_common.spaced_gap_seconds` rather than re-derived, and behind `host_lock(HOST_PANORAMAX)` — the fourth locked host, exit codes **84 blocked / 85 busy**.
+**403 and 429 are `HostBlockedError` at the first request**, which is a stronger reading than the other two providers get and follows from there being no credential: on Mapillary and KartaView a 403 is a rejected token and is deliberately scoped to the key, while here it can only be the IP.
+**A 404 is an empty tile rather than a failure** — measured, not assumed: 0 empty tiles across 3,321 phase-1 requests including 20 cities holding nothing, because an empty area answers 200 with no layer.
+The guard that reading needs is that **a lattice where EVERY tile 404s is refused**, since that is what a moved endpoint looks like and the alternative is publishing a city as having lost all its imagery.
+Unlike the probe there is no `refuse_on_collection_host()`: a collector's whole purpose is to run on the collection host, so what protects the nightly batch is the pace, the host lock and the fact that the channel is not scheduled yet.
 
 **One host, not twenty-five.** `api.panoramax.xyz` is a meta-catalog that harvests metadata from every registered instance (23 on 2026-09-04), so a collector would query one host regardless of how many instances join — one `host_lock.py` entry, no per-instance fan-out, and no per-instance rate question.
 The corollary is that all of our load lands on one volunteer-run endpoint rather than being spread across the federation, which argues for the conservative end of any pacing range rather than against it.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -369,6 +369,28 @@ and `_publish` passing `--local` iff `[publish].local`, read from the TOML and a
   The JS mirror is pinned the same way: the three precisions parsing at LOCAL midnight (in a test file that pins `TZ=America/Los_Angeles` before requiring the module, or every assertion passes on a UTC CI runner without the fix), and out-of-range months and days **not rolling over into plausible dates**
   — `new Date(y, 12, 1)` is Jan of the next year, which `isPlausibleCaptureDate` accepts while pandas coerces the same value to `NaT`)
 
+## The Panoramax collector (issue #316, phase 2)
+
+Three files, split the way the other census providers' are, because each pins something the other two structurally cannot see.
+
+- `tests/test_panoramax.py` — the decoder, the date rules and the transport, all offline over tiles encoded in memory with the same coordinate math the decoder inverts.
+  What it pins is mostly the ways this provider is NOT Mapillary, since those are what a reader coming from that module assumes away: the default zoom is **15** and is asserted against the shared `tiles_for_bbox` at both providers' defaults (with the z15 lattice asserted to be strictly finer, or the two defaults would be interchangeable and the test would pin nothing);
+  `type` is kept verbatim as `image_type` beside the `is_pano` it produces, and an ABSENT type decodes to flat with a non-nullable `bool` column rather than to a null;
+  a picture the layer does not name is **dropped rather than given the MVT feature id** — that fallback was copied over with the decoder's shape, and since `mapbox_vector_tile` supplies a feature id even when the properties carry none, it would have minted id `0` in every tile of the city into a `dedupe_census` that factorizes on it.
+  The date rules are pinned scalar-against-vectorized element-wise (the same contract Mapillary's pair carries), plus the measured 1970 sentinel, a future date, and **mixed precision in one column** — the last with a companion assertion that an inferred format really does NaT one of the values, so the `format="ISO8601"` pin is not protecting against a hazard that does not exist.
+  Transport: 403/429 raise `HostBlockedError` after exactly ONE call, a redirect is seen rather than followed, an HTML body under a 200 is a block, a 404 is an empty tile that is counted and not retried, and a 5xx is retried with every attempt paced AND counted (the #198 contract).
+- `tests/test_panoramax_grid_run.py` — the join between the fetch and the shared tail, which neither of the other two files can see: that the bindings actually reached are Panoramax's, so the CSV carries its schema in **its own column order**.
+  Also the three #116 statuses over one city (a pano is OK, a flat-only point is FLAT_ONLY with a NULL capture date, an empty point is ZERO_RESULTS), the 1970 sentinel landing as **NO_DATE rather than as a dropped row** — it is in `PRESENT_STATUSES`, so the imagery still covers while ageing nothing — an undownloaded tile marking REQUEST_FAILED at this provider's zoom, the spend surviving a crash in the tail, and both halves of the 404 rule: an all-404 lattice is refused, while a city that genuinely holds nothing and answers 200 publishes as ZERO_RESULTS.
+  That pair is the point — 730 of 1,144 catalog cities really are empty, so a guard keyed on emptiness rather than on the 404 would fail two thirds of the catalog.
+- `tests/test_panoramax_collector.py` — resume and the shared cache.
+  The headline is **byte identity asserted three ways against each other** — one uninterrupted pass, a run interrupted after one tile and resumed, and a different channel reading the promoted census for zero requests — rather than against a committed golden fixture.
+  Three-way because the two grid columns come from a geodesic solve whose last ULP differs between macOS and glibc, so a second committed fixture would have to carry the same numeric tolerance the Mapillary one does, while comparing runs produced on one machine pins the ORDERING exactly, which is the property at risk.
+  The city straddles a z15 tile boundary and a border picture is served by both tiles, so the comparison can actually see a reordering.
+  Also: only successful tiles commit, an empty tile gets a record and no file, the two counters split across a resume (asserted as the SUM of the two nights, not as the tile count — the first night attempted every tile and committed one, so the crawl legitimately cost more requests than the lattice has tiles), a blocked night's refused requests still reach the crawl total, seven separate ways a checkpoint can be unusable each discard and refetch **without raising**, a city refused before committing leaves no empty directory, and the cache accounting in both directions (`api_requests` 0 for every reuser, `api_requests_total` the crawl cost only for the channel that paid).
+
+Suite-wide, the autouse pacing fixture is `_no_tile_census_pacing` and now covers **both** tile censuses.
+It was renamed from `_no_mapillary_tile_pacing` rather than duplicated, and the reason is measured: the Panoramax grid-run file ran in 46 s against a live limiter and 0.3 s behind the fixture, because this provider is both slower per request (30/min) and at a zoom with ~4x the tiles.
+
 ## The Panoramax feasibility probe (issue #316)
 
 `tests/test_panoramax_feasibility.py` pins the phase-1 instrument in `scripts/panoramax_feasibility.py`, offline, over synthetic MVT tiles encoded with the same coordinate math the decoder inverts.

--- a/scripts/panoramax_feasibility.py
+++ b/scripts/panoramax_feasibility.py
@@ -103,12 +103,22 @@ from kartaview_probe import refuse_on_collection_host  # noqa: E402
 from streetscape_metadata_tracker.download_common import (  # noqa: E402
     _unit_exponential,
     grid_bbox,
-    spaced_gap_seconds,
-)
-from streetscape_metadata_tracker.download_mapillary import (  # noqa: E402
     lonlat_to_tile_frac,
+    spaced_gap_seconds,
     tile_frac_to_lonlat,
     tiles_for_bbox,
+)
+
+# The per-picture decoder and the two imagery-type constants come from the
+# COLLECTOR (issue #316 phase 2), not from a copy kept here. Same rule that made
+# this script import `spaced_gap_seconds` rather than rewriting the gap formula:
+# a decoder rewritten beside its caller is how the study and the collector come
+# to disagree about what a picture is, and this study's whole job is to describe
+# what the collector will see. The hex/lattice decoders below stay here, since
+# the collector does not read the `grid` layer at all.
+from streetscape_metadata_tracker.download_panoramax import (  # noqa: E402
+    TYPE_360,
+    pictures_from_tile,
 )
 
 logger = logging.getLogger("panoramax_feasibility")
@@ -140,16 +150,17 @@ SCREEN_LAYER = "grid"
 SCREEN_VARIANTS = {"v1_lattice": MAP_V1_URL, "v2_h3": MAP_V2_URL}
 DEFAULT_SCREEN_VARIANT = "v2_h3"
 MEASURE_LAYER = "grid"
-DETAIL_LAYER = "pictures"
+# The detail layer's NAME lives in download_panoramax now, beside the decoder
+# that reads it (PICTURE_LAYER); this study names the zoom it reads it at.
 
 # The v1 z6 lattice's spacing, measured off the decoded tiles: anchors sit on a
 # 0.1 degree graticule in BOTH axes (a geographic lattice, not a Mercator one).
 SCREEN_CELL_DEG = 0.1
 
-# Panoramax's own vocabulary for the two imagery types, from the tile layers.
-# `equirectangular` is 360; anything else is flat. Never absent (see the module
-# docstring, finding 4), which is why this is read as a two-state field.
-TYPE_360 = "equirectangular"
+# Panoramax's own vocabulary for the two imagery types is imported above, from
+# the collector, rather than spelled again here: `equirectangular` is 360 and
+# anything else is flat, never absent (module docstring, finding 4), which is
+# why it is read as a two-state field.
 
 # Conservative by construction: no published limit means no evidence, and this
 # study is small enough that a slow pace costs an afternoon rather than a
@@ -475,49 +486,6 @@ def hexes_overlapping_bbox(
         ):
             out.append({"id": hex_id, **hexagon})
     return out
-
-
-def pictures_from_tile(
-    tile_bytes: bytes, tile_x: int, tile_y: int, zoom: int = DETAIL_ZOOM
-) -> list[dict[str, Any]]:
-    """
-    The v1 `pictures` layer of one z15 tile, one dict per picture.
-
-    This is the only layer with per-picture rows, and therefore the only way to
-    get capture DATES rather than counts. Keeps id, lon/lat, the capture
-    timestamp `ts`, the imagery `type`, the contributor `account_id` and the
-    owning sequence.
-    """
-    if not tile_bytes:
-        return []
-    decoded = mapbox_vector_tile.decode(tile_bytes)
-    layer = decoded.get(DETAIL_LAYER)
-    if not layer:
-        return []
-    extent = layer.get("extent", 4096)
-    pictures = []
-    for feature in layer["features"]:
-        geometry = feature.get("geometry", {})
-        if geometry.get("type") != "Point":
-            continue
-        props = feature.get("properties", {})
-        picture_id = props.get("id", feature.get("id"))
-        if picture_id is None:
-            continue
-        px, py = geometry["coordinates"]
-        lon, lat = _tile_point_to_lonlat(px, py, tile_x, tile_y, zoom, extent)
-        pictures.append(
-            {
-                "id": str(picture_id),
-                "lon": lon,
-                "lat": lat,
-                "ts": props.get("ts"),
-                "type": props.get("type"),
-                "account_id": props.get("account_id"),
-                "sequence_id": props.get("first_sequence"),
-            }
-        )
-    return pictures
 
 
 def capture_month(ts: Any) -> str | None:

--- a/streetscape_metadata_tracker/__init__.py
+++ b/streetscape_metadata_tracker/__init__.py
@@ -3,6 +3,7 @@ from .config import load_config
 from .download_gsv import download_gsv_metadata_async
 from .download_kartaview import download_kartaview_metadata_async
 from .download_mapillary import download_mapillary_metadata_async
+from .download_panoramax import download_panoramax_metadata_async
 from .fileutils import load_city_csv_file, open_in_browser
 from .geoutils import get_city_location_data, get_search_dimensions
 from .naming import (
@@ -23,6 +24,7 @@ __all__ = [
     "download_gsv_metadata_async",
     "download_kartaview_metadata_async",
     "download_mapillary_metadata_async",
+    "download_panoramax_metadata_async",
     "generate_base_filename",
     "generate_run_filename",
     "get_city_location_data",

--- a/streetscape_metadata_tracker/analysis.py
+++ b/streetscape_metadata_tracker/analysis.py
@@ -35,10 +35,12 @@ PRESENT_STATUSES = ("OK", "NO_DATE")
 
 # Statuses that mean "some imagery is present, of any fidelity" — the broader
 # any-imagery footprint (issue #116). FLAT_ONLY marks a grid point covered only
-# by flat/perspective imagery (no 360-degree pano); it is Mapillary-specific
-# (GSV's metadata API only returns panoramas, so GSV never emits it). It is
-# deliberately kept OUT of PRESENT_STATUSES so the 360-degree coverage_rate
-# stays GSV-comparable; any_imagery_coverage_rate is the metric that counts it.
+# by flat/perspective imagery (no 360-degree pano). Every CENSUS provider emits
+# it -- Mapillary, KartaView and Panoramax -- and GSV never does, because its
+# metadata API only returns panoramas. (This comment said "Mapillary-specific"
+# through two more providers; the property is the collection model, not the
+# vendor.) It is deliberately kept OUT of PRESENT_STATUSES so the 360-degree
+# coverage_rate stays GSV-comparable; any_imagery_coverage_rate counts it.
 FLAT_ONLY = "FLAT_ONLY"
 ANY_IMAGERY_STATUSES = ("OK", "NO_DATE", FLAT_ONLY)
 
@@ -86,6 +88,17 @@ EARLIEST_PLAUSIBLE_CAPTURE = {
     # the same reason Mapillary's floor is 2004 rather than its 2013 founding.
     # download_kartaview applies this at decode, as Mapillary's parser does.
     "kartaview": date(2004, 1, 1),
+    # Same reasoning again, and a third rationale of its own. Panoramax's own
+    # instances date from 2022, but the corpus is volunteer uploads -- often of
+    # footage recorded years earlier -- and it also HARVESTS from federated
+    # instances, so a picture's presence here says nothing about when it was
+    # taken. Ties the other two census floors deliberately, which keeps the JS
+    # side's LOOSEST_EARLIEST_PLAUSIBLE_CAPTURE (a Math.min over the registry)
+    # where it already was. What this floor actually catches is measured, not
+    # hypothetical: phase 1 found two Paris pictures stamped 1970-01-01, i.e.
+    # the Unix epoch (docs/experiments/panoramax-feasibility.md).
+    # download_panoramax applies it at decode, as both other census parsers do.
+    "panoramax": date(2004, 1, 1),
 }
 # Floor for a provider not listed above. GSV's is the stricter of the two, but
 # an unknown provider is more likely to resemble a contributor-fed archive than

--- a/streetscape_metadata_tracker/checkpointing.py
+++ b/streetscape_metadata_tracker/checkpointing.py
@@ -92,10 +92,17 @@ MAPILLARY_CHECKPOINT_FORMAT_VERSION = 1
 # by the ordinary format-mismatch arm and its sweep restarts. That costs at most
 # one in-flight city, once, on the build that ships this.
 KARTAVIEW_CHECKPOINT_FORMAT_VERSION = 2
+# Panoramax v1 (issue #316): the same tile-store record Mapillary v1 writes --
+# `done_tiles` as [x, y, rows] triples plus `created_at` -- since the two are the
+# same crawl shape. It is a SEPARATE constant rather than an alias of Mapillary's
+# because the two providers' formats are free to diverge and a shared name would
+# make one bump silently discard the other's checkpoints.
+PANORAMAX_CHECKPOINT_FORMAT_VERSION = 1
 
 STORE_FORMAT_VERSIONS: dict[str, int] = {
     "kartaview": KARTAVIEW_CHECKPOINT_FORMAT_VERSION,
     "mapillary": MAPILLARY_CHECKPOINT_FORMAT_VERSION,
+    "panoramax": PANORAMAX_CHECKPOINT_FORMAT_VERSION,
 }
 
 # The providers whose collection is a CENSUS -- one crawl of the whole frozen

--- a/streetscape_metadata_tracker/cli.py
+++ b/streetscape_metadata_tracker/cli.py
@@ -43,6 +43,7 @@ from . import (
     download_gsv_metadata_async,
     download_kartaview_metadata_async,
     download_mapillary_metadata_async,
+    download_panoramax_metadata_async,
     get_city_location_data,
     get_search_dimensions,
     load_config,
@@ -71,6 +72,10 @@ from .download_kartaview import (
     SweepIncompleteError,
 )
 from .download_mapillary import DEFAULT_TILE_JITTER, DEFAULT_TILE_REQUESTS_PER_MINUTE
+from .download_panoramax import DEFAULT_TILE_JITTER as DEFAULT_PANORAMAX_JITTER
+from .download_panoramax import (
+    DEFAULT_TILE_REQUESTS_PER_MINUTE as DEFAULT_PANORAMAX_REQUESTS_PER_MINUTE,
+)
 from .fileutils import load_city_csv_file
 from .json_summarizer import (
     generate_aggregate_v2,
@@ -412,6 +417,35 @@ def parse_args():
              run exits 83 and the next invocation resumes from the cells
              already answered, so a metro that needs 10 hours can be taken a
              night at a time. Default: sweep to completion.""",
+    )
+
+    concurrency_group.add_argument(
+        "--panoramax-max-requests-per-minute",
+        type=int,
+        default=DEFAULT_PANORAMAX_REQUESTS_PER_MINUTE,
+        help=f"""Client-side cap on Panoramax vector-tile requests per minute
+             (panoramax provider only). A FOURTH separate flag because this
+             limit is a fourth kind again: Panoramax documents no limit at all
+             — not in its API docs, not in its OpenAPI spec, and no
+             X-RateLimit-*/Retry-After header comes back — so there is no
+             published number to pace to and this one is chosen, not measured.
+             It is deliberately half the Mapillary cap against a host with
+             strictly less published guidance, and one that is a single
+             volunteer-run meta-catalog taking all of our load. Default
+             {DEFAULT_PANORAMAX_REQUESTS_PER_MINUTE}; 0 disables pacing.""",
+    )
+
+    concurrency_group.add_argument(
+        "--panoramax-jitter",
+        type=jitter_fraction,
+        default=DEFAULT_PANORAMAX_JITTER,
+        help=f"""Randomize the gap between Panoramax tile requests (panoramax
+             provider only), with the same shifted-exponential shape and the
+             same meaning as --mapillary-jitter: this number is the gaps'
+             coefficient of variation, not a plus-or-minus range, and the mean
+             rate is unchanged. Adopted here BEFORE any incident rather than
+             after three (issue #292). Default {DEFAULT_PANORAMAX_JITTER}; 0
+             restores the exact cadence.""",
     )
 
     parser.add_argument(
@@ -833,6 +867,30 @@ async def _collect_one_run(conn, args, city_row, run_date, provider, config, vis
                 # path above separates channels only as long as every caller
                 # derives it correctly, so the state file also records which
                 # ledger its spend belongs to and refuses to resume another's.
+                checkpoint_channel=provider,
+                census_cache=census_cache,
+            )
+        elif provider == "panoramax":
+            # NO access_token, and that is not an omission: Panoramax reads are
+            # unauthenticated, so `config` here is the credential-free arm's
+            # {"access_token": None} and the downloader takes no such parameter
+            # (issue #316).
+            dict_results = await download_panoramax_metadata_async(
+                city_name=city_row.display_name,
+                center_lat=city_row.center_lat,
+                center_lon=city_row.center_lon,
+                grid_width=city_row.grid_width_m,
+                grid_height=city_row.grid_height_m,
+                step_length=city_row.step_m,
+                output_csv_gz_path=output_csv_gz_path,
+                request_timeout=request_timeout,
+                max_requests_per_minute=args.panoramax_max_requests_per_minute,
+                jitter=args.panoramax_jitter,
+                checkpoint_path=checkpoint_path,
+                # The channel again, this time INSIDE the commit record: the
+                # path separates channels only as long as every caller derives
+                # it correctly, so the state file also records which ledger its
+                # spend belongs to and refuses to resume another's.
                 checkpoint_channel=provider,
                 census_cache=census_cache,
             )

--- a/streetscape_metadata_tracker/config.py
+++ b/streetscape_metadata_tracker/config.py
@@ -93,6 +93,33 @@ KARTAVIEW_EXTRA_DTYPES = {
 # The full KartaView run schema: shared core + KartaView extras.
 KARTAVIEW_METADATA_DTYPES = {**METADATA_DTYPES, **KARTAVIEW_EXTRA_DTYPES}
 
+# Panoramax-only columns (issue #316). DELIBERATELY THIN, and the reason is
+# worth stating so nobody "fixes" it by adding a licence column: Panoramax
+# publishes far richer per-picture metadata than this -- `license`,
+# `geovisio:producer`, `quality:horizontal_accuracy`, the `via` link naming the
+# source instance -- but ALL of it only through `/api/search`, which cannot be
+# the census (it does not paginate; see download_panoramax's module docstring).
+# What the z15 `pictures` layer carries is what is here, and buying the rest
+# would mean a second, unbounded request per picture.
+#   - account_id: the contributor, also embedded in copyright_info for parity
+#     with the other two census providers. Panoramax accounts are UUIDs, hence
+#     a string rather than KartaView's numeric id.
+#   - sequence_id: the tile's `first_sequence`, i.e. the owning capture run.
+#   - is_pano: type == "equirectangular"; anything else is flat imagery (#116).
+#   - image_type: the raw `type` string, kept BESIDE the boolean it produces.
+#     Two-state today across 119M federation pictures, but a run file records
+#     what the provider said -- so a third value Panoramax has never yet served
+#     appears in the data as itself instead of being silently counted as flat.
+PANORAMAX_EXTRA_DTYPES = {
+    "account_id": pd.StringDtype(),  # nullable string
+    "sequence_id": pd.StringDtype(),  # nullable string
+    "is_pano": pd.BooleanDtype(),  # nullable bool (null on ZERO_RESULTS rows)
+    "image_type": pd.StringDtype(),  # nullable string; the provider's own word
+}
+
+# The full Panoramax run schema: shared core + Panoramax extras.
+PANORAMAX_METADATA_DTYPES = {**METADATA_DTYPES, **PANORAMAX_EXTRA_DTYPES}
+
 # Provider token (as it appears in a run filename) -> that provider's run
 # schema. The read side of the naming contract: a run CSV is only self-
 # describing through its filename, and pandas INFERS any column a dtype
@@ -113,6 +140,7 @@ PROVIDER_RUN_DTYPES = {
     # could not be brought into step in the wrong order -- and
     # test_every_known_provider_has_a_run_schema holds the other direction.
     "kartaview": KARTAVIEW_METADATA_DTYPES,
+    "panoramax": PANORAMAX_METADATA_DTYPES,
 }
 
 
@@ -172,7 +200,22 @@ CHANNEL_ENV_VARS: dict[str, tuple[str, ...]] = {
     "kartaview_streets": ("KARTAVIEW_STREETS_ACCESS_TOKEN", "KARTAVIEW_ACCESS_TOKEN"),
     "mapillary": ("MAPILLARY_ACCESS_TOKEN",),
     "mapillary_streets": ("MAPILLARY_STREETS_ACCESS_TOKEN",),
+    # THE EMPTY TUPLE IS THE POINT, not an omission (issue #316). Panoramax
+    # reads are unauthenticated, so there is no variable to name -- and the
+    # honest way to say that is a declared channel with no variable, rather than
+    # leaving the channel out of this table entirely. Out of the table it would
+    # also drop out of the router's credentials-table check, so the one provider
+    # whose credential story is unusual would be the one provider CLAUDE.md
+    # never mentions. Keep the row; document it as "none".
+    "panoramax": (),
 }
+
+# Channels that need no credential at all, derived from the table above rather
+# than listed a second time. Read by load_config and by the tests that would
+# otherwise index CHANNEL_ENV_VARS[channel][0] and IndexError here.
+CREDENTIAL_FREE_CHANNELS = frozenset(
+    channel for channel, variables in CHANNEL_ENV_VARS.items() if not variables
+)
 
 
 def load_config(provider: str = "gsv") -> dict[str, Any]:
@@ -182,6 +225,10 @@ def load_config(provider: str = "gsv") -> dict[str, Any]:
     gsv requires GMAPS_API_KEY; mapillary requires MAPILLARY_ACCESS_TOKEN.
     Only the requested provider's credential is required, so a machine can
     run one provider without the other's key.
+
+    'panoramax' requires NOTHING and succeeds on any machine: its reads are
+    unauthenticated (issue #316). It is still a declared channel here rather
+    than an exception in the caller — see CREDENTIAL_FREE_CHANNELS.
 
     'gsv_streets' and 'mapillary_streets' are ISOLATED credential channels for
     street-coverage collection (issue #99): separate keys so street-sampling
@@ -323,8 +370,19 @@ def load_config(provider: str = "gsv") -> dict[str, Any]:
             )
         return config
 
+    if provider in CREDENTIAL_FREE_CHANNELS:
+        # THE ONE ARM THAT CANNOT RAISE, and it has to be that way rather than
+        # merely happening to be. `cli.py` loads EVERY requested provider's
+        # config up front — `--provider all` included — precisely so a host
+        # missing one key is told before anything collects; a channel that
+        # raised for a credential it does not have would take down every other
+        # provider in the same invocation.
+        #
+        # Returns the same `access_token` key its siblings do, set to None, so a
+        # caller can keep one shape. The Panoramax downloader takes no token
+        # parameter at all and never reads it.
+        return {"access_token": None}
+
     raise ValueError(
-        f"Unknown provider {provider!r} "
-        f"(known: gsv, mapillary, kartaview, gsv_streets, mapillary_streets, "
-        f"kartaview_streets)"
+        f"Unknown provider {provider!r} (known: {', '.join(sorted(CHANNEL_ENV_VARS))})"
     )

--- a/streetscape_metadata_tracker/download_common.py
+++ b/streetscape_metadata_tracker/download_common.py
@@ -9,6 +9,7 @@ provider importing from another's module.
 
 import argparse
 import asyncio
+import math
 import random
 import re
 from collections.abc import Callable, Iterator
@@ -58,11 +59,20 @@ HOST_OVERPASS = "overpass"
 # project's prior bans were on limits no document described, which is why this
 # is locked on the documented-per-key reading rather than exempted by it.
 HOST_KARTAVIEW = "kartaview"
+# Panoramax publishes NO rate limit anywhere found -- not in the API docs, not
+# in the OpenAPI spec, and no X-RateLimit-*/Retry-After header comes back -- so
+# per this repo's standing rule that is unknown rather than unlimited (issue
+# #316, docs/provider-access.md). Locked for a second reason the other three do
+# not have: api.panoramax.xyz is a META-CATALOG harvesting 23 instances, so all
+# of our load lands on ONE volunteer-run endpoint however wide the federation
+# grows, rather than being spread across it.
+HOST_PANORAMAX = "panoramax"
 
 HOST_LABELS = {
     HOST_MAPILLARY_TILES: "Mapillary's tile CDN (tiles.mapillary.com)",
     HOST_OVERPASS: "the Overpass API (overpass-api.de)",
     HOST_KARTAVIEW: "the KartaView API (kartaview.org)",
+    HOST_PANORAMAX: "the Panoramax meta-catalog (api.panoramax.xyz)",
 }
 
 
@@ -119,15 +129,20 @@ class HostBlockedError(HostUnavailableError):
 # denied" — a plausible-sounding wrong answer, which is worse than an
 # unallocated number. The families are defined by these dicts rather than by
 # being contiguous, so the numbering has a gap and each entry is justified.
+#
+# 84/85 continue the same numbering for Panoramax (issue #316), taken after 83
+# rather than filling the 77/78 gap, which stays open for the reason above.
 HOST_EXIT_CODES = {
     HOST_MAPILLARY_TILES: 75,
     HOST_OVERPASS: 76,
     HOST_KARTAVIEW: 81,
+    HOST_PANORAMAX: 84,
 }
 HOST_BUSY_EXIT_CODES = {
     HOST_MAPILLARY_TILES: 79,
     HOST_OVERPASS: 80,
     HOST_KARTAVIEW: 82,
+    HOST_PANORAMAX: 85,
 }
 HOST_BY_EXIT_CODE = {code: host for host, code in HOST_EXIT_CODES.items()}
 HOST_BY_BUSY_EXIT_CODE = {code: host for host, code in HOST_BUSY_EXIT_CODES.items()}
@@ -644,6 +659,90 @@ def assign_to_grid(
     j_min, j_max = -width_steps // 2, width_steps // 2
     in_grid = (i >= i_min) & (i <= i_max) & (j >= j_min) & (j <= j_max)
     return i, j, in_grid
+
+
+# ── Slippy-map tile math: shared by every TILE census provider ──────────────
+#
+# Stdlib-only Web-Mercator lattice arithmetic. It lived in `download_mapillary`
+# until Panoramax became the second tile census (issue #316), and it moved here
+# for exactly the reason `grid_bbox` and `assign_to_grid` did: it is pure
+# geometry that merely happened to sit in the first provider that needed it, and
+# a second provider was otherwise going to reach it by importing another
+# provider's module. The zoom is a REQUIRED argument here — a shared lattice
+# function has no default zoom to be right about — and each provider re-exposes
+# it with its own (`download_mapillary` z14, `download_panoramax` z15), so no
+# existing call site moved.
+
+
+def lonlat_to_tile_frac(lon: float, lat: float, zoom: int) -> tuple[float, float]:
+    """Fractional Web-Mercator tile coordinates (x, y; y from the top)."""
+    n = 2**zoom
+    fx = (lon + 180.0) / 360.0 * n
+    lat_rad = math.radians(lat)
+    fy = (1.0 - math.asinh(math.tan(lat_rad)) / math.pi) / 2.0 * n
+    return fx, fy
+
+
+def tile_frac_to_lonlat(fx: float, fy: float, zoom: int) -> tuple[float, float]:
+    """Inverse of :func:`lonlat_to_tile_frac`."""
+    n = 2**zoom
+    lon = fx / n * 360.0 - 180.0
+    lat = math.degrees(math.atan(math.sinh(math.pi * (1 - 2 * fy / n))))
+    return lon, lat
+
+
+def tiles_for_bbox(
+    min_lon: float, min_lat: float, max_lon: float, max_lat: float, zoom: int
+) -> list[tuple[int, int]]:
+    """
+    All (x, y) tile indices at the given zoom intersecting the bbox.
+
+    A bbox that crosses the antimeridian (min_lon > max_lon after geopy
+    normalizes longitudes to ±180 — e.g. Suva, Fiji) wraps: it covers the
+    x columns from min_lon to the right edge plus those from the left edge
+    to max_lon. The naive single range was empty there, silently yielding
+    a 0-tile (0-pano) run.
+
+    PURE, and every tile census depends on that: the reassembly order of a
+    resumed census is RECOMPUTED from this function rather than stored, so a
+    change to it invalidates checkpoints rather than merely re-tiling
+    (`docs/census.md`, issue #256). Both providers' checkpoint validators
+    compare a stored tile COUNT for that reason.
+    """
+    fx_min, fy_max = lonlat_to_tile_frac(min_lon, min_lat, zoom)  # y grows southward
+    fx_max, fy_min = lonlat_to_tile_frac(max_lon, max_lat, zoom)
+    n = 2**zoom
+    if fx_min > fx_max:  # bbox crosses the antimeridian
+        x_indices = [*range(max(0, int(fx_min)), n), *range(0, min(n - 1, int(fx_max)) + 1)]
+    else:
+        x_indices = list(range(max(0, int(fx_min)), min(n - 1, int(fx_max)) + 1))
+    y_range = range(max(0, int(fy_min)), min(n - 1, int(fy_max)) + 1)
+    return [(x, y) for x in x_indices for y in y_range]
+
+
+def points_in_tiles(
+    lats: np.ndarray, lons: np.ndarray, tiles: list[tuple[int, int]], zoom: int
+) -> np.ndarray:
+    """
+    Boolean mask of which (lat, lon) points fall inside any of ``tiles``.
+
+    Vectorized form of :func:`lonlat_to_tile_frac`; used to attribute
+    undownloaded tiles back to the query points they cover (issue #168), i.e.
+    every tile provider's ``unmeasured_mask``. Deliberately ignores the tiles'
+    render buffer: a point just outside a failed tile may in fact have been
+    covered by a neighbour, and calling it "unknown" errs toward admitting we
+    don't know rather than claiming empty.
+    """
+    if len(lats) == 0:
+        return np.zeros(0, dtype=bool)
+    n = 2**zoom
+    fx = (lons + 180.0) / 360.0 * n
+    fy = (1.0 - np.arcsinh(np.tan(np.radians(lats))) / np.pi) / 2.0 * n
+    # One packed int per tile so membership is a single sorted-array lookup
+    # instead of a Python loop over the (usually tiny) failed-tile list.
+    keys = fx.astype(np.int64) * n + fy.astype(np.int64)
+    failed_keys = np.array(sorted(x * n + y for x, y in tiles), dtype=np.int64)
+    return np.isin(keys, failed_keys)
 
 
 def standardize_capture_date(date_str: str | None) -> str | None:

--- a/streetscape_metadata_tracker/download_mapillary.py
+++ b/streetscape_metadata_tracker/download_mapillary.py
@@ -107,6 +107,10 @@ from .download_common import (
 )
 from .download_common import assign_to_grid as assign_to_grid
 from .download_common import grid_bbox as grid_bbox
+from .download_common import lonlat_to_tile_frac as lonlat_to_tile_frac
+from .download_common import points_in_tiles as common_points_in_tiles
+from .download_common import tile_frac_to_lonlat as tile_frac_to_lonlat
+from .download_common import tiles_for_bbox as common_tiles_for_bbox
 from .host_lock import host_lock
 from .progress import progress
 
@@ -127,44 +131,20 @@ IMAGE_LAYER = "image"
 # ── Slippy-map tile math (stdlib only) ─────────────────────────────────────
 
 
-def lonlat_to_tile_frac(lon: float, lat: float, zoom: int) -> tuple[float, float]:
-    """Fractional Web-Mercator tile coordinates (x, y; y from the top)."""
-    n = 2**zoom
-    fx = (lon + 180.0) / 360.0 * n
-    lat_rad = math.radians(lat)
-    fy = (1.0 - math.asinh(math.tan(lat_rad)) / math.pi) / 2.0 * n
-    return fx, fy
-
-
-def tile_frac_to_lonlat(fx: float, fy: float, zoom: int) -> tuple[float, float]:
-    """Inverse of lonlat_to_tile_frac."""
-    n = 2**zoom
-    lon = fx / n * 360.0 - 180.0
-    lat = math.degrees(math.atan(math.sinh(math.pi * (1 - 2 * fy / n))))
-    return lon, lat
-
-
 def tiles_for_bbox(
     min_lon: float, min_lat: float, max_lon: float, max_lat: float, zoom: int = TILE_ZOOM
 ) -> list[tuple[int, int]]:
     """
-    All (x, y) tile indices at the given zoom intersecting the bbox.
+    All (x, y) z14 tile indices intersecting the bbox — Mapillary's default zoom
+    over the shared :func:`download_common.tiles_for_bbox`.
 
-    A bbox that crosses the antimeridian (min_lon > max_lon after geopy
-    normalizes longitudes to ±180 — e.g. Suva, Fiji) wraps: it covers the
-    x columns from min_lon to the right edge plus those from the left edge
-    to max_lon. The naive single range was empty there, silently yielding
-    a 0-tile (0-pano) run.
+    A one-line wrapper rather than a re-export, because the shared function
+    takes the zoom as a REQUIRED argument (a lattice helper serving two
+    providers at two zooms has no default to be right about) while ~20 call
+    sites here — the collector, the road walk, the tests, the golden fixture —
+    call this one with four arguments and mean z14.
     """
-    fx_min, fy_max = lonlat_to_tile_frac(min_lon, min_lat, zoom)  # y grows southward
-    fx_max, fy_min = lonlat_to_tile_frac(max_lon, max_lat, zoom)
-    n = 2**zoom
-    if fx_min > fx_max:  # bbox crosses the antimeridian
-        x_indices = [*range(max(0, int(fx_min)), n), *range(0, min(n - 1, int(fx_max)) + 1)]
-    else:
-        x_indices = list(range(max(0, int(fx_min)), min(n - 1, int(fx_max)) + 1))
-    y_range = range(max(0, int(fy_min)), min(n - 1, int(fy_max)) + 1)
-    return [(x, y) for x in x_indices for y in y_range]
+    return common_tiles_for_bbox(min_lon, min_lat, max_lon, max_lat, zoom)
 
 
 def estimate_tile_count(
@@ -429,24 +409,12 @@ def _points_in_tiles(
     lats: np.ndarray, lons: np.ndarray, tiles: list[tuple[int, int]], zoom: int = TILE_ZOOM
 ) -> np.ndarray:
     """
-    Boolean mask of which (lat, lon) points fall inside any of ``tiles``.
-
-    Vectorized form of ``lonlat_to_tile_frac``; used to attribute undownloaded
-    tiles back to the grid points they cover (issue #168). Deliberately ignores
-    the tiles' render buffer: a point just outside a failed tile may in fact
-    have been covered by a neighbour, and calling it "unknown" errs toward
-    admitting we don't know rather than claiming empty.
+    Mapillary's ``unmeasured_mask``: which grid points sit under a tile that
+    never downloaded (issue #168). The shared
+    :func:`download_common.points_in_tiles` at this provider's default zoom, for
+    the same reason :func:`tiles_for_bbox` above is a wrapper.
     """
-    if len(lats) == 0:
-        return np.zeros(0, dtype=bool)
-    n = 2**zoom
-    fx = (lons + 180.0) / 360.0 * n
-    fy = (1.0 - np.arcsinh(np.tan(np.radians(lats))) / np.pi) / 2.0 * n
-    # One packed int per tile so membership is a single sorted-array lookup
-    # instead of a Python loop over the (usually tiny) failed-tile list.
-    keys = fx.astype(np.int64) * n + fy.astype(np.int64)
-    failed_keys = np.array(sorted(x * n + y for x, y in tiles), dtype=np.int64)
-    return np.isin(keys, failed_keys)
+    return common_points_in_tiles(lats, lons, tiles, zoom)
 
 
 # ── Download ───────────────────────────────────────────────────────────────

--- a/streetscape_metadata_tracker/download_panoramax.py
+++ b/streetscape_metadata_tracker/download_panoramax.py
@@ -1,0 +1,1595 @@
+"""
+Panoramax metadata downloader (issue #316, phase 2).
+
+Panoramax is a federated open imagery commons founded by IGN and OpenStreetMap
+France: ~120 M pictures across 23 registered instances, harvested into ONE
+meta-catalog at api.panoramax.xyz. It is the third census provider — every
+picture in an area, rather than the nearest one to a query point — so it binds
+to the shared seam in `census.py` exactly as Mapillary and KartaView do, and
+this module is shaped on `download_mapillary` rather than `download_kartaview`
+because its primitive is a concurrently-fetched vector tile rather than a
+serial radius sweep.
+
+READ THIS BEFORE CHANGING THE INSTRUMENT. Phase 1 measured the alternatives and
+`docs/experiments/panoramax-feasibility.md` is the record; the three findings
+that decide this module's shape are:
+
+  1. `/api/search` CANNOT COUNT and is never the census. It does not paginate
+     (`links` is empty at limit=1, 1000 and 10000 alike), reports no
+     `numberMatched`, SILENTLY IGNORES its own `datetime` filter (measured over
+     20 cities: 5,045 pictures that the requested windows should have excluded
+     all came back), and embeds a ~90-key EXIF blob per feature, so 10,000
+     features is 75 MB. An incremental "everything since the last run" fetch
+     built on it would re-read the whole history and report it as new.
+  2. THE PER-PICTURE INSTRUMENT IS THE v1 `pictures` LAYER, WHICH STARTS AT z15.
+     One row per picture carrying `id`, `ts` (capture), `type`, `account_id` and
+     `first_sequence`. z15 rather than Mapillary's z14 is not a tunable — it is
+     the coarsest zoom that serves the layer at all — and it costs about 4x as
+     many tiles for the same bbox (catalog p50 35 tiles/city against
+     Mapillary's 12, p95 900).
+  3. `type` HAS NO ABSENT STATE. Summed federation-wide, 119,362,642 pictures =
+     52,128,373 `equirectangular` + 67,234,269 `flat` + 0 unclassified, and not
+     one of the 1,345,143 pictures phase 1 read off this layer carried an absent
+     type. The "10-34% field of view absent" third state in #316 is an artifact
+     of reading EXIF out of the SEARCH response: every one of those pictures
+     that could be looked up is `flat` in the tiles. So `is_pano` is total here,
+     which is what lets the census schema declare it non-nullable `"bool"` (see
+     `census.census_is_pano` for what the other two declarations cost).
+
+Collection model — identical to Mapillary's, because #116's stratification is
+provider-agnostic: every 360 picture is a census row assigned to its nearest
+frozen grid point; a point covered ONLY by flat imagery becomes one FLAT_ONLY
+row with a null capture date; a point with neither becomes ZERO_RESULTS. That
+yields the two coverage numbers that are never conflated, and for Panoramax
+reporting BOTH is not optional — the mix is a per-city property, from 99.5% 360
+in Des Moines to 0% in Tulsa and Boise.
+
+NO CREDENTIAL. Reads are unauthenticated, so there is no token in the URL, no
+`.env` entry to fail fast on, and no per-channel key isolation to build. What
+replaces the credential as the thing to be careful with is the host itself: one
+volunteer-run meta-catalog absorbing all of our load however wide the federation
+grows, publishing no rate limit of any kind. Pacing is therefore deliberately
+half Mapillary's (see DEFAULT_TILE_REQUESTS_PER_MINUTE) and 403/429 is a stop
+rather than a retry.
+
+The census CHECKPOINTS and is PROMOTED into the shared cache exactly as
+Mapillary's is; the tile-keyed reassembly contract, the fails-open posture and
+the caller-discards rule are all `docs/census.md`'s and are preconditions for
+reading the checkpoint section below rather than background.
+"""
+
+import asyncio
+import json
+import logging
+import math
+import os
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from datetime import UTC, date, datetime
+from typing import Any
+
+import aiohttp
+import backoff
+import mapbox_vector_tile
+import numpy as np
+import pandas as pd
+import pyarrow.parquet as pq
+
+# Aliased for the reason download_mapillary aliases it: `census` is also the
+# name of the local DataFrame this module passes around.
+from . import census as census_core
+from .analysis import EARLIEST_PLAUSIBLE_CAPTURE
+from .census import dedupe_census
+from .checkpointing import (
+    CHECKPOINT_MAX_AGE_S,
+    PANORAMAX_CHECKPOINT_FORMAT_VERSION,
+    CensusCache,
+    _bbox_matches,
+    _fsync_dir,
+    _remove_empty_checkpoint_dir,
+    _state_path,
+    _write_json_durable,
+    census_cache_marker,
+    discard_checkpoint,
+    load_cached_store,
+    observation_timestamp,
+    promote_checkpoint_to_cache,
+    reconcile_cache_hit,
+    reused_census_provenance,
+)
+from .config import PANORAMAX_METADATA_DTYPES
+from .download_common import (
+    HOST_PANORAMAX,
+    AsyncRateLimiter,
+    DownloadError,
+    HostBlockedError,
+    grid_bbox,
+    points_in_tiles,
+    redact_credentials,
+    tile_frac_to_lonlat,
+)
+from .download_common import tiles_for_bbox as common_tiles_for_bbox
+from .host_lock import host_lock
+from .progress import progress
+
+logger = logging.getLogger(__name__)
+
+API_BASE = "https://api.panoramax.xyz/api"
+# The v1 map endpoint. There is also a v2 (`/api/map/2/{z}/{x}/{y}.mvt`) whose
+# `grid` layer serves H3 hexagon COUNTS at every zoom; that is the screen and
+# measure instrument (issue #316 phase 1, and the standing screen), not this
+# one. Both endpoints serve a `pictures` layer at z15+ and phase 1 measured them
+# agreeing to p50 1.000, so v1 is used here simply because it is the one the API
+# root advertises.
+TILE_URL_TEMPLATE = API_BASE + "/map/{z}/{x}/{y}.mvt"
+# The COARSEST zoom that serves per-picture rows, hence the cheapest. Not a
+# tunable: below z15 the `pictures` layer is absent entirely and a city would
+# collect zero panos rather than fail.
+TILE_ZOOM = 15
+PICTURE_LAYER = "pictures"
+# Panoramax's own vocabulary for the two imagery types. Anything else is flat;
+# see finding 3 in the module docstring for why there is no third bucket, and
+# `image_type` in the run schema for how a future third value stays visible
+# rather than being silently folded in here.
+TYPE_360 = "equirectangular"
+
+# Sent on every request. Panoramax is volunteer-run infrastructure with no
+# credential to identify us, so the User-Agent is the ONLY way an operator there
+# can tell what this traffic is or who to contact about it — which matters more
+# here than on a metered commercial CDN, not less.
+USER_AGENT = (
+    "streetscape-tracker/1.0 (+https://github.com/jonfroehlich/streetscape-tracker; "
+    "street-level imagery coverage research)"
+)
+
+
+# ── Slippy-map tile math ───────────────────────────────────────────────────
+
+
+def tiles_for_bbox(
+    min_lon: float, min_lat: float, max_lon: float, max_lat: float, zoom: int = TILE_ZOOM
+) -> list[tuple[int, int]]:
+    """
+    All (x, y) z15 tile indices intersecting the bbox — this provider's default
+    zoom over the shared :func:`download_common.tiles_for_bbox`.
+
+    Note the zoom, which is the one number a reader coming from
+    ``download_mapillary`` will assume: Panoramax's per-picture layer starts at
+    z15, so the same bbox is ~4x the tiles.
+    """
+    return common_tiles_for_bbox(min_lon, min_lat, max_lon, max_lat, zoom)
+
+
+def estimate_tile_count(
+    center_lat: float,
+    center_lon: float,
+    grid_width: float,
+    grid_height: float,
+    step_length: float = 20,
+) -> int:
+    """
+    Number of z15 tile requests a run will make — the scheduler's cost hook, and
+    the one this channel's per-city timeout is derived from.
+
+    EXACT rather than estimated, and free: the lattice is counted from the
+    frozen geometry with no network call and no imagery-dependent term, so
+    unlike KartaView's sweep estimate there is no observed-versus-geometric
+    correction to apply. Measured over the 20 richest cities phase 1 found:
+    p50 414 tiles, p90 2,400, max 3,132 (~104 minutes at the shipped pace).
+    """
+    return len(
+        tiles_for_bbox(*grid_bbox(center_lat, center_lon, grid_width, grid_height, step_length))
+    )
+
+
+def _points_in_tiles(
+    lats: np.ndarray, lons: np.ndarray, tiles: list[tuple[int, int]], zoom: int = TILE_ZOOM
+) -> np.ndarray:
+    """This provider's ``unmeasured_mask``: grid points under an undownloaded tile."""
+    return points_in_tiles(lats, lons, tiles, zoom)
+
+
+# ── Tile decoding ──────────────────────────────────────────────────────────
+
+
+def pictures_from_tile(
+    tile_bytes: bytes, tile_x: int, tile_y: int, zoom: int = TILE_ZOOM
+) -> list[dict[str, Any]]:
+    """
+    The `pictures` layer of one tile, one dict per picture.
+
+    This is the only layer with per-picture rows, and therefore the only way to
+    get capture DATES rather than counts. Keeps `id`, lon/lat, the capture
+    timestamp `ts`, the imagery `type` VERBATIM, the contributor `account_id`
+    and the owning sequence, plus the derived `is_pano` the census schema reads.
+
+    ``type`` is carried through unchanged as well as reduced to ``is_pano``,
+    deliberately: a run file records what the provider said, so a third `type`
+    value Panoramax has never yet served would appear in the data as itself
+    rather than being silently counted as flat by this function.
+
+    Shared with ``scripts/panoramax_feasibility.py``, which imports it rather
+    than keeping its own copy — the same rule that keeps the pacing formula in
+    one place. A decoder rewritten beside its caller is how the study and the
+    collector would come to disagree about what a picture is.
+
+    Args:
+        tile_bytes: the raw MVT body. Empty bytes decode to nothing.
+        tile_x, tile_y: the tile's indices, needed to place its local
+            coordinates back on the globe.
+        zoom: the zoom those indices are at.
+    """
+    if not tile_bytes:
+        return []
+    decoded = mapbox_vector_tile.decode(tile_bytes)
+    layer = decoded.get(PICTURE_LAYER)
+    if not layer:
+        return []
+    extent = layer.get("extent", 4096)
+
+    pictures = []
+    for feature in layer["features"]:
+        geometry = feature.get("geometry", {})
+        if geometry.get("type") != "Point":
+            continue
+        props = feature.get("properties", {})
+        # THE PROPERTY ONLY -- deliberately no fall back to the MVT feature id,
+        # which download_mapillary's decoder does have. An MVT feature id is
+        # TILE-LOCAL (mapbox_vector_tile numbers features 0, 1, 2 ... per tile),
+        # so falling back to it would mint an id that collides with a different
+        # picture in every other tile -- and `dedupe_census` factorizes on `id`,
+        # so those collisions would silently collapse distinct pictures into one
+        # across the whole city. A picture the layer does not name is dropped.
+        picture_id = props.get("id")
+        if picture_id is None:
+            continue
+        px, py = geometry["coordinates"]
+        # decode() returns y-up tile-local coords; convert to global fractions.
+        lon, lat = tile_frac_to_lonlat(tile_x + px / extent, tile_y + (1 - py / extent), zoom)
+        image_type = props.get("type")
+        account_id = props.get("account_id")
+        sequence_id = props.get("first_sequence")
+        pictures.append(
+            {
+                "id": str(picture_id),
+                "lon": lon,
+                "lat": lat,
+                "ts": props.get("ts"),
+                "type": image_type,
+                "image_type": None if image_type is None else str(image_type),
+                "is_pano": image_type == TYPE_360,
+                "account_id": None if account_id is None else str(account_id),
+                "sequence_id": None if sequence_id is None else str(sequence_id),
+            }
+        )
+    return pictures
+
+
+# The earliest date this provider could plausibly have imagery for. Read from
+# analysis.py rather than spelled here so the collector's decode-time floor and
+# every reader's cannot drift apart -- both existing census providers do the
+# same. See analysis.EARLIEST_PLAUSIBLE_CAPTURE for why it is 2004 rather than
+# Panoramax's own 2022 founding.
+_EARLIEST_CAPTURE = EARLIEST_PLAUSIBLE_CAPTURE["panoramax"]
+# The same floor as an aware Timestamp. Both the scalar and the vectorized rule
+# compare TIMESTAMPS rather than calling `.dt.date`: on a column that parsed to
+# all-NaT, `.dt.date` stays datetime64 instead of becoming objects and the
+# comparison raises `InvalidComparison` -- i.e. a city whose every timestamp was
+# unusable would fail the run rather than record it as undated.
+_EARLIEST_CAPTURE_TS = pd.Timestamp(_EARLIEST_CAPTURE, tz=UTC)
+
+
+def ts_to_iso_date(ts) -> str:
+    """
+    A tile capture timestamp -> 'YYYY-MM-DD' (UTC), or '' when unusable.
+
+    Panoramax serves `ts` as a string, and phase 1 saw at least three shapes of
+    it: '2025-11-02 00:24:37+00', an ISO 'T'/'Z' form, and a fractional-second
+    form. It also serves a genuine SENTINEL — two Paris pictures dated
+    1970-01-01, i.e. the Unix epoch — which is this provider's known analogue of
+    Mapillary's epoch-zero device clocks and is what the floor below drops.
+
+    Scalar reference implementation for :func:`ts_to_iso_dates`, which is what
+    the collection paths actually call; a test pins the two together
+    element-wise, so the rules live here in readable form and are stated once.
+    """
+    if not ts:
+        return ""
+    parsed = pd.to_datetime(pd.Series([ts]), format="ISO8601", utc=True, errors="coerce")[0]
+    if pd.isna(parsed):
+        return ""
+    if parsed < _EARLIEST_CAPTURE_TS or parsed > pd.Timestamp.now(tz=UTC):
+        return ""
+    return parsed.date().isoformat()
+
+
+def ts_to_iso_dates(values) -> pd.Series:
+    """
+    Vectorized :func:`ts_to_iso_date` over a column of tile timestamps.
+
+    ``format="ISO8601"`` IS LOAD-BEARING and must not be dropped as redundant.
+    Left to infer, pandas locks onto ONE format from the first non-null value
+    and coerces every value at another precision to NaT — silently, since
+    ``errors="coerce"`` is what makes a genuinely bad value survivable. That is
+    #226 from one direction and KartaView's mixed-precision pages from another,
+    and Panoramax mixes precisions too: a fractional-second `ts` beside a
+    whole-second one nulls one of the two, whichever came second.
+
+    Args:
+        values: array-like of `ts` strings, nulls allowed.
+
+    Returns:
+        A str Series of 'YYYY-MM-DD' / '' values, aligned to the input.
+    """
+    ts = pd.to_datetime(
+        pd.Series(values, dtype="object").reset_index(drop=True),
+        format="ISO8601",
+        utc=True,
+        errors="coerce",
+    )
+    usable = ts.notna() & ts.ge(_EARLIEST_CAPTURE_TS) & ts.le(pd.Timestamp.now(tz=UTC))
+    # Mask BEFORE formatting, exactly as the Mapillary parser does: pandas
+    # represents timestamps Python's datetime cannot and then refuses to
+    # strftime them, and those are the values `usable` has already rejected.
+    return ts.where(usable).dt.strftime("%Y-%m-%d").fillna("").astype(str)
+
+
+# Census columns, in decode order. Columnar rather than per-picture dicts for
+# the reason issue #157 records, which binds harder here than on Mapillary: a
+# leader city is 500,000+ pictures over a few thousand tiles.
+#
+# `is_pano` is non-nullable "bool" and that is a correctness choice, not a size
+# one -- Panoramax's `type` has no absent state (module docstring, finding 3),
+# so there is no null to represent, and the two wrong declarations fail in ways
+# `census.census_is_pano` documents at length (an `object` column of Python
+# bools marks the ENTIRE city FLAT_ONLY without raising).
+_CENSUS_DTYPES = {
+    "id": pd.StringDtype("pyarrow"),
+    "lon": "float64",
+    "lat": "float64",
+    "ts": pd.StringDtype("pyarrow"),
+    "image_type": pd.StringDtype("pyarrow"),
+    "is_pano": "bool",
+    "account_id": pd.StringDtype("pyarrow"),
+    "sequence_id": pd.StringDtype("pyarrow"),
+}
+
+
+def records_to_census(records: list[dict[str, Any]]) -> pd.DataFrame:
+    """Panoramax's binding of :func:`census_core.records_to_census`."""
+    return census_core.records_to_census(records, _CENSUS_DTYPES)
+
+
+def concat_census(frames: list[pd.DataFrame]) -> pd.DataFrame:
+    """Combine per-tile census frames into one, preserving tile order."""
+    return census_core.concat_census(frames, _CENSUS_DTYPES)
+
+
+def _panoramax_image_columns(picked: pd.DataFrame) -> dict[str, Any]:
+    """
+    Panoramax's own output columns: the copyright convention plus its extras.
+
+    Handed to :func:`census_core.build_image_rows`, which fills the shared core.
+
+    The copyright string carries the contributor account, matching Mapillary's
+    `creator_id` and KartaView's `username` parity convention. It is NOT the
+    per-picture licence: Panoramax publishes `license` and `geovisio:producer`
+    only through `/api/search`, which the module docstring explains cannot be
+    the census, so the honest thing to record from a tile is who took it.
+    """
+    account = picked["account_id"].astype("string")
+    return {
+        # Through the nullable string dtype rather than astype(str), so a
+        # missing account stays missing instead of rendering "<NA>".
+        "copyright_info": ("© Panoramax contributor " + account)
+        .fillna("© Panoramax")
+        .to_numpy(dtype=object),
+        "account_id": account.to_numpy(dtype=object),
+        "sequence_id": picked["sequence_id"].to_numpy(dtype=object),
+        "image_type": picked["image_type"].to_numpy(dtype=object),
+        "is_pano": picked["is_pano"].to_numpy(),
+    }
+
+
+def _panoramax_capture_dates(census_frame: pd.DataFrame, positions: np.ndarray) -> np.ndarray:
+    """
+    Capture dates for the census rows at ``positions``, per Panoramax's rules.
+
+    Takes positions rather than a taken sub-frame so this indexes the ONE column
+    it needs; see :func:`census_core.write_census_grid_run` (issue #157).
+    """
+    return ts_to_iso_dates(census_frame["ts"].to_numpy()[positions]).to_numpy()
+
+
+def build_image_rows(
+    census_frame: pd.DataFrame,
+    image_positions: np.ndarray,
+    query_lat,
+    query_lon,
+    query_timestamp: str,
+    status,
+    capture_date,
+) -> pd.DataFrame:
+    """PANORAMAX_METADATA_DTYPES rows for query locations matched to census images."""
+    return census_core.build_image_rows(
+        census_frame,
+        image_positions,
+        query_lat,
+        query_lon,
+        query_timestamp,
+        status,
+        capture_date,
+        dtypes=PANORAMAX_METADATA_DTYPES,
+        image_columns=_panoramax_image_columns,
+    )
+
+
+def build_empty_rows(query_lat, query_lon, query_timestamp: str, status) -> pd.DataFrame:
+    """Rows for query locations with no imagery — ZERO_RESULTS and REQUEST_FAILED."""
+    return census_core.build_empty_rows(
+        query_lat, query_lon, query_timestamp, status, dtypes=PANORAMAX_METADATA_DTYPES
+    )
+
+
+# ── Download ───────────────────────────────────────────────────────────────
+
+
+# Same posture and the same 2% as Mapillary's: tolerate a blip, refuse a hole.
+# A fraction rather than a count for the reason recorded there — the threshold
+# bounds the size of the unknown region in an immutable snapshot, it does not
+# count requests.
+MAX_FAILED_TILE_FRACTION = 0.02
+
+_TILE_MAX_TRIES = 5
+_TILE_MAX_TIME_S = 120
+
+# Client-side pacing. NOTHING IS DOCUMENTED — no limit in the API docs, none in
+# the OpenAPI spec, and no X-RateLimit-*/Retry-After header comes back — so per
+# this repo's standing rule that is unknown rather than unlimited, and the
+# conservative end is the right end for three reasons that all point the same
+# way: api.panoramax.xyz is one volunteer-run meta-catalog taking all of our
+# load; there is no credential, so we cannot even be identified and throttled
+# individually before being blocked; and this host is reached from the same IP
+# as the nightly batch, which is exactly how both Mapillary bans took out
+# channels that had done nothing wrong.
+#
+# 30/min is phase 1's figure — half the Mapillary channels' configured rate
+# against a host with strictly less published guidance, which is the intended
+# direction of the asymmetry. It is not a measurement of anything Panoramax
+# said; raising it is a volume change under the top-of-file rule in CLAUDE.md.
+#
+# What it costs, over the cities that would actually be enrolled rather than
+# over the catalog: a p50 leader city is 414 z15 tiles (~14 min), p90 2,400
+# (~80 min), max 3,132 (~104 min), against a 12 h batch deadline.
+DEFAULT_TILE_REQUESTS_PER_MINUTE = 30
+
+# Jitter fraction, the #292 shifted exponential. Non-zero by default for the
+# reason the Mapillary channels are: after three per-IP blocks there, request
+# REGULARITY is the property never varied between restarts, and a metronomic
+# cadence from a datacenter IP is the one shape a rate-limiter's scorer reads
+# most easily. Adopted here BEFORE any incident rather than after three.
+DEFAULT_TILE_JITTER = 0.6
+
+# An error page rather than a tile. A DENY-list, not an allow-list, for the
+# reason #199 records: an allow-list would reject every tile the day the server
+# relabels a real content type, halting collection entirely.
+_TILE_ERROR_CONTENT_TYPES = ("text/html", "application/json")
+
+
+@backoff.on_exception(
+    backoff.expo,
+    (asyncio.TimeoutError, aiohttp.ClientError),
+    max_tries=_TILE_MAX_TRIES,
+    max_time=_TILE_MAX_TIME_S,
+)
+async def _fetch_tile(
+    session: aiohttp.ClientSession,
+    url: str,
+    timeout: aiohttp.ClientTimeout,
+    rate_limiter: AsyncRateLimiter | None = None,
+    on_request: Callable[[], None] | None = None,
+    on_empty: Callable[[], None] | None = None,
+) -> bytes:
+    # Pacing and counting sit INSIDE the retried body (issue #198): this
+    # function may issue up to _TILE_MAX_TRIES requests, and taking one token in
+    # the caller would let a retrying tile present five times the configured
+    # rate — during a 5xx storm, i.e. when the host is least able to absorb it —
+    # while under-reporting the same factor to the ledger.
+    if rate_limiter is not None:
+        await rate_limiter.acquire()
+    if on_request is not None:
+        on_request()
+    # allow_redirects=False for the reason #199 made it load-bearing on
+    # Mapillary: a host that answers a rate limit with a 302 to a login page
+    # would otherwise deliver that page's perfectly good HTTP 200 to the
+    # protobuf decoder, and a block would read as corrupt data.
+    async with session.get(url, timeout=timeout, allow_redirects=False) as response:
+        if response.status in (403, 429):
+            # STOP, NEVER RETRY. There is no credential here, so 403 cannot be a
+            # rejected token the way it is on Mapillary and KartaView — on this
+            # host both of these mean the IP is refused, and retrying into a
+            # refusal is reported to extend it.
+            raise HostBlockedError(
+                f"Panoramax refused this host (HTTP {response.status}). Reads are "
+                f"unauthenticated, so this is a per-IP refusal rather than a "
+                f"credential problem: stop, wait, and record what happened in "
+                f"docs/provider-access.md before collecting again.",
+                host=HOST_PANORAMAX,
+            )
+        if response.status in (301, 302, 303, 307, 308):
+            location = redact_credentials(response.headers.get("Location", "(none)"))
+            raise HostBlockedError(
+                f"Panoramax redirected instead of serving a tile (HTTP "
+                f"{response.status} → {location}). A redirect to a login or "
+                f"error page means this host's IP is being refused; a redirect "
+                f"anywhere else means the tile endpoint has moved and this code "
+                f"needs updating.",
+                host=HOST_PANORAMAX,
+            )
+        if response.status == 404:
+            # A tile the host has nothing for — an ANSWER, not a failure, which
+            # is the opposite of Mapillary's reading and is measured rather than
+            # assumed: phase 1 saw 0 empty tiles across 3,321 z14 requests
+            # including 20 cities that hold no imagery at all, because an empty
+            # area comes back 200 with no layer. Counted rather than silent, so
+            # the caller can refuse a run where EVERY tile 404s (see
+            # _fetch_city_images) — which is what a moved endpoint looks like,
+            # and would otherwise publish as "every pano in the city removed".
+            if on_empty is not None:
+                on_empty()
+            return b""
+        if response.status != 200:
+            # 5xx raises ClientResponseError, which backoff retries.
+            response.raise_for_status()
+        content_type = response.headers.get("Content-Type", "")
+        if any(bad in content_type.lower() for bad in _TILE_ERROR_CONTENT_TYPES):
+            raise HostBlockedError(
+                f"Panoramax served an error page instead of a vector tile "
+                f"(HTTP 200, Content-Type: {content_type}). This is usually a "
+                f"rate limit or a block on this host's IP, not a corrupt tile.",
+                host=HOST_PANORAMAX,
+            )
+        return await response.read()
+
+
+# ── The tile checkpoint on disk ────────────────────────────────────────────
+#
+# Layout and contract are Mapillary's, and deliberately so — the two are the
+# same crawl shape, and `docs/census.md` states the rules once:
+#
+#     <checkpoint_path>/
+#       state.json                the commit record; written LAST
+#       tile-17462-24880.parquet  one committed tile's census rows
+#
+# PARTS ARE KEYED BY TILE (x, y), NOT BY FETCH ORDER, because tiles are fetched
+# concurrently and completion order is nondeterministic; the reassembly order is
+# RECOMPUTED from `tiles_for_bbox` rather than stored. That is the byte-identity
+# mechanism, and without it `dedupe_census`'s first-position rule would resolve a
+# border duplicate differently depending on which night fetched which copy —
+# reading, in `diff.py`, as imagery churn indistinguishable from a real re-drive.
+#
+# ONLY SUCCESSFUL TILES ARE COMMITTED, so #168's tolerance keeps measuring
+# against the FULL tile set. A ZERO-ROW TILE GETS A RECORD AND NO FILE, which
+# matters more here than on Mapillary: at z15 most tiles over a real bbox are
+# empty and a leader city is thousands of them.
+#
+# CHECKPOINTING FAILS OPEN. The trade differs from Mapillary's by degree rather
+# than in kind — the worst city here is ~104 minutes rather than ~15 — but the
+# conclusion is the same: a city must never fail over its own safety net, and
+# what a lost checkpoint costs is a re-fetch, not an artifact.
+
+CHECKPOINT_PART_TEMPLATE = "tile-{x}-{y}.parquet"
+
+# Re-exposed under this module's own name; DECLARED in checkpointing.py beside
+# the other providers' so the census-cache probe can tell whether an entry's
+# commit record is one this loader reads without importing this module.
+CHECKPOINT_FORMAT_VERSION = PANORAMAX_CHECKPOINT_FORMAT_VERSION
+
+
+@dataclass
+class TileCheckpoint:
+    """Handle to an on-disk tile checkpoint, loaded or freshly opened."""
+
+    path: str
+    channel: str | None = None
+    # What distinguishes two crawls of one city inside one channel -- a walk's
+    # --network-type. None for a grid run, which has exactly one.
+    variant: str | None = None
+    # When the FIRST tile of this crawl was committed, carried forward by every
+    # later write. The age cap is measured from here and never from a timestamp
+    # that moves on writes committing no tile; see _commit_spend.
+    created_at: str | None = None
+    # (x, y) -> committed row count. Membership means "this tile is done"; the
+    # count distinguishes a committed empty tile from a missing part.
+    done: dict[tuple[int, int], int] = field(default_factory=dict)
+    # Spend of the PREVIOUS invocations only.
+    api_requests_before: int = 0
+    # Latched by the first failed commit, so the warning is logged once and the
+    # rest of the fetch runs uncheckpointed rather than retrying a directory
+    # that has already proved unwritable.
+    degraded: bool = False
+
+
+def _tile_part_path(path: str, x: int, y: int) -> str:
+    return os.path.join(path, CHECKPOINT_PART_TEMPLATE.format(x=x, y=y))
+
+
+def _validate_tile_store(
+    path: str,
+    state: dict,
+    *,
+    bbox: tuple[float, float, float, float],
+    tiles: list[tuple[int, int]],
+) -> tuple[dict[tuple[int, int], int] | None, str | None]:
+    """
+    The geometric/footer cascade every reader of a tile store makes.
+
+    ``(done, None)`` when the directory holds what its commit record claims for
+    THIS lattice, ``(None, reason)`` otherwise. Raises nothing of its own.
+
+    Factored out because a promoted cache entry IS a checkpoint directory that
+    was moved, so it must be validated exactly as a resume is. What each caller
+    adds differs: :func:`load_tile_checkpoint` adds the channel, the variant and
+    the crawl's age; :func:`load_cached_census` adds the marker's own window and
+    the one check a resume must NOT make, completeness.
+    """
+    if state["format_version"] != PANORAMAX_CHECKPOINT_FORMAT_VERSION:
+        return None, (
+            f"it is format v{state['format_version']}, this build writes "
+            f"v{PANORAMAX_CHECKPOINT_FORMAT_VERSION}"
+        )
+    if not _bbox_matches(state["bbox"], bbox):
+        return None, f"it covers bbox {state['bbox']}, this run uses {list(bbox)}"
+    if int(state["zoom"]) != TILE_ZOOM:
+        # The tile INDICES in every part name mean nothing without the zoom that
+        # produced them, so this is checked even though only z15 is served.
+        return None, f"it was fetched at z{state['zoom']}, this run uses z{TILE_ZOOM}"
+    if int(state["tile_count"]) != len(tiles):
+        return None, f"it covers {state['tile_count']} tiles, this run has {len(tiles)}"
+    done = {(int(x), int(y)): int(rows) for x, y, rows in state["done_tiles"]}
+    if not done.keys() <= set(tiles):
+        return None, "it holds tiles this run's lattice does not contain"
+    # Verify the parts from their FOOTERS — a seek to the end of each file —
+    # rather than discovering a truncated one at reassembly, after the fetch has
+    # already been paid for.
+    rows_on_disk = 0
+    for (x, y), rows in done.items():
+        if rows == 0:
+            continue  # committed empty tile; no part by design
+        part = _tile_part_path(path, x, y)
+        if not os.path.exists(part):
+            return None, f"committed part {os.path.basename(part)} is missing"
+        found = pq.ParquetFile(part).metadata.num_rows
+        if found != rows:
+            return None, (
+                f"part {os.path.basename(part)} holds {found} rows where the "
+                f"commit record says {rows}"
+            )
+        rows_on_disk += found
+    if rows_on_disk != int(state["census_rows"]):
+        return None, (
+            f"its parts hold {rows_on_disk} rows where the commit record says "
+            f"{state['census_rows']}"
+        )
+    return done, None
+
+
+def load_tile_checkpoint(
+    path: str,
+    *,
+    bbox: tuple[float, float, float, float],
+    tiles: list[tuple[int, int]],
+    channel: str | None = None,
+    variant: str | None = None,
+) -> TileCheckpoint | None:
+    """
+    Resume state for this census, or None if there is nothing usable here.
+
+    NEVER RAISES: every failure degrades to "fetch every tile" with a warning. A
+    checkpoint is not a comparison whose mismatch corrupts an artifact — the
+    worst case of ignoring one is a re-spend, so refusing outright would cost a
+    night to protect nothing.
+
+    An unusable checkpoint is DELETED. Its parts are named for the tiles they
+    hold, so a stale directory that is never resumed is also never overwritten.
+
+    Args:
+        path: the checkpoint directory. Need not exist.
+        bbox: this run's frame. A different one means a different lattice.
+        tiles: this run's tile list, from :func:`tiles_for_bbox`.
+        channel: which api_usage channel this census meters into. The PATH
+            already keys it, but the path is caller-built, so it is recorded and
+            compared here too.
+        variant: what separates two crawls of one city WITHIN one channel — a
+            walk's ``--network-type``, None for a grid run. The half a wrong
+            path cannot fix: two walks of one city agree on every geometric
+            parameter and on the ledger.
+    """
+
+    def discard(reason: str) -> None:
+        logger.warning(f"Ignoring the Panoramax tile checkpoint at {path}: {reason}")
+        discard_checkpoint(path)
+
+    state_path = _state_path(path)
+    if not os.path.exists(state_path):
+        return None  # the ordinary first-run case
+    try:
+        with open(state_path, encoding="utf-8") as f:
+            state = json.load(f)
+        if state.get("channel") != channel:
+            discard(
+                f"it belongs to the {state.get('channel')!r} channel and this run is "
+                f"{channel!r}; the two meter into different api_usage ledgers"
+            )
+            return None
+        if state.get("variant") != variant:
+            discard(
+                f"it belongs to the {state.get('variant')!r} crawl of this channel and "
+                f"this run is {variant!r}; resuming it would price this crawl with "
+                f"another one's requests"
+            )
+            return None
+        # MEASURED FROM created_at -- WHEN THE OLDEST ROW WAS FETCHED. Frozen
+        # geometry never changes, so every other check still passes months later
+        # and resuming would splice last quarter's rows into a snapshot dated
+        # today. `updated_at` cannot carry this: _commit_spend rewrites the
+        # record on a night that committed NO tile, and a host-blocked night
+        # records no consecutive_failure, so a city would refresh its own clock
+        # indefinitely. See checkpointing.CHECKPOINT_MAX_AGE_S.
+        age_s = (datetime.now(UTC) - datetime.fromisoformat(state["created_at"])).total_seconds()
+        if age_s > CHECKPOINT_MAX_AGE_S:
+            discard(
+                f"its first tile was committed {age_s / 86400:.1f} days ago, past the "
+                f"{CHECKPOINT_MAX_AGE_S / 86400:.0f}-day limit; its rows would be spliced "
+                f"into a snapshot dated today"
+            )
+            return None
+        done, reason = _validate_tile_store(path, state, bbox=bbox, tiles=tiles)
+        if reason is not None:
+            discard(reason)
+            return None
+        cp = TileCheckpoint(
+            path=path,
+            channel=channel,
+            variant=variant,
+            created_at=state["created_at"],
+            done=done,
+            api_requests_before=int(state["api_requests_total"]),
+        )
+    except Exception as e:
+        # Broad on purpose; see the NEVER RAISES note above.
+        discard(f"{type(e).__name__}: {e}")
+        return None
+
+    _purge_checkpoint_debris(cp.path, cp.done)
+    return cp
+
+
+def load_cached_census(
+    cache_path: str,
+    *,
+    bbox: tuple[float, float, float, float],
+    tiles: list[tuple[int, int]],
+    run_date: date | None = None,
+) -> tuple[TileCheckpoint, dict] | None:
+    """
+    A COMPLETE census another consumer already paid for, or None (issue #290).
+
+    :func:`checkpointing.load_cached_store` — which owns the marker window, the
+    ``run_date`` rule, the never-raise posture and the delete-what-is-refused
+    contract — with this provider's two checks plugged in: the same
+    geometric/footer cascade a resume makes, and COMPLETENESS, which a resume
+    deliberately does NOT check and which is the whole difference between the
+    two. A partial entry reused as a census would publish the missing tiles'
+    grid points as genuine no-imagery — absence never observed — in an immutable
+    dated snapshot.
+    """
+
+    def validate(state: dict) -> tuple[dict[tuple[int, int], int] | None, str | None]:
+        return _validate_tile_store(cache_path, state, bbox=bbox, tiles=tiles)
+
+    def is_complete(done: dict[tuple[int, int], int], state: dict, marker: dict) -> str | None:
+        failed = {(int(x), int(y)) for x, y in marker.get("failed") or []}
+        if done.keys() | failed == set(tiles):
+            return None
+        missing = len(set(tiles) - done.keys() - failed)
+        return (
+            f"it covers {len(done)} fetched + {len(failed)} failed of {len(tiles)} tiles, "
+            f"leaving {missing} never observed; only a COMPLETE census is reusable"
+        )
+
+    loaded = load_cached_store(
+        cache_path,
+        label="Panoramax census",
+        run_date=run_date,
+        validate=validate,
+        is_complete=is_complete,
+    )
+    if loaded is None:
+        return None
+    done, marker = loaded
+    return TileCheckpoint(path=cache_path, done=done), marker
+
+
+def _purge_checkpoint_debris(path: str, done: dict[tuple[int, int], int]) -> None:
+    """
+    Delete part files nothing committed, and any staging leftovers.
+
+    A part written for a tile that never reached the commit record is a torn
+    write. Takes ``done`` rather than a checkpoint because it must also run when
+    there is NO commit record: a process that died between its first
+    ``to_parquet`` and its first ``state.json`` leaves a part that
+    :func:`load_tile_checkpoint` returns too early to reach, and if that tile
+    later commits as EMPTY the footer loop skips it on ``rows == 0`` and the
+    file survives every later purge holding rows nothing will ever read.
+    """
+    if not os.path.isdir(path):
+        return
+    try:
+        for name in os.listdir(path):
+            if name.endswith(".tmp"):
+                os.remove(os.path.join(path, name))
+                continue
+            if not name.startswith("tile-") or not name.endswith(".parquet"):
+                continue
+            try:
+                _, x, y = name[: -len(".parquet")].split("-")
+                committed = (int(x), int(y)) in done
+            except ValueError:
+                committed = False
+            if not committed:
+                os.remove(os.path.join(path, name))
+    except OSError as e:
+        logger.warning(f"Could not tidy the Panoramax tile checkpoint at {path}: {e}")
+
+
+def _open_tile_checkpoint(
+    path: str | None,
+    *,
+    bbox: tuple[float, float, float, float],
+    tiles: list[tuple[int, int]],
+    channel: str | None,
+    variant: str | None = None,
+) -> TileCheckpoint | None:
+    """
+    Prepare the checkpoint directory and load any resumable state.
+
+    THE LOAD RUNS BEFORE THE ``makedirs``, AND THAT ORDER IS LOAD-BEARING. An
+    unusable checkpoint here is DELETED, so a directory created first would be
+    the one the discard removes: the fresh handle would point at nothing, every
+    commit would fail, ``degraded`` would latch on the first tile, and the city
+    would fetch unprotected. That is the case the age cap produces — the first
+    attempt after a multi-day block — so the one run that most needs protecting
+    would be the one running without it.
+    """
+    if path is None:
+        return None
+    resumed = load_tile_checkpoint(path, bbox=bbox, tiles=tiles, channel=channel, variant=variant)
+    try:
+        os.makedirs(path, exist_ok=True)
+    except OSError as e:
+        logger.warning(f"Could not open a tile checkpoint at {path}; fetching unprotected: {e}")
+        return None
+    if resumed is not None:
+        return resumed
+    # Nothing to resume, so nothing has swept this directory: a part left by a
+    # process that died before its first commit record is still here.
+    _purge_checkpoint_debris(path, {})
+    return TileCheckpoint(path=path, channel=channel, variant=variant)
+
+
+def _commit_tile(
+    cp: TileCheckpoint,
+    x: int,
+    y: int,
+    frame: pd.DataFrame,
+    *,
+    bbox: tuple[float, float, float, float],
+    tiles: list[tuple[int, int]],
+    api_requests_total: int,
+) -> None:
+    """
+    Make one fetched tile durable: its part first, then the commit record.
+
+    The ordering IS the commit point. ``state.json`` is written last and
+    atomically, so a part that exists without being counted never happened —
+    :func:`_purge_checkpoint_debris` sweeps it and the tile is refetched.
+
+    Best effort, and it LATCHES: the first failure warns once and turns
+    checkpointing off for the rest of the run.
+    """
+    if cp.degraded:
+        return
+    try:
+        if len(frame):
+            part = _tile_part_path(cp.path, x, y)
+            tmp = f"{part}.tmp"
+            frame.to_parquet(tmp, index=False)
+            # FSYNCED BEFORE THE RENAME, and the directory after it. Without
+            # them the part-then-state ordering holds against a process crash
+            # (where the page cache survives) but not against a power loss,
+            # where the two renames may reach the disk in either order — losing
+            # the WHOLE checkpoint rather than the last tile.
+            with open(tmp, "rb+") as f:
+                os.fsync(f.fileno())
+            os.replace(tmp, part)
+            _fsync_dir(cp.path)
+        done = dict(cp.done)
+        done[(x, y)] = len(frame)
+        _write_checkpoint_state(
+            cp, done, bbox=bbox, tiles=tiles, api_requests_total=api_requests_total
+        )
+        # Only after the record is durable, so an in-memory `done` can never
+        # claim a tile the next invocation would not find.
+        cp.done = done
+    except Exception as e:
+        cp.degraded = True
+        logger.warning(
+            f"Could not checkpoint tile ({x}, {y}) at {cp.path}; continuing "
+            f"unprotected for the rest of this city: {e}"
+        )
+
+
+def _write_checkpoint_state(
+    cp: TileCheckpoint,
+    done: dict[tuple[int, int], int],
+    *,
+    bbox: tuple[float, float, float, float],
+    tiles: list[tuple[int, int]],
+    api_requests_total: int,
+) -> None:
+    """
+    Write the commit record atomically. Raises; callers decide what that costs.
+
+    ``created_at`` is stamped by the FIRST write of a crawl and carried forward
+    by every later one, including the ones that commit no tile. It is what the
+    age cap is measured against, so it must describe the oldest row this
+    checkpoint holds rather than the last time anything touched the file.
+    """
+    created_at = cp.created_at or datetime.now(UTC).isoformat()
+    state = {
+        "format_version": PANORAMAX_CHECKPOINT_FORMAT_VERSION,
+        "bbox": list(bbox),
+        "zoom": TILE_ZOOM,
+        "channel": cp.channel,
+        "variant": cp.variant,
+        "tile_count": len(tiles),
+        "done_tiles": [[tx, ty, rows] for (tx, ty), rows in done.items()],
+        "census_rows": sum(done.values()),
+        "api_requests_total": api_requests_total,
+        "created_at": created_at,
+        "updated_at": datetime.now(UTC).isoformat(),
+    }
+    _write_json_durable(_state_path(cp.path), state)
+    cp.created_at = created_at
+
+
+def _commit_spend(
+    cp: TileCheckpoint | None,
+    *,
+    bbox: tuple[float, float, float, float],
+    tiles: list[tuple[int, int]],
+    api_requests_total: int,
+) -> None:
+    """
+    Persist spend that happened AFTER the last committed tile.
+
+    Without this the crawl total on the catalog row under-reports a night that
+    ended badly: the requests a block refused are counted into ``api_usage``
+    deliberately, but would die with the process.
+
+    Skipped when nothing was committed, so a city refused at request 1 leaves no
+    directory behind. THIS IS THE WRITE THAT MUST NOT AGE A CHECKPOINT —
+    ``created_at`` is carried forward instead; see :func:`_write_checkpoint_state`.
+    """
+    if cp is None or cp.degraded or not cp.done:
+        return
+    try:
+        _write_checkpoint_state(
+            cp, cp.done, bbox=bbox, tiles=tiles, api_requests_total=api_requests_total
+        )
+    except Exception as e:  # pragma: no cover - same fail-open posture as _commit_tile
+        logger.warning(f"Could not record the interrupted spend at {cp.path}: {e}")
+
+
+def _census_requests_total(cp: TileCheckpoint | None, api_requests: int) -> int:
+    """This census's spend across every invocation, checkpointed or not."""
+    return (cp.api_requests_before if cp else 0) + api_requests
+
+
+def _checkpoint_frame_for_tile(cp: TileCheckpoint, x: int, y: int) -> pd.DataFrame:
+    """Read one committed tile back. An empty tile has a record but no file."""
+    if cp.done[(x, y)] == 0:
+        return records_to_census([])
+    return pd.read_parquet(_tile_part_path(cp.path, x, y))
+
+
+def _reuse_cached_census(
+    cached: tuple[TileCheckpoint, dict],
+    *,
+    city_name: str,
+    tiles: list[tuple[int, int]],
+    checkpoint_channel: str | None,
+    checkpoint_variant: str | None,
+) -> dict[str, Any]:
+    """
+    Assemble a census from the shared cache. Zero requests (issue #290).
+
+    Reassembly walks ``tiles`` IN TILE ORDER, the same loop the fetch path ends
+    with, because that order is the whole byte-identity mechanism.
+
+    Failed tiles are INHERITED from the marker rather than re-probed: the reuser
+    is republishing the same observation, so the same grid points read
+    REQUEST_FAILED in both artifacts. The one reader for whom that is wrong —
+    the crawl's OWN channel re-finalizing after a tail crash — never reaches
+    here, because :func:`checkpointing.reconcile_cache_hit` hands such an entry
+    back to its checkpoint first.
+    """
+    store, marker = cached
+    fetched_by = marker.get("fetched_by")
+    crawl_started_at = marker.get("crawl_started_at")
+    # WARNING, not INFO: a collection that issues no request is otherwise
+    # indistinguishable from a real one in its artifact, and this line is what
+    # an operator reading the per-attempt log has to tell them apart.
+    logger.warning(
+        f"REUSING the Panoramax census fetched by {fetched_by} (crawl started "
+        f"{crawl_started_at}) for {city_name}: 0 tile requests"
+    )
+    results = [_checkpoint_frame_for_tile(store, x, y) for (x, y) in tiles if (x, y) in store.done]
+    raw_feature_count = sum(len(r) for r in results)
+    census = concat_census(results)
+    # The same release the fetch path makes before the dedup copy (issue #157).
+    del results
+    census = dedupe_census(census)
+    return {
+        "census": census,
+        "tiles": len(tiles),
+        "raw_feature_count": raw_feature_count,
+        "num_images": len(census),
+        "num_panos": int(census_core.census_is_pano(census).sum()),
+        "failed_tiles": [(int(x), int(y)) for x, y in marker.get("failed") or []],
+        # api_requests, api_requests_total, checkpoint_path and the provenance
+        # columns: the accounting all providers must agree on, from one place.
+        **reused_census_provenance(marker, channel=checkpoint_channel, variant=checkpoint_variant),
+    }
+
+
+async def fetch_city_images_async(
+    city_name: str,
+    bbox: tuple[float, float, float, float],
+    connection_limit: int = 5,
+    request_timeout: float = 30,
+    max_requests_per_minute: int = DEFAULT_TILE_REQUESTS_PER_MINUTE,
+    jitter: float = DEFAULT_TILE_JITTER,
+    checkpoint_path: str | None = None,
+    checkpoint_channel: str | None = None,
+    checkpoint_variant: str | None = None,
+    census_cache: CensusCache | None = None,
+) -> dict[str, Any]:
+    """
+    Fetch a city's Panoramax tile census, serialized against other processes.
+
+    Every Panoramax request in the repo passes through here, which is what makes
+    this the one place the machine-wide host lock has to be taken. The
+    ``AsyncRateLimiter`` bounds THIS process; the lock supplies the other half by
+    ensuring no second process is pacing itself at the same time (issue #208).
+
+    See :func:`_fetch_city_images` for the arguments and return value.
+
+    Raises:
+        HostBusyError: another process on this machine is already talking to
+            Panoramax. Raised before any request is issued.
+    """
+    # The lock hold covers the CHECKPOINT as well as the requests, which is why
+    # the checkpoint needs no lock of its own.
+    with host_lock(HOST_PANORAMAX):
+        try:
+            return await _fetch_city_images(
+                city_name,
+                bbox,
+                connection_limit=connection_limit,
+                request_timeout=request_timeout,
+                max_requests_per_minute=max_requests_per_minute,
+                jitter=jitter,
+                checkpoint_path=checkpoint_path,
+                checkpoint_channel=checkpoint_channel,
+                checkpoint_variant=checkpoint_variant,
+                census_cache=census_cache,
+            )
+        except BaseException:
+            # A city that failed before committing anything would otherwise
+            # leave an empty directory behind on every attempt. os.rmdir refuses
+            # a non-empty one, so a real checkpoint is never touched.
+            _remove_empty_checkpoint_dir(checkpoint_path)
+            raise
+
+
+async def _fetch_city_images(
+    city_name: str,
+    bbox: tuple[float, float, float, float],
+    connection_limit: int = 5,
+    request_timeout: float = 30,
+    max_requests_per_minute: int = DEFAULT_TILE_REQUESTS_PER_MINUTE,
+    jitter: float = DEFAULT_TILE_JITTER,
+    checkpoint_path: str | None = None,
+    checkpoint_channel: str | None = None,
+    checkpoint_variant: str | None = None,
+    census_cache: CensusCache | None = None,
+) -> dict[str, Any]:
+    """
+    Fetch and dedupe every Panoramax picture in a bbox from the z15 tiles.
+
+    Extracted from :func:`download_panoramax_metadata_async` so a future
+    road-walk collector can share the same fetch and decode: the two would differ
+    only in what they assign pictures TO afterwards.
+
+    Args:
+        city_name: label for logging/progress only.
+        bbox: (min_lon, min_lat, max_lon, max_lat), e.g. from grid_bbox.
+        connection_limit: max concurrent tile fetches.
+        request_timeout: per-request timeout in seconds.
+        max_requests_per_minute: client-side pacing cap. <= 0 disables pacing.
+        jitter: the #292 gap coefficient of variation.
+        checkpoint_path: directory to resume from and commit into, or None for
+            fetch-everything. Built by the caller, because only the caller knows
+            the channel — see :func:`checkpointing.checkpoint_path_for`.
+        checkpoint_channel: the api_usage channel this census meters into,
+            recorded so a checkpoint cannot be resumed under a different one.
+        checkpoint_variant: what separates two crawls of one city within that
+            channel — a walk's ``--network-type``, None for a grid run.
+        census_cache: the shared per-(provider, city, bbox) cache entry and how
+            this caller may use it (issue #290), also caller-built. Given one, a
+            COMPLETE census another consumer already paid for is reused here for
+            zero requests, and a census this call completes is PROMOTED into it
+            on the way out.
+
+    Returns:
+        Dict with ``census``, ``api_requests`` (THIS call's spend, for the
+        additive daily ledger), ``api_requests_total`` (the whole crawl's, for
+        the catalog row), ``tiles``, ``raw_feature_count``, ``num_images``,
+        ``num_panos``, ``failed_tiles``, ``checkpoint_path`` (None after a
+        promotion — the directory MOVED) and the census provenance
+        (``census_fetched_by`` / ``census_fetched_at`` / ``census_reused``).
+
+    Raises:
+        DownloadError: on a refusal or transport failure, carrying
+            ``api_requests`` so the caller can still record what it spent.
+    """
+    tiles = tiles_for_bbox(*bbox)
+    logger.info(
+        f"Fetching Panoramax metadata for {city_name}: {len(tiles)} z{TILE_ZOOM} "
+        f"tiles covering bbox {tuple(round(v, 4) for v in bbox)}"
+    )
+
+    # THE CACHE IS CONSULTED BEFORE THE CHECKPOINT IS OPENED (issue #290). The
+    # two answer different questions: a checkpoint is THIS crawl's unfinished
+    # work, a cache entry is a COMPLETE observation somebody already paid for
+    # over the identical lattice. If a usable entry exists there is nothing left
+    # to fetch, so opening a checkpoint first would create a directory, resume a
+    # partial crawl and re-request tiles the answer for is already on disk. A hit
+    # is then RECONCILED with whatever sits at checkpoint_path. This whole block
+    # runs inside the host lock.
+    if census_cache is not None and census_cache.reuse:
+        cached = load_cached_census(
+            census_cache.path, bbox=bbox, tiles=tiles, run_date=census_cache.run_date
+        )
+        if cached is not None and reconcile_cache_hit(
+            cached[1],
+            cache_path=census_cache.path,
+            checkpoint_path=checkpoint_path,
+            channel=checkpoint_channel,
+            variant=checkpoint_variant,
+        ):
+            return _reuse_cached_census(
+                cached,
+                city_name=city_name,
+                tiles=tiles,
+                checkpoint_channel=checkpoint_channel,
+                checkpoint_variant=checkpoint_variant,
+            )
+
+    checkpoint = _open_tile_checkpoint(
+        checkpoint_path,
+        bbox=bbox,
+        tiles=tiles,
+        channel=checkpoint_channel,
+        variant=checkpoint_variant,
+    )
+    done = checkpoint.done if checkpoint else {}
+    todo = [tile for tile in tiles if tile not in done]
+    if done and todo:
+        logger.warning(
+            f"Resuming {city_name} from the checkpoint at {checkpoint.path}: "
+            f"{len(done)}/{len(tiles)} tiles already fetched for "
+            f"{checkpoint.api_requests_before:,} requests; {len(todo)} to go"
+        )
+    elif done and not todo:
+        # Recovers the crash-after-fetch-before-catalog case for ~0 requests.
+        # Loud, because the other way to arrive here is a checkpoint the caller
+        # forgot to discard, and then a zero-request 'collection' would look
+        # like a real one.
+        logger.warning(
+            f"The checkpoint at {checkpoint.path} is COMPLETE: all {len(tiles)} tiles "
+            f"were fetched by an earlier invocation, so this one issues ZERO requests "
+            f"and re-finalizes from disk. If that is not what you meant, remove the "
+            f"directory and re-run."
+        )
+
+    api_requests = 0
+    empty_tiles = 0
+    timeout = aiohttp.ClientTimeout(total=request_timeout)
+    semaphore = asyncio.Semaphore(connection_limit)
+    rate_limiter = AsyncRateLimiter(max_requests_per_minute, jitter=jitter)
+    if max_requests_per_minute <= 0:
+        logger.info("Tile pacing DISABLED (max_requests_per_minute <= 0)")
+    elif jitter > 0:
+        # Logged as the gap DISTRIBUTION, not as a rate: the rate is what the
+        # metronome also said, and the shape is the property being chosen.
+        mean_gap_s = 60.0 / max_requests_per_minute
+        floor_s = mean_gap_s * (1 - jitter)
+        p99_s = mean_gap_s * ((1 - jitter) + jitter * math.log(100.0))
+        logger.info(
+            f"Pacing tile requests at a mean {max_requests_per_minute}/min, "
+            f"exponentially jittered (CV {jitter:.2f}; gaps floor {floor_s:.2f} s, "
+            f"mean {mean_gap_s:.2f} s, p99 {p99_s:.2f} s, no ceiling — issue #292)"
+        )
+    else:
+        logger.info(f"Pacing tile requests at {max_requests_per_minute}/min")
+    progress_bar = progress(
+        total=len(todo),
+        desc=f"Downloading Panoramax tiles for {city_name}",
+        unit="tile",
+        logger=logger,
+    )
+
+    def count_request() -> None:
+        nonlocal api_requests
+        api_requests += 1
+
+    def count_empty() -> None:
+        nonlocal empty_tiles
+        empty_tiles += 1
+
+    def interrupted(err: DownloadError) -> DownloadError:
+        """
+        Stamp an interrupted census's two counters and persist what it spent.
+
+        Every path that leaves this function without a census owes the caller
+        the same three things, so it is written once. The counters are
+        deliberately different numbers: ``api_requests`` is THIS process's spend,
+        for the additive (date, provider) ledger, and the total is the whole
+        crawl's, for the operator and the catalog row.
+        """
+        total = _census_requests_total(checkpoint, api_requests)
+        err.api_requests = api_requests
+        err.api_requests_total = total
+        _commit_spend(checkpoint, bbox=bbox, tiles=tiles, api_requests_total=total)
+        return err
+
+    # First whole-city condition seen: a refusal or an error page. Every
+    # remaining tile would fail identically, so stop issuing them (issue #205).
+    fatal: DownloadError | None = None
+
+    async def fetch_one(x: int, y: int) -> pd.DataFrame:
+        nonlocal fatal
+        url = TILE_URL_TEMPLATE.format(z=TILE_ZOOM, x=x, y=y)
+        async with semaphore:
+            # The abort check belongs HERE, inside the semaphore: gather starts
+            # every task at once and each runs to its first suspension point, so
+            # a check above this line would be evaluated by all N tasks before
+            # any response came back. Behind the semaphore, tasks resume a few at
+            # a time, see the flag, and return without taking a token.
+            if fatal is not None:
+                # Keep the progress bar honest: a city that stopped at request 1
+                # must not read like a city that hung at tile 3.
+                progress_bar.update(1)
+                return records_to_census([])
+            try:
+                # Pacing/counting happen inside _fetch_tile, per retried attempt.
+                tile_bytes = await _fetch_tile(
+                    session, url, timeout, rate_limiter, count_request, count_empty
+                )
+            except DownloadError as e:
+                # ONLY DownloadError trips the abort. Per-tile failures (a 5xx
+                # that exhausted its retries, a decode error) must still fan out
+                # to every tile — that is #168's guarantee that one bad tile
+                # cannot discard a city.
+                fatal = fatal or e
+                raise
+        progress_bar.update(1)
+        # Convert to columns HERE, not after the gather: asyncio.gather holds
+        # every tile's result until the last one lands, so returning dicts would
+        # keep the entire city's per-picture dicts alive at once (issue #157).
+        frame = records_to_census(pictures_from_tile(tile_bytes, x, y))
+        if checkpoint is not None:
+            # Synchronous, inside the coroutine: the loop is single-threaded, so
+            # this is atomic with respect to every other tile's commit, and the
+            # host lock rules out another process. Only a SUCCESSFUL tile gets
+            # here — a failure raised above, and stays refetchable.
+            _commit_tile(
+                checkpoint,
+                x,
+                y,
+                frame,
+                bbox=bbox,
+                tiles=tiles,
+                api_requests_total=checkpoint.api_requests_before + api_requests,
+            )
+        return frame
+
+    try:
+        # return_exceptions: one bad tile out of thousands must not discard the
+        # whole city (issue #168).
+        async with aiohttp.ClientSession(headers={"User-Agent": USER_AGENT}) as session:
+            settled = await asyncio.gather(
+                *(fetch_one(x, y) for x, y in todo), return_exceptions=True
+            )
+    except DownloadError as e:
+        # Called for its side effects, then a BARE re-raise: it is the same
+        # exception object, and `raise ... from e` would chain it to itself.
+        interrupted(e)
+        raise
+    except (TimeoutError, aiohttp.ClientError) as e:
+        error = DownloadError(f"Panoramax tile download failed: {redact_credentials(e)}")
+        raise interrupted(error) from e
+    finally:
+        progress_bar.close()
+
+    # This block wins over the loop's DownloadError arm below, which is dead on
+    # current code: `fetch_one` assigns `fatal` before it re-raises, so such an
+    # error is always ALSO in `settled`, and raising it here reports the error
+    # that actually caused the abort rather than whichever one sits earliest in
+    # tile order. Both are kept, and what the pair guards is a future edit that
+    # makes `fetch_one` swallow that error — then every aborted tile becomes an
+    # empty SUCCESS, `failed_tiles` is empty, and a 0-pano census registers,
+    # publishes and diffs as "every pano in the city removed".
+    if fatal is not None:
+        raise interrupted(fatal)
+
+    fetched: dict[tuple[int, int], pd.DataFrame] = {}
+    failed_tiles: list[tuple[int, int]] = []
+    first_error: BaseException | None = None
+    # `todo`, not `tiles`: a resumed run only attempted the missing ones.
+    for (x, y), outcome in zip(todo, settled, strict=True):
+        if isinstance(outcome, BaseException):
+            # Unreachable on current code (the `fatal` block above raises
+            # first); kept as the belt to that braces.
+            if isinstance(outcome, DownloadError):
+                raise interrupted(outcome)
+            failed_tiles.append((x, y))
+            first_error = first_error or outcome
+        else:
+            fetched[(x, y)] = outcome
+
+    # EVERY TILE ANSWERED 404 — refuse rather than publish a city as empty.
+    # A 404 is an ordinary "nothing here" on this host (see _fetch_tile), and a
+    # genuinely empty area answers 200 with no layer, so a whole lattice of them
+    # is what a MOVED OR RENAMED ENDPOINT looks like, not what an empty city
+    # looks like. Without this the run would finalize 0 panos, and against the
+    # previous snapshot `diff.py` would report every pano in the city removed.
+    #
+    # Bounded by `len(todo) >= 2`, and it is `todo` rather than `tiles` because
+    # a RESUMED run only asks for what it is missing -- a moved endpoint has to
+    # be caught there too, or a resume would assemble the census from committed
+    # tiles alone and publish a partial city as a complete one. Two is the bar
+    # because a single 404 is a hole worth one tile while two, against a
+    # measured baseline of zero in 3,321 requests, is a moved endpoint.
+    if len(todo) >= 2 and empty_tiles == len(todo):
+        error = DownloadError(
+            f"Every one of the {len(todo)} Panoramax tiles requested for {city_name} "
+            f"answered HTTP 404. An empty area answers 200 with no picture layer, so "
+            f"this means the tile endpoint ({TILE_URL_TEMPLATE}) has moved or been "
+            f"renamed — refusing to finalize a snapshot claiming the city holds no "
+            f"imagery."
+        )
+        raise interrupted(error)
+
+    if failed_tiles:
+        # Denominator is the FULL tile set, not this invocation's share: the
+        # tolerance asks what fraction of the city is unmeasured, and a tile a
+        # previous night already fetched is measured.
+        failed_fraction = len(failed_tiles) / len(tiles)
+        detail = f"{len(failed_tiles)}/{len(tiles)} tiles failed: {redact_credentials(first_error)}"
+        if failed_fraction > MAX_FAILED_TILE_FRACTION:
+            error = DownloadError(
+                f"Panoramax tile download failed: {detail} "
+                f"({failed_fraction:.1%} > {MAX_FAILED_TILE_FRACTION:.0%} tolerated); "
+                f"refusing to finalize an incomplete snapshot"
+            )
+            raise interrupted(error) from first_error
+        logger.warning(f"Continuing with {detail}; affected grid points marked REQUEST_FAILED")
+
+    # REASSEMBLE IN TILE ORDER, taking each tile from this run if it was fetched
+    # now and from its part file otherwise. This is the whole byte-identity
+    # mechanism: `gather` preserves argument order, so an uninterrupted run
+    # produces exactly this sequence, and concat + dedupe therefore see
+    # positionally identical input however the work was split across nights.
+    results = []
+    for tile in tiles:
+        if tile in fetched:
+            # pop, so the only surviving reference is the one in `results`.
+            results.append(fetched.pop(tile))
+        elif tile in done:
+            results.append(_checkpoint_frame_for_tile(checkpoint, *tile))
+        # else: it failed this run and no earlier one committed it. Already in
+        # failed_tiles, and the caller marks its points REQUEST_FAILED.
+
+    raw_feature_count = sum(len(r) for r in results)
+    census = concat_census(results)
+    # ALL THREE names have to go before the dedup copy: they hold references to
+    # the same per-tile frames, so dropping fewer frees nothing (issue #157).
+    del results, settled, fetched
+    census = dedupe_census(census)
+
+    # PROMOTION IS THE LAST STATEMENT BEFORE THE RETURN, and that placement is
+    # the safety argument (issue #290). Everything above it can raise, and a
+    # raise must leave the checkpoint exactly where the caller expects to resume
+    # from; here, nothing between the move and the return can fail.
+    #
+    # `not degraded` is the completeness guarantee: a checkpoint whose commits
+    # latched off is missing tiles it never recorded, and an incomplete entry
+    # reused as a census would publish absence that was never observed.
+    promoted = False
+    total = _census_requests_total(checkpoint, api_requests)
+    if (
+        census_cache is not None
+        and checkpoint is not None
+        and not checkpoint.degraded
+        and checkpoint.created_at is not None
+    ):
+        promoted = promote_checkpoint_to_cache(
+            checkpoint.path,
+            census_cache.path,
+            census_cache_marker(
+                "panoramax",
+                # RECORDED, never keyed: the entry is reusable by any channel,
+                # and this is what lets the catalog say who actually paid.
+                fetched_by=checkpoint.channel,
+                fetched_variant=checkpoint.variant,
+                crawl_started_at=checkpoint.created_at,
+                api_requests_total=total,
+                failed=[[int(x), int(y)] for x, y in failed_tiles],
+            ),
+        )
+
+    return {
+        "census": census,
+        "api_requests": api_requests,
+        "api_requests_total": total,
+        "checkpoint_path": None if promoted else (checkpoint.path if checkpoint else None),
+        "tiles": len(tiles),
+        "raw_feature_count": raw_feature_count,
+        # Summarized HERE, where the census is already in hand: the caller may
+        # not bind it to a local (write_census_grid_run pops and releases it).
+        "num_images": len(census),
+        "num_panos": int(census_core.census_is_pano(census).sum()),
+        "failed_tiles": failed_tiles,
+        "census_fetched_by": checkpoint_channel,
+        "census_fetched_at": checkpoint.created_at if checkpoint else None,
+        "census_reused": False,
+    }
+
+
+async def download_panoramax_metadata_async(
+    city_name: str,
+    center_lat: float,
+    center_lon: float,
+    grid_width: float,
+    grid_height: float,
+    step_length: float,
+    output_csv_gz_path: str,
+    connection_limit: int = 5,
+    request_timeout: float = 30,
+    max_requests_per_minute: int = DEFAULT_TILE_REQUESTS_PER_MINUTE,
+    jitter: float = DEFAULT_TILE_JITTER,
+    checkpoint_path: str | None = None,
+    checkpoint_channel: str | None = None,
+    census_cache: CensusCache | None = None,
+) -> dict[str, Any]:
+    """
+    Fetch Panoramax picture metadata for a city and write it as a run csv.gz.
+
+    Same calling convention as the other providers' downloaders MINUS the
+    credential: reads here are unauthenticated, so there is no ``access_token``
+    parameter and nothing for the CLI's fail-fast credential check to find.
+
+    The checkpoint is the caller's to DISCARD, once the run row is committed.
+    Nothing here removes it: this function returns after writing the CSV and the
+    caller still has stats, the runs row, the JSON and the diff to do, so a
+    delete issued here would guarantee that a crash in that tail costs the whole
+    census again.
+
+    Returns:
+        Dict with:
+            df: DataFrame containing the metadata (PANORAMAX_METADATA_DTYPES)
+            filename_with_path: the written .csv.gz path
+            api_requests: number of tile requests issued this call
+            api_requests_total: the census's spend across every invocation
+            checkpoint_path: the checkpoint to discard, or None (None too when
+                the census was promoted into the shared cache, issue #290)
+            census_fetched_by / census_fetched_at: which channel paid for this
+                census and when it observed Panoramax, for the ``runs`` row
+            num_flat_images: the flat census magnitude (issue #116)
+            started_at / finished_at: UTC ISO 8601 timestamps
+    """
+    started_at = datetime.now(UTC).isoformat()
+
+    # Checked before a single tile is fetched, though write_census_grid_run
+    # re-checks as it takes ownership of the write: one implementation, called
+    # at the point where failing is free.
+    census_core.prepare_output_path(output_csv_gz_path)
+
+    # Built before the fetch (its bbox bounds the tile set) and consumed after.
+    grid = census_core.build_grid(center_lat, center_lon, grid_width, grid_height, step_length)
+
+    fetched = await fetch_city_images_async(
+        city_name,
+        grid.bbox,
+        connection_limit=connection_limit,
+        request_timeout=request_timeout,
+        max_requests_per_minute=max_requests_per_minute,
+        jitter=jitter,
+        checkpoint_path=checkpoint_path,
+        checkpoint_channel=checkpoint_channel,
+        census_cache=census_cache,
+    )
+    # A reused census is stamped with when the provider was observed, a fresh
+    # one with this process's clock; see checkpointing.observation_timestamp.
+    query_timestamp = observation_timestamp(fetched, started_at)
+    api_requests = fetched["api_requests"]
+    api_requests_total = fetched["api_requests_total"]
+    failed_tiles = fetched.get("failed_tiles") or []
+    # Counted by the fetch, not recomputed here: binding the census to a local
+    # would pin the whole thing alive through both CSV writes (issue #157).
+    num_images = fetched["num_images"]
+    num_panos = fetched["num_panos"]
+    logger.info(
+        f"Decoded {fetched['raw_feature_count']} features "
+        f"({num_images} unique: {num_panos} panos, {num_images - num_panos} flat) "
+        f"from {fetched['tiles']} tiles"
+    )
+
+    # The tail is wrapped because the checkpoint changes what a crash HERE
+    # costs: with one, the next invocation re-finalizes from disk for ~0
+    # requests, so a tail failure that carried no spend would land this census's
+    # tiles in no ledger, ever.
+    try:
+        written = census_core.write_census_grid_run(
+            fetched,
+            grid,
+            output_csv_gz_path,
+            query_timestamp,
+            capture_dates_for=_panoramax_capture_dates,
+            image_columns=_panoramax_image_columns,
+            dtypes=PANORAMAX_METADATA_DTYPES,
+            # A tile that never downloaded leaves its grid points UNKNOWN rather
+            # than empty (issue #168); a clean fetch passes None and pays nothing.
+            unmeasured_mask=(
+                (lambda lats, lons: _points_in_tiles(lats, lons, failed_tiles))
+                if failed_tiles
+                else None
+            ),
+            unmeasured_desc=f"{len(failed_tiles)} undownloaded tile(s)",
+        )
+    except BaseException as e:
+        e.api_requests = api_requests
+        e.api_requests_total = api_requests_total
+        raise
+
+    return {
+        "df": written["df"],
+        "filename_with_path": output_csv_gz_path,
+        "api_requests": api_requests,
+        "api_requests_total": api_requests_total,
+        "checkpoint_path": fetched.get("checkpoint_path"),
+        "census_fetched_by": fetched.get("census_fetched_by"),
+        "census_fetched_at": fetched.get("census_fetched_at"),
+        "census_reused": bool(fetched.get("census_reused")),
+        # Census magnitude of flat imagery (issue #116): every in-grid flat
+        # picture, including those at points that also hold a pano. Not
+        # reconstructable from the CSV (flat-only points collapse to one
+        # FLAT_ONLY row), so it is threaded to the catalog separately.
+        "num_flat_images": written["num_flat_images"],
+        "started_at": started_at,
+        "finished_at": datetime.now(UTC).isoformat(),
+    }

--- a/streetscape_metadata_tracker/download_panoramax.py
+++ b/streetscape_metadata_tracker/download_panoramax.py
@@ -1273,6 +1273,15 @@ async def _fetch_city_images(
     async def fetch_one(x: int, y: int) -> pd.DataFrame:
         nonlocal fatal
         url = TILE_URL_TEMPLATE.format(z=TILE_ZOOM, x=x, y=y)
+        # Per-tile, alongside the whole-city counter: the commit below needs to
+        # know whether THIS tile 404ed, not how many did.
+        answered_404 = False
+
+        def note_empty() -> None:
+            nonlocal answered_404
+            answered_404 = True
+            count_empty()
+
         async with semaphore:
             # The abort check belongs HERE, inside the semaphore: gather starts
             # every task at once and each runs to its first suspension point, so
@@ -1287,7 +1296,7 @@ async def _fetch_city_images(
             try:
                 # Pacing/counting happen inside _fetch_tile, per retried attempt.
                 tile_bytes = await _fetch_tile(
-                    session, url, timeout, rate_limiter, count_request, count_empty
+                    session, url, timeout, rate_limiter, count_request, note_empty
                 )
             except DownloadError as e:
                 # ONLY DownloadError trips the abort. Per-tile failures (a 5xx
@@ -1301,11 +1310,27 @@ async def _fetch_city_images(
         # every tile's result until the last one lands, so returning dicts would
         # keep the entire city's per-picture dicts alive at once (issue #157).
         frame = records_to_census(pictures_from_tile(tile_bytes, x, y))
-        if checkpoint is not None:
+        if checkpoint is not None and not answered_404:
             # Synchronous, inside the coroutine: the loop is single-threaded, so
             # this is atomic with respect to every other tile's commit, and the
             # host lock rules out another process. Only a SUCCESSFUL tile gets
             # here — a failure raised above, and stays refetchable.
+            #
+            # A 404 is deliberately NOT committed, even though this run reads it
+            # as an empty tile. The moved-endpoint guard below is evidence that
+            # only exists per invocation — it asks whether everything REQUESTED
+            # answered 404 — so committing one spends that evidence: the run
+            # that correctly refuses would leave a checkpoint in which every
+            # tile is recorded fetched-and-empty, and the next invocation would
+            # find nothing to do, skip the guard, and re-finalize the city from
+            # disk as a genuine ZERO_RESULTS snapshot for 0 requests (then
+            # promote that into the shared #290 cache). Leaving it uncommitted
+            # re-asks the question every night, which is the only honest thing
+            # to do with a tile whose meaning a single response cannot settle.
+            # The cost is paid by the case measured at zero in 3,321 phase-1
+            # requests: a city with a scattered 404 never completes its
+            # checkpoint, so it re-fetches that tile on a resume and its cache
+            # entry is refused (and deleted) on the next read.
             _commit_tile(
                 checkpoint,
                 x,

--- a/streetscape_metadata_tracker/naming.py
+++ b/streetscape_metadata_tracker/naming.py
@@ -24,7 +24,7 @@ from datetime import date
 # Providers with a filename token. GSV files carry no token (legacy compat),
 # so 'gsv' never appears in filenames but is the parse default.
 DEFAULT_PROVIDER = "gsv"
-KNOWN_PROVIDERS = ("gsv", "mapillary", "kartaview")
+KNOWN_PROVIDERS = ("gsv", "mapillary", "kartaview", "panoramax")
 
 # Accepts int or float numeric groups, an optional provider token, and an
 # optional trailing ISO run date. The groups can't bleed into each other:

--- a/streetscape_metadata_tracker/scheduler.py
+++ b/streetscape_metadata_tracker/scheduler.py
@@ -88,6 +88,7 @@ from .download_mapillary import (
     DEFAULT_TILE_REQUESTS_PER_MINUTE,
     estimate_tile_count,
 )
+from .download_panoramax import estimate_tile_count as estimate_panoramax_tile_count
 from .json_summarizer import (
     generate_aggregate_v2,
     generate_driving_plan_summary,
@@ -1166,6 +1167,9 @@ def estimate_requests(
     KartaView: the radius-sweep lattice over the frozen bbox, carrying the
     study's measured overhead (see :func:`estimate_kartaview_requests`).
 
+    Panoramax: the same shape as Mapillary's, at the z15 the picture layer
+    starts at — so roughly four times the tiles over the identical bbox.
+
     ``conn`` is read by ``gsv_streets`` and ``kartaview``; without it each falls
     back to its geometry-only tier (the area proxy, and the default-radius
     lattice respectively).
@@ -1195,6 +1199,17 @@ def estimate_requests(
         # the sample count would have read 18,851 requests for a Krabi walk the
         # sweep covers in 64 circles.
         return estimate_kartaview_requests(conn, city)
+    if provider == "panoramax":
+        # A z15 lattice, so ~4x Mapillary's tiles over the same bbox — and NOT
+        # the grid formula below, which would read tens of thousands of points
+        # for a city the lattice covers in a few hundred tiles. This arm is
+        # reachable before the channel is wired (#316 phase 2): `panoramax` is
+        # opt-in, so `enroll-city --all` already prices the whole catalog with
+        # it, and cheapest-first tranche ordering computed on the grid formula
+        # would order cities by area rather than by what the channel spends.
+        return estimate_panoramax_tile_count(
+            city.center_lat, city.center_lon, city.grid_width_m, city.grid_height_m, city.step_m
+        )
     return (city.grid_width_m // city.step_m + 1) * (city.grid_height_m // city.step_m + 1)
 
 

--- a/streetscape_metadata_tracker/scheduler.py
+++ b/streetscape_metadata_tracker/scheduler.py
@@ -71,6 +71,7 @@ from .download_common import (
     HOST_LABELS,
     HOST_MAPILLARY_TILES,
     HOST_OVERPASS,
+    HOST_PANORAMAX,
     SWEEP_INCOMPLETE_EXIT_CODE,
     coerce_jitter,
     redact_credentials,
@@ -159,6 +160,14 @@ CHANNEL_HOSTS: dict[str, tuple[str, ...]] = {
     # host) + ONE of the three Overpass channels + mapillary (tiles) +
     # kartaview (KV) = 4. So 4 of 6 now, where it was 4 of 5.
     "kartaview_streets": (HOST_OVERPASS, HOST_KARTAVIEW),
+    # api.panoramax.xyz, shared with nothing (issue #316). Re-derive the ceiling
+    # rather than quoting the line above, which is what that line asks for: the
+    # largest host-disjoint set becomes gsv (no host) + ONE of the three Overpass
+    # channels + mapillary (tiles) + kartaview (KV) + panoramax = 5, so 5 of 7.
+    # The denominator moved and so did the numerator this time; neither is a
+    # constant, and the next channel gets the same re-derivation rather than
+    # this number.
+    "panoramax": (HOST_PANORAMAX,),
 }
 
 # What a NULL `schedule_state.member` means for each channel (issue #248), i.e.
@@ -198,6 +207,16 @@ CHANNEL_DEFAULT_MEMBERSHIP: dict[str, bool] = {
     "mapillary_streets": True,
     "kartaview": False,
     "kartaview_streets": False,
+    # panoramax is False on a MEASUREMENT rather than on a cost argument, which
+    # makes it the clearest case in this table (issue #316 phase 1). A screen of
+    # all 1,144 enabled cities found 730 of them — 63.8% — holding no Panoramax
+    # imagery AT ALL, and a screened zero is conclusive: every one of the 20
+    # screened-zero control cities measured exactly zero. So a default-membership
+    # channel would spend most of its nightly slots confirming absence, each one
+    # taken from a city with a second dated interval to gain (#308). The imagery
+    # is concentrated instead — roughly 20 cities hold 3.16 M pictures between
+    # them — which is exactly the shape enroll-city exists for.
+    "panoramax": False,
 }
 
 
@@ -243,6 +262,16 @@ CHANNEL_RESUMABLE: dict[str, bool] = {
     "kartaview_streets": True,
     "mapillary": False,
     "mapillary_streets": False,
+    # panoramax is False for the SAME reason the two Mapillary channels are, and
+    # for once that is a comfortable answer rather than a deferred one: it is a
+    # tile census that checkpoints (#316) but takes only a pacing knob, so there
+    # is nothing for a cap to stop. The largest city that would be enrolled is
+    # ~3,132 z15 tiles ≈ 104 minutes at 30/min, under the 180-minute floor, so
+    # no capped launch is needed to keep it inside a night. Revisit this the
+    # moment a bigger city is enrolled OR the downloader grows a request cap —
+    # marking it True with nothing reading the cap downstream is the fail-open
+    # this table was written against.
+    "panoramax": False,
 }
 
 
@@ -286,7 +315,24 @@ def is_resumable_channel(name: str) -> bool:
 # gone; the dict stays, because the record/drop/don't-raise asymmetry above is
 # the mechanism the NEXT unwired channel needs, and rebuilding it from scratch
 # under time pressure is how a fail-open arm gets missed again.
-UNWIRED_CHANNELS: dict[str, str] = {}
+#
+# AND THE NEXT ONE IS HERE. "panoramax" joined naming.KNOWN_PROVIDERS with its
+# collector (issue #316), so `streetscape_tracker.py --provider panoramax`
+# collects a city by hand and [providers.panoramax] would start PARSING — which
+# is the exact state kartaview sat in, and the state this dict exists to refuse.
+# Three of the four arms above are still unwritten for it: estimate_requests has
+# no panoramax term and falls through to the GSV grid formula, city_timeout_seconds
+# would hand a ~104-minute city the flat 180-minute floor, and enabled_providers'
+# rank.get(p, 99) would order it by accident. Removing this entry is the LAST
+# step of wiring the channel, not the first.
+UNWIRED_CHANNELS: dict[str, str] = {
+    "panoramax": (
+        "the panoramax collector has landed but its scheduler arms have not "
+        "(estimate_requests, city_timeout_seconds, the enabled_providers rank "
+        "and the _run_one_city pacing flag). Collect it by hand with "
+        "`streetscape_tracker.py --provider panoramax` until then."
+    ),
+}
 
 
 logger = logging.getLogger("streetscape_scheduler")

--- a/streetscape_metadata_tracker/vis.py
+++ b/streetscape_metadata_tracker/vis.py
@@ -216,6 +216,31 @@ PROVIDER_DISPLAY = {
         "label": "KartaView",
         "viewer_url": _kartaview_viewer_url,
     },
+    # THE PICTURE ITSELF, NOT A 360 VIEWER, and that is measured rather than a
+    # shortcut (probed 2026-09-06, issue #316). Panoramax's interactive viewer
+    # is served by each INSTANCE at its own root, and the federated meta-catalog
+    # we collect from hosts no viewer at all -- its root is a marketing page.
+    # The z15 `pictures` layer carries no instance either (only `via` in the
+    # /api/search response does, and search cannot be the census), so a run row
+    # has no way to name which of the 23 instances owns a picture.
+    #
+    # What DOES resolve federation-wide from the id alone is the asset route:
+    # /api/pictures/{id}/sd.jpg answers 308 to the owning instance's copy, so
+    # this link always opens the actual imagery. `sd` rather than `hd` because
+    # an equirectangular original is tens of megabytes.
+    #
+    # The alternative was no link at all, which is what the #312 rule prescribes
+    # when the only candidate is a guess -- and a guessed instance is exactly
+    # that. A working link to the picture beats a broken link to a viewer.
+    "panoramax": {
+        "label": "Panoramax",
+        # The only entry that overrides the link text, because the default
+        # "View in <label>" would promise a viewer this link is not.
+        "viewer_link_text": "Open this Panoramax picture",
+        "viewer_url": lambda pano_id, row: (
+            f"https://api.panoramax.xyz/api/pictures/{quote(str(pano_id), safe='')}/sd.jpg"
+        ),
+    },
 }
 
 
@@ -406,8 +431,11 @@ def create_visualization_map(df: pd.DataFrame, city_name: str, provider: str = "
         color = matplotlib.colors.to_hex(colormap(age_years))
 
         viewer_url = display["viewer_url"](row["pano_id"], row)
+        # Most providers get "View in <label>"; a provider whose link does not
+        # open its own viewer says so instead (see PROVIDER_DISPLAY).
+        link_text = display.get("viewer_link_text", f"View in {label}")
         viewer_link = (
-            f'<br><a href="{viewer_url}" target="_blank">View in {label}</a>' if viewer_url else ""
+            f'<br><a href="{viewer_url}" target="_blank">{link_text}</a>' if viewer_url else ""
         )
         popup = folium.Popup(
             f"""

--- a/streetscape_metadata_tracker/vis.py
+++ b/streetscape_metadata_tracker/vis.py
@@ -195,7 +195,12 @@ def _kartaview_viewer_url(pano_id, row) -> str | None:
 
 
 # User-facing labels and pano viewer deep-links per provider (mirrors the
-# PROVIDERS registry in www/js/streetscape-utils.js). viewer_url takes the whole
+# PROVIDERS registry in www/js/streetscape-utils.js — EXCEPT for panoramax,
+# which is deliberately here and not there until #316 phase 2's frontend PR: a
+# hand-collected panoramax run does reach cities.json.gz, but grid.js and
+# streets.js enumerate that registry, so its rows render nowhere and city.js
+# rewrites an unknown ?provider= to gsv. Per-run maps and popups, which is all
+# this table feeds, work now.) viewer_url takes the whole
 # row besides the pano id because KartaView's viewer is not addressable by photo
 # id; it may return None, which the popup renders as no link at all. Every
 # naming.KNOWN_PROVIDERS member must have an entry — a run's map is generated

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -175,18 +175,23 @@ def city_df_factory():
 
 
 @pytest.fixture(autouse=True)
-def _no_mapillary_tile_pacing(monkeypatch):
+def _no_tile_census_pacing(monkeypatch):
     """
-    Disable the Mapillary tile rate limiter (issue #198) for the whole suite.
+    Disable BOTH tile censuses' rate limiters for the whole suite.
 
-    The production default is deliberately slow — 60 tile requests/minute
-    against a per-IP limit on Mapillary's CDN — so a fixture city of a couple
-    hundred tiles would otherwise pace a single test out to several minutes of
-    real sleeping. Tests that care about pacing (rather than about what the
-    fetch returns) monkeypatch ``AsyncRateLimiter`` themselves, which runs after
-    this fixture and so wins.
+    Every production default here is deliberately slow — 60 tile requests/minute
+    for Mapillary against a per-IP limit on its CDN (issue #198), 30/min for
+    Panoramax against a host that documents no limit at all (issue #316) — so a
+    fixture city of a couple of hundred tiles would otherwise pace a single test
+    out to minutes of real sleeping. Panoramax is the worse of the two, being
+    both slower per request and at a zoom with ~4x the tiles.
+
+    Tests that care about pacing (rather than about what the fetch returns)
+    monkeypatch ``AsyncRateLimiter`` themselves, which runs after this fixture
+    and so wins.
     """
     from streetscape_metadata_tracker import download_mapillary as dm
+    from streetscape_metadata_tracker import download_panoramax as dp
 
     class _NoPacing:
         def __init__(self, max_per_minute, *args, **kwargs):
@@ -196,6 +201,7 @@ def _no_mapillary_tile_pacing(monkeypatch):
             return None
 
     monkeypatch.setattr(dm, "AsyncRateLimiter", _NoPacing)
+    monkeypatch.setattr(dp, "AsyncRateLimiter", _NoPacing)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_census_cache.py
+++ b/tests/test_census_cache.py
@@ -203,14 +203,19 @@ def test_every_census_provider_declares_its_store_format_in_one_place():
     module reads its format FROM here, so the probe compares against the same
     number the loader does.
     """
-    from streetscape_metadata_tracker import download_kartaview, download_mapillary
+    from streetscape_metadata_tracker import (
+        download_kartaview,
+        download_mapillary,
+        download_panoramax,
+    )
 
-    assert cp.CENSUS_PROVIDERS == {"kartaview", "mapillary"}
+    assert cp.CENSUS_PROVIDERS == {"kartaview", "mapillary", "panoramax"}
     assert (
         download_mapillary.MAPILLARY_CHECKPOINT_FORMAT_VERSION
         is cp.STORE_FORMAT_VERSIONS["mapillary"]
     )
     assert download_kartaview.CHECKPOINT_FORMAT_VERSION is cp.STORE_FORMAT_VERSIONS["kartaview"]
+    assert download_panoramax.CHECKPOINT_FORMAT_VERSION is cp.STORE_FORMAT_VERSIONS["panoramax"]
 
 
 def test_crawl_store_for_derives_both_paths_from_one_city_row():

--- a/tests/test_claude_md_router.py
+++ b/tests/test_claude_md_router.py
@@ -211,17 +211,41 @@ def test_every_credential_channel_appears_in_the_routers_credentials_table():
     without documenting it fails here, and so does documenting one that no
     longer exists.
     """
-    from streetscape_metadata_tracker.config import CHANNEL_ENV_VARS
+    from streetscape_metadata_tracker.config import CHANNEL_ENV_VARS, CREDENTIAL_FREE_CHANNELS
 
     text = _ROUTER.read_text(encoding="utf-8")
-    documented = dict(re.findall(r"^\| `([a-z_]+)` \| `([A-Z_]+)`", text, re.MULTILINE))
+    # SCOPED TO THE CREDENTIALS SECTION, which the previous version got for free
+    # and this one has to ask for. The variable cell is now read as free text
+    # rather than as a backticked SHOUTING_NAME, because a channel can
+    # legitimately have no variable to name (issue #316: Panoramax reads are
+    # unauthenticated) -- and requiring the name shape would have forced the
+    # choice between inventing a variable nothing reads and dropping the one
+    # provider whose credential story is unusual out of the table entirely,
+    # which is exactly the "the rows that are there read as complete" failure
+    # above, one provider further on. But a free-text second cell also matches
+    # the SUBCOMMAND table two sections up (`| `status` | Per-city ... |`), so
+    # the section slice is what keeps this reading the table it names.
+    section = re.search(
+        r"^### Credentials and config$(.*?)^#{2,3} ", text, re.MULTILINE | re.DOTALL
+    )
+    assert section, "CLAUDE.md no longer has a '### Credentials and config' section"
+    documented = dict(re.findall(r"^\| `([a-z_]+)` \| ([^|]+?) \|", section.group(1), re.MULTILINE))
     assert set(documented) == set(CHANNEL_ENV_VARS), (
         "every credential channel needs a row in CLAUDE.md's credentials table"
     )
-    for channel, env_var in documented.items():
-        assert env_var == CHANNEL_ENV_VARS[channel][0], (
-            f"the table says {channel} reads {env_var}, the code reads "
-            f"{CHANNEL_ENV_VARS[channel][0]} first"
+    for channel, cell in documented.items():
+        if channel in CREDENTIAL_FREE_CHANNELS:
+            # Say so in words. "none" is the assertion that the blank is
+            # deliberate; an empty cell would read as an unfinished row.
+            assert "none" in cell.lower(), (
+                f"{channel} needs no credential, so its table cell must SAY so "
+                f"rather than being blank or naming a variable; got {cell!r}"
+            )
+            assert "`" not in cell, f"{channel} reads no env var, but the table names one: {cell!r}"
+            continue
+        assert cell == f"`{CHANNEL_ENV_VARS[channel][0]}`", (
+            f"the table says {channel} reads {cell}, the code reads "
+            f"`{CHANNEL_ENV_VARS[channel][0]}` first"
         )
 
 

--- a/tests/test_cli_policy.py
+++ b/tests/test_cli_policy.py
@@ -1068,6 +1068,7 @@ EXPECTED_DOWNLOADER = {
     "gsv": "download_gsv_metadata_async",
     "mapillary": "download_mapillary_metadata_async",
     "kartaview": "download_kartaview_metadata_async",
+    "panoramax": "download_panoramax_metadata_async",
 }
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -82,17 +82,64 @@ def test_load_config_reads_no_env_var_outside_the_declared_table():
     assert read == declared
 
 
-@pytest.mark.parametrize("channel", sorted(config.CHANNEL_ENV_VARS))
+@pytest.mark.parametrize(
+    "channel", sorted(set(config.CHANNEL_ENV_VARS) - config.CREDENTIAL_FREE_CHANNELS)
+)
 def test_every_declared_channel_loads_from_its_own_variable(channel):
     """
     The other direction: a declared channel must be one load_config accepts,
     reading the variable the table names first. Pinned per channel so a typo in
     the table is a named failure rather than a KeyError somewhere downstream.
+
+    Credential-FREE channels are excluded by the derived set rather than by a
+    name, and get their own test below: they declare an empty tuple, so this
+    one's `[0]` would IndexError on them and say nothing about the table.
     """
     primary = config.CHANNEL_ENV_VARS[channel][0]
     with mock.patch.dict(os.environ, {primary: "SENTINEL"}, clear=True):
         loaded = config.load_config(channel)
     assert "SENTINEL" in loaded.values()
+
+
+@pytest.mark.parametrize("channel", sorted(config.CREDENTIAL_FREE_CHANNELS))
+def test_a_credential_free_channel_loads_with_a_BARE_environment(channel):
+    """
+    A channel declaring no variable must SUCCEED with nothing set at all, and
+    that is a real contract rather than a formality (issue #316).
+
+    `cli.py` loads every requested provider's config before any of them
+    collects — `--provider all` included, deliberately, so a host missing one
+    key is told before work starts. A credential-free channel that raised for
+    the credential it does not have would therefore take down every OTHER
+    provider in the same invocation, on a machine that is perfectly able to
+    collect them.
+
+    `clear=True` is the whole test: it asserts the success survives an
+    environment holding nothing, not merely one that happens to lack this
+    channel's variable.
+    """
+    assert config.CHANNEL_ENV_VARS[channel] == ()
+    with mock.patch.dict(os.environ, {}, clear=True):
+        loaded = config.load_config(channel)
+    # Same shape as its siblings so a caller can keep one code path, with the
+    # value that says "there is nothing to carry".
+    assert loaded == {"access_token": None}
+
+
+def test_the_credential_free_set_is_derived_from_the_table_not_listed_twice():
+    """
+    Pins the derivation, not the membership — a second hand-maintained list of
+    which channels need no key is exactly the drift CHANNEL_ENV_VARS exists to
+    stop, and it would fail open: a channel dropped from the second list starts
+    raising for a variable that does not exist.
+
+    The membership assertion beside it is deliberately weak (non-empty), so this
+    test does not have to be edited by the next credential-free provider.
+    """
+    assert config.CREDENTIAL_FREE_CHANNELS == frozenset(
+        channel for channel, variables in config.CHANNEL_ENV_VARS.items() if not variables
+    )
+    assert config.CREDENTIAL_FREE_CHANNELS, "at least panoramax should be credential-free"
 
 
 def test_the_kartaview_walk_falls_back_but_prefers_its_own_token():

--- a/tests/test_panoramax.py
+++ b/tests/test_panoramax.py
@@ -1,0 +1,574 @@
+"""
+The Panoramax tile decoder, its date rules and its transport (issue #316).
+
+Offline throughout: tiles are encoded in memory with the same coordinate math
+the decoder inverts, and the transport tests drive `_fetch_tile` against a
+minimal `aiohttp.ClientSession` stand-in rather than mocking HTTP. Nothing here
+touches api.panoramax.xyz.
+
+Three groups, each pinning a way this provider differs from the tile census it
+is modelled on, because those are the differences a reader coming from
+`download_mapillary` will assume away:
+
+  * THE ZOOM IS 15, not 14. Panoramax's per-picture layer does not exist below
+    z15, so a bbox costs ~4x the tiles and every derived cost figure moves with
+    it. A default that silently reverted to 14 would collect NOTHING and publish
+    it as a city with no imagery.
+  * `type` IS THE SOURCE OF `is_pano`, kept verbatim beside it. The census
+    schema declares `is_pano` NON-nullable, which is only honest because the
+    field has no absent state -- so what is pinned is that an absent type
+    produces flat rather than a null.
+  * 403/429 IS A STOP AND 404 IS AN ANSWER. There is no credential here, so a
+    403 cannot be a rejected token; and an empty area answers 200 with no layer,
+    so a 404 means "nothing at this tile" -- which is why a whole lattice of
+    them has to be refused rather than published.
+"""
+
+import asyncio
+from datetime import UTC, datetime, timedelta
+
+import aiohttp
+import mapbox_vector_tile
+import pandas as pd
+import pytest
+import yarl
+from multidict import CIMultiDict, CIMultiDictProxy
+
+from streetscape_metadata_tracker import config
+from streetscape_metadata_tracker import download_panoramax as dp
+from streetscape_metadata_tracker.census import QUERY_COLUMNS, census_is_pano
+from streetscape_metadata_tracker.download_common import (
+    HOST_BUSY_EXIT_CODES,
+    HOST_EXIT_CODES,
+    HOST_LABELS,
+    HOST_PANORAMAX,
+    DownloadError,
+    HostBlockedError,
+)
+
+SEATTLE = (47.6062, -122.3321)
+
+
+def encode_tile(features, tile_x, tile_y, zoom=dp.TILE_ZOOM, extent=4096, layer=None):
+    """
+    Raw MVT bytes for the `pictures` layer, inverting the decode path's math.
+
+    Properties are passed through as given, so a test can omit one entirely --
+    which is what a real tile does for an absent field, and is a different thing
+    from sending it as null.
+    """
+    encoded = []
+    for f in features:
+        fx, fy = _lonlat_to_tile_frac(f["lon"], f["lat"], zoom)
+        px = (fx - tile_x) * extent
+        py = (1 - (fy - tile_y)) * extent  # y-up, matching decode()'s default
+        encoded.append(
+            {
+                "geometry": {"type": "Point", "coordinates": [px, py]},
+                "properties": {k: v for k, v in f.items() if k not in ("lon", "lat")},
+            }
+        )
+    return mapbox_vector_tile.encode([{"name": layer or dp.PICTURE_LAYER, "features": encoded}])
+
+
+def _lonlat_to_tile_frac(lon, lat, zoom):
+    from streetscape_metadata_tracker.download_common import lonlat_to_tile_frac
+
+    return lonlat_to_tile_frac(lon, lat, zoom)
+
+
+def make_picture(
+    picture_id, lon, lat, *, image_type="equirectangular", ts="2025-11-02 00:24:37+00"
+):
+    """One tile feature. `image_type=None` OMITS the property, as a real tile does."""
+    picture = {"id": picture_id, "lon": lon, "lat": lat, "ts": ts}
+    if image_type is not None:
+        picture["type"] = image_type
+    return picture
+
+
+# ── 1. The zoom, which is the assumption a reader brings from Mapillary ─────
+
+
+def test_the_default_zoom_is_15_because_the_picture_layer_starts_there():
+    """
+    Not a tunable, and getting it wrong is SILENT: below z15 the `pictures`
+    layer is absent entirely, so every tile would decode to nothing and the run
+    would publish a city holding no imagery rather than failing.
+    """
+    assert dp.TILE_ZOOM == 15
+
+
+def test_tiles_for_bbox_defaults_to_this_providers_zoom_not_mapillarys():
+    """
+    Both providers expose a `tiles_for_bbox` with a default zoom, over ONE
+    shared implementation that has none. This pins that the two defaults are
+    different, which is the whole reason the shared one takes zoom as a required
+    argument.
+    """
+    from streetscape_metadata_tracker import download_mapillary as dm
+    from streetscape_metadata_tracker.download_common import tiles_for_bbox as shared
+
+    bbox = dp.grid_bbox(*SEATTLE, 400, 400, 20)
+    assert dp.tiles_for_bbox(*bbox) == shared(*bbox, 15)
+    assert dm.tiles_for_bbox(*bbox) == shared(*bbox, 14)
+    # And the z15 lattice really is finer, or the two defaults would be
+    # interchangeable and this test would pin nothing.
+    assert len(dp.tiles_for_bbox(*bbox)) > len(dm.tiles_for_bbox(*bbox))
+
+
+def test_the_cost_estimate_counts_the_z15_lattice_over_the_frozen_grid():
+    """
+    The scheduler's cost hook, and the number this channel's per-city timeout
+    would be derived from. Exact rather than estimated -- it counts the lattice
+    the fetch will walk -- so it is asserted against that lattice rather than
+    against a remembered figure.
+    """
+    lat, lon = SEATTLE
+    assert dp.estimate_tile_count(lat, lon, 1000, 1000, 20) == len(
+        dp.tiles_for_bbox(*dp.grid_bbox(lat, lon, 1000, 1000, 20))
+    )
+
+
+# ── 2. Decoding: `type` verbatim, `is_pano` derived, nothing absent ─────────
+
+
+def test_the_raw_type_is_kept_beside_the_boolean_it_produces():
+    """
+    A run file records what the provider said. `type` is two-state across the
+    federation's own totals today, but keeping it means a third value Panoramax
+    has never yet served would show up in the data as itself rather than being
+    counted as flat by the decoder and never seen again.
+    """
+    x, y = _tile_of(*SEATTLE)
+    raw = encode_tile(
+        [
+            make_picture("a", -122.3321, 47.6062, image_type="equirectangular"),
+            make_picture("b", -122.3322, 47.6063, image_type="flat"),
+        ],
+        x,
+        y,
+    )
+    decoded = {p["id"]: p for p in dp.pictures_from_tile(raw, x, y)}
+    assert decoded["a"]["image_type"] == dp.TYPE_360
+    assert decoded["a"]["is_pano"] is True
+    assert decoded["b"]["image_type"] == "flat"
+    assert decoded["b"]["is_pano"] is False
+
+
+def test_an_absent_type_decodes_as_FLAT_and_never_as_a_null():
+    """
+    The census schema declares `is_pano` NON-nullable "bool", which is only
+    honest if the decoder can never produce a null -- and `census_is_pano`
+    documents at length what the two nullable spellings cost (an `object` column
+    of Python bools marks the ENTIRE city FLAT_ONLY without raising).
+
+    Phase 1 measured 0 absent types over 1,345,143 pictures, so this is the
+    belt to that: if Panoramax ever omits the field, the row is flat imagery
+    with a recorded null `image_type`, not a null boolean.
+    """
+    x, y = _tile_of(*SEATTLE)
+    raw = encode_tile([make_picture("a", -122.3321, 47.6062, image_type=None)], x, y)
+    decoded = dp.pictures_from_tile(raw, x, y)
+    assert len(decoded) == 1
+    assert decoded[0]["is_pano"] is False
+    assert decoded[0]["image_type"] is None
+
+    census = dp.records_to_census(decoded)
+    assert census["is_pano"].dtype == "bool"  # non-nullable, so `~` is safe
+    assert not census_is_pano(census).any()
+
+
+def test_the_sequence_comes_from_first_sequence_and_the_contributor_from_account_id():
+    """The two tile property names differ from the column names they become, and
+    a silent rename here would publish an all-null column rather than fail."""
+    x, y = _tile_of(*SEATTLE)
+    raw = encode_tile(
+        [
+            {
+                "id": "a",
+                "lon": -122.3321,
+                "lat": 47.6062,
+                "ts": "2025-11-02 00:24:37+00",
+                "type": "equirectangular",
+                "first_sequence": "seq-1",
+                "account_id": "acct-1",
+            }
+        ],
+        x,
+        y,
+    )
+    decoded = dp.pictures_from_tile(raw, x, y)[0]
+    assert decoded["sequence_id"] == "seq-1"
+    assert decoded["account_id"] == "acct-1"
+
+
+def test_an_empty_tile_and_empty_bytes_are_answers_not_errors():
+    """
+    Most z15 tiles over a real bbox hold nothing, so this is the common case
+    rather than an edge one -- and a raise here would fail a city over its own
+    empty water.
+    """
+    x, y = _tile_of(*SEATTLE)
+    assert dp.pictures_from_tile(b"", x, y) == []
+    assert dp.pictures_from_tile(mapbox_vector_tile.encode([]), x, y) == []
+    # A tile carrying only some OTHER layer is the same answer.
+    assert dp.pictures_from_tile(encode_tile([], x, y, layer="sequences"), x, y) == []
+
+
+def test_a_picture_with_no_id_is_dropped_rather_than_given_the_TILE_LOCAL_one():
+    """
+    `dedupe_census` factorizes on `id`, and an MVT feature id is numbered PER
+    TILE -- so falling back to it (which `download_mapillary`'s decoder does)
+    would mint id "0" in every tile of the city and silently collapse those
+    distinct pictures into one.
+
+    This test caught exactly that: the fallback was copied across with the rest
+    of the decoder's shape, and mapbox_vector_tile supplies a feature id even
+    when the properties carry none, so nothing else would have shown it.
+    """
+    x, y = _tile_of(*SEATTLE)
+    raw = encode_tile(
+        [
+            {"lon": -122.3321, "lat": 47.6062, "ts": "2025-01-01 00:00:00+00"},
+            make_picture("a", -122.3322, 47.6063),
+        ],
+        x,
+        y,
+    )
+    assert [p["id"] for p in dp.pictures_from_tile(raw, x, y)] == ["a"]
+
+
+# ── 3. Capture dates: the floor, the sentinel, and the format pin ───────────
+
+
+@pytest.mark.parametrize(
+    "ts",
+    [
+        "2025-11-02 00:24:37+00",  # the shape the tiles actually serve
+        "2015-06-01T12:00:00Z",  # ISO with T and Z
+        "2026-08-27 21:27:43.123+00",  # fractional seconds
+        "1970-01-01 00:00:00+00",  # the measured epoch sentinel
+        "",
+        None,
+        "not a date",
+    ],
+)
+def test_the_scalar_and_vectorized_date_rules_agree(ts):
+    """
+    The scalar form is the readable statement of the rules and the vectorized
+    one is what a collection actually calls, so they are pinned element-wise --
+    the same contract `captured_at_to_iso_date(s)` carries for Mapillary. They
+    diverge exactly where a whole-column parse behaves differently from a
+    per-value one, which is the bug this pair exists to catch.
+    """
+    assert dp.ts_to_iso_dates([ts]).tolist() == [dp.ts_to_iso_date(ts)]
+
+
+def test_the_epoch_sentinel_is_dropped_by_the_floor():
+    """
+    Panoramax's first known sentinel, measured: two Paris pictures stamped
+    1970-01-01. It is not a null and no null check catches it -- it is a
+    perfectly well-formed timestamp that cannot be a capture date.
+    """
+    assert dp.ts_to_iso_date("1970-01-01 00:00:00+00") == ""
+    assert dp.ts_to_iso_date("2003-12-31 00:00:00+00") == ""
+    assert dp.ts_to_iso_date("2004-01-01 00:00:00+00") == "2004-01-01"
+
+
+def test_a_capture_date_in_the_future_is_dropped():
+    """Nothing can be captured after the query that saw it."""
+    tomorrow = (datetime.now(UTC) + timedelta(days=1)).isoformat()
+    assert dp.ts_to_iso_date(tomorrow) == ""
+
+
+def test_MIXED_PRECISION_IN_ONE_COLUMN_SURVIVES_the_parse():
+    """
+    THE REASON `format="ISO8601"` IS PINNED IN THE PARSER, and the one property
+    here that fails silently rather than loudly.
+
+    Left to infer, pandas locks onto ONE format from the first non-null value
+    and coerces every value at another precision to NaT -- so a whole-second
+    timestamp beside a fractional-second one nulls whichever came second, and
+    `errors="coerce"` is what makes that survivable instead of noisy. Same
+    defect as #226 from one direction and KartaView's mixed-precision pages
+    from another.
+    """
+    mixed = ["2025-11-02 00:24:37+00", "2026-08-27 21:27:43.123+00", "2015-06-01T12:00:00Z"]
+    assert dp.ts_to_iso_dates(mixed).tolist() == ["2025-11-02", "2026-08-27", "2015-06-01"]
+    # And the failure it prevents, demonstrated against the same input, so this
+    # test cannot pass by pinning a distinction that does not exist.
+    inferred = pd.to_datetime(pd.Series(mixed), utc=True, errors="coerce")
+    assert inferred.isna().any()
+
+
+def test_the_floor_is_read_from_analysis_rather_than_spelled_twice():
+    """A decode-time floor that drifted from the readers' would drop rows the
+    catalog then re-admits, or the reverse. Both existing census providers read
+    it from the same table."""
+    from streetscape_metadata_tracker.analysis import EARLIEST_PLAUSIBLE_CAPTURE
+
+    assert dp._EARLIEST_CAPTURE is EARLIEST_PLAUSIBLE_CAPTURE["panoramax"]
+
+
+# ── 4. The census bindings' contract with the shared seam ───────────────────
+
+
+def test_the_image_columns_binding_supplies_exactly_the_providers_own_columns():
+    """
+    `census._check_image_columns` enforces this, and it is asserted here too
+    because the three ways to get it wrong are each silent in the artifact: an
+    omitted column publishes all-null, a misspelled one vanishes, and one
+    colliding with the shared core overwrites `pano_lat`.
+    """
+    core = set(QUERY_COLUMNS) | {"pano_lat", "pano_lon", "pano_id", "capture_date"}
+    expected = set(config.PANORAMAX_METADATA_DTYPES) - core
+
+    picked = dp.records_to_census(
+        [
+            {
+                "id": "a",
+                "lon": -122.3,
+                "lat": 47.6,
+                "ts": "2025-11-02 00:24:37+00",
+                "image_type": "equirectangular",
+                "is_pano": True,
+                "account_id": "acct-1",
+                "sequence_id": "seq-1",
+            }
+        ]
+    )
+    assert set(dp._panoramax_image_columns(picked)) == expected
+
+
+def test_the_copyright_string_carries_the_contributor_and_degrades_to_the_platform():
+    """
+    Parity with Mapillary's `creator_id` and KartaView's `username`. It is NOT
+    the licence: Panoramax publishes per-picture licences only through
+    `/api/search`, which cannot be the census, so the honest thing a tile can
+    say is who took the picture.
+    """
+    picked = dp.records_to_census(
+        [
+            {
+                "id": "a",
+                "lon": -122.3,
+                "lat": 47.6,
+                "ts": "2025-11-02 00:24:37+00",
+                "image_type": "flat",
+                "is_pano": False,
+                "account_id": "acct-1",
+                "sequence_id": None,
+            },
+            {
+                "id": "b",
+                "lon": -122.3,
+                "lat": 47.6,
+                "ts": "2025-11-02 00:24:37+00",
+                "image_type": "flat",
+                "is_pano": False,
+                "account_id": None,
+                "sequence_id": None,
+            },
+        ]
+    )
+    copyright_info = list(dp._panoramax_image_columns(picked)["copyright_info"])
+    assert copyright_info[0] == "© Panoramax contributor acct-1"
+    # A missing account must not render "<NA>" into a published column.
+    assert copyright_info[1] == "© Panoramax"
+
+
+def test_the_capture_date_binding_indexes_positions_rather_than_taking_a_frame():
+    """
+    The seam hands a provider POSITIONS precisely so it can index the one or two
+    date columns it needs; a `.take()` here would materialize every column of a
+    multi-million-row census a second time (issue #157).
+    """
+    import numpy as np
+
+    census = dp.records_to_census(
+        [
+            {
+                "id": str(i),
+                "lon": -122.3,
+                "lat": 47.6,
+                "ts": ts,
+                "image_type": "equirectangular",
+                "is_pano": True,
+                "account_id": None,
+                "sequence_id": None,
+            }
+            for i, ts in enumerate(["2025-11-02 00:24:37+00", "1970-01-01 00:00:00+00"])
+        ]
+    )
+    dates = dp._panoramax_capture_dates(census, np.array([1, 0]))
+    assert list(dates) == ["", "2025-11-02"]
+
+
+# ── 5. Transport: what stops, what retries, what is merely empty ───────────
+
+
+_TILE_URL = "https://api.panoramax.xyz/api/map/15/5241/11447.mvt"
+
+
+class _FakeTileResponse:
+    def __init__(self, status, headers=None, body=b""):
+        self.status = status
+        self.headers = headers or {}
+        self._body = body
+
+    async def read(self):
+        return self._body
+
+    def raise_for_status(self):
+        """As aiohttp does it — without this the fake cannot reach the 4xx/5xx
+        path and a test aimed at a block fails with an AttributeError instead of
+        its own assertion."""
+        if self.status >= 400:
+            request_info = aiohttp.RequestInfo(
+                url=yarl.URL(_TILE_URL),
+                method="GET",
+                headers=CIMultiDictProxy(CIMultiDict()),
+                real_url=yarl.URL(_TILE_URL),
+            )
+            raise aiohttp.ClientResponseError(
+                request_info=request_info, history=(), status=self.status, message="error"
+            )
+
+
+class _FakeTileSession:
+    """Minimal aiohttp.ClientSession stand-in: .get() as an async CM."""
+
+    def __init__(self, response):
+        self._response = response
+        self.get_kwargs = []
+        self.calls = 0
+
+    def get(self, url, **kwargs):
+        self.calls += 1
+        self.get_kwargs.append(kwargs)
+        response = self._response
+
+        class _Ctx:
+            async def __aenter__(self):
+                return response
+
+            async def __aexit__(self, *exc):
+                return False
+
+        return _Ctx()
+
+
+def _fetch(session, **kwargs):
+    return asyncio.run(dp._fetch_tile(session, _TILE_URL, aiohttp.ClientTimeout(total=5), **kwargs))
+
+
+@pytest.mark.parametrize("status", [403, 429])
+def test_a_refusal_stops_at_the_FIRST_request_and_is_never_a_credential_problem(status):
+    """
+    There is no credential on this host, so a 403 cannot mean "rejected token"
+    the way it does on Mapillary and KartaView -- both of these mean the IP is
+    refused, and retrying into a refusal is reported to extend it. Typed as a
+    host condition so the scheduler's night-level breaker sees it.
+    """
+    session = _FakeTileSession(_FakeTileResponse(status))
+    with pytest.raises(HostBlockedError) as excinfo:
+        _fetch(session)
+    assert excinfo.value.host == HOST_PANORAMAX
+    assert session.calls == 1, "a refusal must not be retried"
+
+
+def test_a_redirect_is_seen_rather_than_followed():
+    """The whole point of allow_redirects=False: if aiohttp follows a redirect
+    to a login or error page, that page's own HTTP 200 is what the status checks
+    see and a block reads as corrupt protobuf (issue #199's shape)."""
+    session = _FakeTileSession(_FakeTileResponse(200, {"Content-Type": "application/x-protobuf"}))
+    _fetch(session)
+    assert session.get_kwargs[0]["allow_redirects"] is False
+
+    session = _FakeTileSession(_FakeTileResponse(302, {"Location": "https://example.test/login"}))
+    with pytest.raises(HostBlockedError) as excinfo:
+        _fetch(session)
+    assert excinfo.value.host == HOST_PANORAMAX
+
+
+def test_an_error_page_served_with_a_200_is_a_block_not_a_corrupt_tile():
+    session = _FakeTileSession(_FakeTileResponse(200, {"Content-Type": "text/html; charset=utf-8"}))
+    with pytest.raises(HostBlockedError):
+        _fetch(session)
+
+
+def test_a_404_is_an_EMPTY_TILE_that_is_counted_rather_than_raised():
+    """
+    The opposite reading from Mapillary's, and it is measured rather than
+    assumed: phase 1 saw 0 empty tiles across 3,321 requests INCLUDING 20 cities
+    holding no imagery at all, because an empty area answers 200 with no layer.
+    Counted so the caller can refuse a whole lattice of them.
+    """
+    empties = []
+    session = _FakeTileSession(_FakeTileResponse(404))
+    assert _fetch(session, on_empty=lambda: empties.append(1)) == b""
+    assert len(empties) == 1
+    assert session.calls == 1, "a 404 is an answer, so it must not be retried"
+
+
+def test_a_5xx_is_retried_and_every_attempt_is_paced_and_counted():
+    """
+    Pacing and counting sit INSIDE the retried body (issue #198): a stub that
+    took one token in the caller would let a retrying tile present five times
+    the configured rate during exactly the storm the host is least able to
+    absorb, while under-reporting the same factor to the ledger.
+    """
+    counted = []
+
+    class _Limiter:
+        def __init__(self):
+            self.acquired = 0
+
+        async def acquire(self):
+            self.acquired += 1
+
+    limiter = _Limiter()
+    session = _FakeTileSession(_FakeTileResponse(503))
+    with pytest.raises(aiohttp.ClientResponseError):
+        _fetch(session, rate_limiter=limiter, on_request=lambda: counted.append(1))
+    assert session.calls == dp._TILE_MAX_TRIES
+    assert len(counted) == session.calls == limiter.acquired
+
+
+def test_a_healthy_tile_returns_its_body():
+    body = mapbox_vector_tile.encode([])
+    session = _FakeTileSession(
+        _FakeTileResponse(200, {"Content-Type": "application/x-protobuf"}, body)
+    )
+    assert _fetch(session) == body
+
+
+# ── 6. The host, and the two exit codes it owns ────────────────────────────
+
+
+def test_panoramax_is_a_locked_host_with_its_own_unallocated_exit_codes():
+    """
+    A fourth per-IP host. The codes continue past 83 rather than filling the
+    77/78 gap, which stays open because those are EX_NOPERM and EX_CONFIG and a
+    plausible-sounding wrong answer is worse than an unallocated number.
+    """
+    assert HOST_LABELS[HOST_PANORAMAX] == "the Panoramax meta-catalog (api.panoramax.xyz)"
+    assert HOST_EXIT_CODES[HOST_PANORAMAX] == 84
+    assert HOST_BUSY_EXIT_CODES[HOST_PANORAMAX] == 85
+    # Distinct from every other host's, in both families.
+    assert len(set(HOST_EXIT_CODES.values())) == len(HOST_EXIT_CODES)
+    assert len(set(HOST_BUSY_EXIT_CODES.values())) == len(HOST_BUSY_EXIT_CODES)
+    assert not set(HOST_EXIT_CODES.values()) & set(HOST_BUSY_EXIT_CODES.values())
+
+
+def test_the_downloader_raises_DownloadError_kinds_the_cli_already_maps():
+    """`HostBlockedError` is a `DownloadError`, which is what lets cli.py's
+    existing exception handling record the spend and exit with a host code
+    without a Panoramax-shaped arm of its own."""
+    assert issubclass(HostBlockedError, DownloadError)
+
+
+def _tile_of(lat, lon, zoom=dp.TILE_ZOOM):
+    fx, fy = _lonlat_to_tile_frac(lon, lat, zoom)
+    return int(fx), int(fy)

--- a/tests/test_panoramax_collector.py
+++ b/tests/test_panoramax_collector.py
@@ -1,0 +1,561 @@
+"""
+Resume and shared-cache behaviour for the Panoramax tile census (issue #316).
+
+The contract is narrower than "it resumes". A checkpoint that resumed but
+assembled the census in a different order would be WORSE than no checkpoint at
+all: a run file is an immutable dated snapshot, `diff.py` compares one run to the
+previous of the same series, and a reordering shows up there as imagery churn
+that did not happen.
+
+So the headline is BYTE IDENTITY, asserted three ways against each other rather
+than against a committed fixture: an uninterrupted run, a run interrupted after
+one tile and resumed, and a run that reads the promoted census out of the shared
+cache must all write the same bytes. Three-way rather than against a golden file
+because the two grid columns come from a geodesic solve whose last ULP differs
+between macOS and glibc (`docs/census.md`), so a committed fixture would have to
+carry a numeric tolerance — while comparing runs produced on ONE machine pins
+the ordering exactly, which is the property at risk.
+
+The rest fall into three groups: what survives an interruption (only successful
+tiles), what the two counters mean (this process vs the whole crawl, which #239
+got backwards once), and what an unusable checkpoint does (degrade to a full
+fetch, never raise, never a wrong artifact).
+"""
+
+import asyncio
+import gzip
+import json
+import os
+from datetime import UTC, datetime, timedelta
+
+import mapbox_vector_tile
+import pytest
+
+from streetscape_metadata_tracker import download_panoramax as dp
+from streetscape_metadata_tracker.checkpointing import (
+    CHECKPOINT_STATE_FILENAME,
+    CensusCache,
+    census_cache_path_for,
+    checkpoint_path_for,
+    load_census_cache_marker,
+)
+from streetscape_metadata_tracker.download_common import (
+    HOST_PANORAMAX,
+    DownloadError,
+    HostBlockedError,
+)
+from tests.test_panoramax import encode_tile, make_picture
+
+SEATTLE = (47.6062, -122.3321)
+CITY_ID = "test--wa"
+RUN_KWARGS = dict(width=100, height=100, step=20)
+
+
+@pytest.fixture
+def straddling_city():
+    """Centred on a z15 tile x-boundary, so the bbox spans two tiles and a
+    border picture lands in both. That duplicate is the whole reason reassembly
+    order matters — `dedupe_census` keeps the FIRST position."""
+    from streetscape_metadata_tracker.download_common import (
+        lonlat_to_tile_frac,
+        tile_frac_to_lonlat,
+    )
+
+    lat = SEATTLE[0]
+    fx, fy = lonlat_to_tile_frac(SEATTLE[1], lat, dp.TILE_ZOOM)
+    boundary_lon, _ = tile_frac_to_lonlat(int(fx), fy, dp.TILE_ZOOM)
+    return lat, boundary_lon
+
+
+def _tiles(lat, lon):
+    return dp.tiles_for_bbox(*dp.grid_bbox(lat, lon, 100, 100, 20))
+
+
+def _payloads(lat, lon):
+    """One picture per tile plus a BORDER picture served by both, which is what
+    makes reassembly order observable at all."""
+    tiles = _tiles(lat, lon)
+    assert len(tiles) >= 2, "this fixture is meant to straddle a tile boundary"
+    border = make_picture("border", lon, lat)
+    payloads = {}
+    for i, tile in enumerate(tiles):
+        payloads[tile] = encode_tile(
+            [make_picture(f"p{i}", lon + 0.0001 * i, lat + 0.0001 * i), border], *tile
+        )
+    return payloads
+
+
+def _stub(monkeypatch, payloads, *, fail=(), record=None):
+    """Serve the given tiles; raise for any tile named in ``fail``."""
+
+    async def paced(session, url, timeout, rate_limiter=None, on_request=None, on_empty=None):
+        if on_request is not None:
+            on_request()
+        _, _, tail = url.rpartition("/map/")
+        _, x, y = tail.replace(".mvt", "").split("/")
+        xy = (int(x), int(y))
+        if record is not None:
+            record.append(xy)
+        if xy in fail:
+            raise RuntimeError(f"tile {xy} did not download")
+        return payloads.get(xy, mapbox_vector_tile.encode([]))
+
+    monkeypatch.setattr(dp, "_fetch_tile", paced)
+
+
+def _collect(tmp_path, lat, lon, *, name="run", **kwargs):
+    out = str(tmp_path / f"{name}.csv.gz")
+    result = asyncio.run(
+        dp.download_panoramax_metadata_async("Test City", lat, lon, 100, 100, 20, out, **kwargs)
+    )
+    return result, out
+
+
+def _bytes(path):
+    with gzip.open(path, "rb") as f:
+        return f.read()
+
+
+def _without_timestamps(raw: bytes) -> list[bytes]:
+    """
+    The CSV with its `query_timestamp` column blanked.
+
+    Two runs on different clocks differ in that column by construction, and it
+    is the one column that is SUPPOSED to differ — so it is removed rather than
+    tolerated, leaving every other byte compared exactly.
+    """
+    lines = raw.decode("utf-8").splitlines()
+    header = lines[0].split(",")
+    idx = header.index("query_timestamp")
+    out = [lines[0].encode()]
+    for line in lines[1:]:
+        cells = line.split(",")
+        cells[idx] = ""
+        out.append(",".join(cells).encode())
+    return out
+
+
+# ── 1. Byte identity across an interruption and across the cache ───────────
+
+
+def test_a_resumed_run_and_a_cache_reuse_write_THE_SAME_BYTES_as_one_pass(
+    monkeypatch, tmp_path, straddling_city
+):
+    """
+    THE HEADLINE. Reassembly walks `tiles_for_bbox` rather than a directory
+    glob or fetch order, so a border picture served by two tiles resolves to the
+    same position however the work was split — across an interruption, and
+    across a completely different consumer reading the promoted census.
+
+    Get this wrong and `diff.py` reports imagery churn in every Panoramax city
+    that straddles a tile edge, indistinguishable from a real re-drive.
+    """
+    lat, lon = straddling_city
+    payloads = _payloads(lat, lon)
+    tiles = _tiles(lat, lon)
+
+    # (a) One uninterrupted pass, no checkpoint at all.
+    _stub(monkeypatch, payloads)
+    _, plain = _collect(tmp_path, lat, lon, name="plain")
+
+    # (b) Interrupted after the first tile, then resumed.
+    checkpoint = str(tmp_path / "cp")
+    cache = CensusCache(str(tmp_path / "cache"))
+    _stub(monkeypatch, payloads, fail=set(tiles[1:]))
+    with pytest.raises(DownloadError):
+        _collect(
+            tmp_path,
+            lat,
+            lon,
+            name="partial",
+            checkpoint_path=checkpoint,
+            checkpoint_channel="panoramax",
+        )
+    assert os.path.exists(os.path.join(checkpoint, CHECKPOINT_STATE_FILENAME))
+
+    served = []
+    _stub(monkeypatch, payloads, record=served)
+    _, resumed = _collect(
+        tmp_path,
+        lat,
+        lon,
+        name="resumed",
+        checkpoint_path=checkpoint,
+        checkpoint_channel="panoramax",
+        census_cache=cache,
+    )
+    assert set(served) == set(tiles[1:]), "the already-committed tile must not be refetched"
+    assert _without_timestamps(_bytes(plain)) == _without_timestamps(_bytes(resumed))
+
+    # (c) A second channel reads the promoted census for zero requests.
+    served.clear()
+    _, reused = _collect(
+        tmp_path,
+        lat,
+        lon,
+        name="reused",
+        checkpoint_path=str(tmp_path / "cp-walk"),
+        checkpoint_channel="panoramax_streets",
+        census_cache=cache,
+    )
+    assert served == [], "a cache hit must issue no tile requests at all"
+    assert _without_timestamps(_bytes(plain)) == _without_timestamps(_bytes(reused))
+
+
+# ── 2. What survives an interruption ───────────────────────────────────────
+
+
+def test_only_successful_tiles_are_committed(monkeypatch, tmp_path, straddling_city):
+    """
+    A tile that failed stays refetchable, which is also what keeps #168's
+    tolerance measuring against the FULL tile set rather than against whatever
+    one process happened to attempt.
+    """
+    lat, lon = straddling_city
+    tiles = _tiles(lat, lon)
+    checkpoint = str(tmp_path / "cp")
+
+    _stub(monkeypatch, _payloads(lat, lon), fail=set(tiles[1:]))
+    with pytest.raises(DownloadError):
+        _collect(
+            tmp_path,
+            lat,
+            lon,
+            checkpoint_path=checkpoint,
+            checkpoint_channel="panoramax",
+        )
+
+    with open(os.path.join(checkpoint, CHECKPOINT_STATE_FILENAME)) as f:
+        state = json.load(f)
+    done = {(x, y) for x, y, _ in state["done_tiles"]}
+    assert done == {tiles[0]}
+
+
+def test_an_empty_tile_gets_a_RECORD_AND_NO_FILE(monkeypatch, tmp_path, straddling_city):
+    """
+    Most z15 tiles over a real bbox hold nothing, and a part file for each would
+    mean thousands of files per city to say nothing. The record's row count is
+    what separates "empty tile, already fetched" from "not fetched yet".
+    """
+    lat, lon = straddling_city
+    tiles = _tiles(lat, lon)
+    checkpoint = str(tmp_path / "cp")
+
+    # Nothing anywhere: every tile decodes to zero rows.
+    _stub(monkeypatch, {})
+    _collect(tmp_path, lat, lon, checkpoint_path=checkpoint, checkpoint_channel="panoramax")
+
+    with open(os.path.join(checkpoint, CHECKPOINT_STATE_FILENAME)) as f:
+        state = json.load(f)
+    assert {(x, y) for x, y, _ in state["done_tiles"]} == set(tiles)
+    assert all(rows == 0 for _, _, rows in state["done_tiles"])
+    assert [n for n in os.listdir(checkpoint) if n.endswith(".parquet")] == []
+
+
+# ── 3. The two counters ────────────────────────────────────────────────────
+
+
+def test_a_resume_charges_only_ITS_OWN_requests_to_the_daily_ledger(
+    monkeypatch, tmp_path, straddling_city
+):
+    """
+    `api_requests` is THIS process's spend and `api_requests_total` is the
+    crawl's, and #239 got this backwards once. `db.add_api_usage` is additive
+    and keyed by (date, provider), so a resumed night reporting the whole crawl
+    would charge last night's tiles against tonight's budget gate.
+
+    The total is asserted as the SUM of the two nights rather than as the tile
+    count, and the difference is the finding: the first night ATTEMPTED every
+    tile and committed one, so the crawl cost more requests than the lattice has
+    tiles. A total equal to the tile count would mean the failed attempts had
+    been dropped from the crawl's price — which is the direction that
+    under-reports what a city actually cost.
+    """
+    lat, lon = straddling_city
+    tiles = _tiles(lat, lon)
+    checkpoint = str(tmp_path / "cp")
+
+    _stub(monkeypatch, _payloads(lat, lon), fail=set(tiles[1:]))
+    with pytest.raises(DownloadError) as first:
+        _collect(tmp_path, lat, lon, checkpoint_path=checkpoint, checkpoint_channel="panoramax")
+    night_one = first.value.api_requests
+    assert night_one == len(tiles), "every tile was attempted; only one came back"
+
+    _stub(monkeypatch, _payloads(lat, lon))
+    result, _ = _collect(
+        tmp_path,
+        lat,
+        lon,
+        name="resumed",
+        checkpoint_path=checkpoint,
+        checkpoint_channel="panoramax",
+    )
+    assert result["api_requests"] == len(tiles) - 1, "only the tiles this call fetched"
+    assert result["api_requests_total"] == night_one + result["api_requests"]
+
+
+def test_a_blocked_nights_refused_requests_still_reach_the_crawl_total(
+    monkeypatch, tmp_path, straddling_city
+):
+    """
+    The requests a block refuses are counted into `api_usage` deliberately — one
+    token, one counted request — but they die with the process unless
+    `_commit_spend` writes them into the record. Without it a resumed run's
+    catalog row prices the city below what it actually cost.
+    """
+    lat, lon = straddling_city
+    tiles = _tiles(lat, lon)
+    checkpoint = str(tmp_path / "cp")
+
+    payloads = _payloads(lat, lon)
+    blocked_after = {"n": 0}
+
+    async def paced(session, url, timeout, rate_limiter=None, on_request=None, on_empty=None):
+        if on_request is not None:
+            on_request()
+        blocked_after["n"] += 1
+        _, _, tail = url.rpartition("/map/")
+        _, x, y = tail.replace(".mvt", "").split("/")
+        xy = (int(x), int(y))
+        if xy != tiles[0]:
+            raise HostBlockedError("refused", host=HOST_PANORAMAX)
+        return payloads[xy]
+
+    monkeypatch.setattr(dp, "_fetch_tile", paced)
+    with pytest.raises(HostBlockedError) as excinfo:
+        _collect(tmp_path, lat, lon, checkpoint_path=checkpoint, checkpoint_channel="panoramax")
+    spent = excinfo.value.api_requests
+    assert spent > 1, "the refusal itself was a request and must be counted"
+
+    with open(os.path.join(checkpoint, CHECKPOINT_STATE_FILENAME)) as f:
+        state = json.load(f)
+    assert state["api_requests_total"] == spent
+
+
+# ── 4. An unusable checkpoint degrades; it never raises and never lies ─────
+
+
+@pytest.mark.parametrize(
+    "mutate,why",
+    [
+        (lambda s: s.update(format_version=99), "a format this build does not write"),
+        (lambda s: s.update(zoom=14), "the Mapillary zoom, whose tile indices mean something else"),
+        (lambda s: s.update(tile_count=999), "a lattice this run does not have"),
+        (lambda s: s.update(channel="mapillary"), "another channel's ledger"),
+        (lambda s: s.update(variant="all_public"), "another crawl of this channel"),
+        (
+            lambda s: s.update(created_at=(datetime.now(UTC) - timedelta(days=30)).isoformat()),
+            "rows old enough to be spliced into a snapshot dated today",
+        ),
+        (lambda s: s.update(bbox=[0.0, 0.0, 1.0, 1.0]), "a different frame"),
+    ],
+)
+def test_an_unusable_checkpoint_is_discarded_and_refetched_without_raising(
+    monkeypatch, tmp_path, straddling_city, mutate, why
+):
+    """
+    A checkpoint is not a comparison whose mismatch corrupts an artifact — the
+    worst case of ignoring one is a re-spend — so every one of these degrades to
+    a full fetch with a warning. Refusing outright would cost a night to protect
+    nothing; resuming would splice the wrong rows into a dated snapshot.
+    """
+    lat, lon = straddling_city
+    tiles = _tiles(lat, lon)
+    checkpoint = str(tmp_path / "cp")
+
+    _stub(monkeypatch, _payloads(lat, lon), fail=set(tiles[1:]))
+    with pytest.raises(DownloadError):
+        _collect(tmp_path, lat, lon, checkpoint_path=checkpoint, checkpoint_channel="panoramax")
+
+    state_path = os.path.join(checkpoint, CHECKPOINT_STATE_FILENAME)
+    with open(state_path) as f:
+        state = json.load(f)
+    mutate(state)
+    with open(state_path, "w") as f:
+        json.dump(state, f)
+
+    served = []
+    _stub(monkeypatch, _payloads(lat, lon), record=served)
+    result, _ = _collect(
+        tmp_path,
+        lat,
+        lon,
+        name="fresh",
+        checkpoint_path=checkpoint,
+        checkpoint_channel="panoramax",
+    )
+    assert set(served) == set(tiles), f"a checkpoint describing {why} must be refetched whole"
+    assert result["api_requests"] == len(tiles)
+    assert result["api_requests_total"] == len(tiles), (
+        "a discarded checkpoint's spend must not be carried into the new crawl"
+    )
+
+
+def test_no_checkpoint_path_is_the_pre_checkpoint_behaviour_exactly(
+    monkeypatch, tmp_path, straddling_city
+):
+    """Passing None must be byte-equivalent to the fetch-everything path, and
+    must leave nothing on disk to clean up."""
+    lat, lon = straddling_city
+    _stub(monkeypatch, _payloads(lat, lon))
+    result, _ = _collect(tmp_path, lat, lon)
+    assert result["checkpoint_path"] is None
+    assert not any(p.name == "cp" for p in tmp_path.iterdir())
+
+
+def test_a_city_refused_before_committing_anything_leaves_no_empty_directory(
+    monkeypatch, tmp_path, straddling_city
+):
+    """Otherwise every blocked night leaves a directory behind, on every city."""
+    lat, lon = straddling_city
+    checkpoint = str(tmp_path / "cp")
+
+    async def refuse(session, url, timeout, rate_limiter=None, on_request=None, on_empty=None):
+        if on_request is not None:
+            on_request()
+        raise HostBlockedError("refused", host=HOST_PANORAMAX)
+
+    monkeypatch.setattr(dp, "_fetch_tile", refuse)
+    with pytest.raises(HostBlockedError):
+        _collect(tmp_path, lat, lon, checkpoint_path=checkpoint, checkpoint_channel="panoramax")
+    assert not os.path.exists(checkpoint)
+
+
+# ── 5. The shared census cache, and who is charged for what ───────────────
+
+
+def test_the_cache_records_who_paid_and_prices_a_cross_channel_reuse_at_zero(
+    monkeypatch, tmp_path, straddling_city
+):
+    """
+    `api_requests` is 0 for every reuser — charging one would bill another
+    channel's spend against its budget gate — while `api_requests_total` is the
+    crawl's cost only for the (channel, variant) that actually paid. The
+    asymmetry is easy to get backwards, so both halves are asserted.
+    """
+    lat, lon = straddling_city
+    tiles = _tiles(lat, lon)
+    cache = CensusCache(str(tmp_path / "cache"))
+
+    _stub(monkeypatch, _payloads(lat, lon))
+    paid, _ = _collect(
+        tmp_path,
+        lat,
+        lon,
+        name="grid",
+        checkpoint_path=str(tmp_path / "cp-grid"),
+        checkpoint_channel="panoramax",
+        census_cache=cache,
+    )
+    assert paid["api_requests"] == len(tiles)
+    assert paid["census_reused"] is False
+    # Promotion MOVED the directory, so the caller must not chase it.
+    assert paid["checkpoint_path"] is None
+
+    marker = load_census_cache_marker(cache.path, run_date=None)
+    assert marker is not None
+    assert marker["fetched_by"] == "panoramax"
+
+    served = []
+    _stub(monkeypatch, _payloads(lat, lon), record=served)
+    reuser, _ = _collect(
+        tmp_path,
+        lat,
+        lon,
+        name="walk",
+        checkpoint_path=str(tmp_path / "cp-walk"),
+        checkpoint_channel="panoramax_streets",
+        census_cache=cache,
+    )
+    assert served == []
+    assert reuser["api_requests"] == 0
+    assert reuser["api_requests_total"] == 0, "a different channel did not pay for this census"
+    assert reuser["census_reused"] is True
+    assert reuser["census_fetched_by"] == "panoramax"
+
+
+def test_refetch_census_ignores_the_entry_and_pays_again(monkeypatch, tmp_path, straddling_city):
+    """
+    `--refetch-census` is about the OBSERVATION — take it now — which is
+    deliberately not what `--force` means. A run that reused the entry here
+    would silently republish a week-old observation the operator asked to
+    replace.
+    """
+    lat, lon = straddling_city
+    tiles = _tiles(lat, lon)
+    cache_path = str(tmp_path / "cache")
+
+    _stub(monkeypatch, _payloads(lat, lon))
+    _collect(
+        tmp_path,
+        lat,
+        lon,
+        name="grid",
+        checkpoint_path=str(tmp_path / "cp-grid"),
+        checkpoint_channel="panoramax",
+        census_cache=CensusCache(cache_path),
+    )
+
+    served = []
+    _stub(monkeypatch, _payloads(lat, lon), record=served)
+    result, _ = _collect(
+        tmp_path,
+        lat,
+        lon,
+        name="again",
+        checkpoint_path=str(tmp_path / "cp-again"),
+        checkpoint_channel="panoramax",
+        census_cache=CensusCache(cache_path, reuse=False),
+    )
+    assert set(served) == set(tiles)
+    assert result["api_requests"] == len(tiles)
+
+
+def test_an_INCOMPLETE_crawl_is_never_promoted(monkeypatch, tmp_path, straddling_city):
+    """
+    Completeness is the whole difference between a checkpoint and a cache entry.
+    A resume is allowed to be partial by definition; a partial entry reused as a
+    census would publish the missing tiles' grid points as genuine no-imagery —
+    absence never observed — in an immutable dated snapshot.
+    """
+    lat, lon = straddling_city
+    tiles = _tiles(lat, lon)
+    cache = CensusCache(str(tmp_path / "cache"))
+
+    _stub(monkeypatch, _payloads(lat, lon), fail=set(tiles[1:]))
+    with pytest.raises(DownloadError):
+        _collect(
+            tmp_path,
+            lat,
+            lon,
+            checkpoint_path=str(tmp_path / "cp"),
+            checkpoint_channel="panoramax",
+            census_cache=cache,
+        )
+    assert load_census_cache_marker(cache.path, run_date=None) is None
+
+
+def test_the_crawl_store_paths_are_channel_keyed_date_free_and_outside_data(tmp_path):
+    """
+    Both halves of #290's key rule, from the one derivation every consumer uses.
+    A cache entry keyed by channel would reuse nothing with nothing failing; a
+    checkpoint NOT keyed by channel would let two crawls resume each other into
+    the wrong ledger. And a date in either path would restart the crawl nightly,
+    since a run is dated on the day it COMPLETES.
+    """
+    from streetscape_metadata_tracker.checkpointing import CENSUS_PROVIDERS
+
+    assert "panoramax" in CENSUS_PROVIDERS
+
+    bbox = dp.grid_bbox(*SEATTLE, 100, 100, 20)
+    grid_cp = checkpoint_path_for(CITY_ID, bbox, "panoramax")
+    walk_cp = checkpoint_path_for(CITY_ID, bbox, "panoramax_streets")
+    entry = census_cache_path_for("panoramax", CITY_ID, bbox)
+
+    assert grid_cp != walk_cp, "two channels must not resume each other's crawl"
+    assert census_cache_path_for("panoramax", CITY_ID, bbox) == entry
+    for path in (grid_cp, walk_cp, entry):
+        assert "2026" not in os.path.basename(path), "a dated path restarts every night"
+        assert f"{os.sep}data{os.sep}" not in path, (
+            "a partial census must never reach the publisher"
+        )

--- a/tests/test_panoramax_grid_run.py
+++ b/tests/test_panoramax_grid_run.py
@@ -1,0 +1,338 @@
+"""
+The Panoramax grid-run wrapper: the join between the fetch and the shared tail.
+
+`tests/test_panoramax.py` covers the decoder and the transport; `tests/test_census.py`
+covers the provider-agnostic seam driven by a deliberately un-Mapillary schema.
+Neither can see what this file is about — that the bindings the tail actually
+reaches are PANORAMAX's. A wrapper that passed another provider's dtypes or
+another provider's `image_columns` would still produce a valid CSV, register a
+run, and publish it, with the wrong schema in the wrong column order under a
+filename claiming otherwise.
+
+Modelled on `tests/test_kartaview_grid_run.py`, which exists for the same reason
+and names the same gap.
+"""
+
+import asyncio
+import gzip
+
+import mapbox_vector_tile
+import pandas as pd
+import pytest
+
+from streetscape_metadata_tracker import analysis
+from streetscape_metadata_tracker import download_panoramax as dp
+from streetscape_metadata_tracker.config import PANORAMAX_METADATA_DTYPES
+from streetscape_metadata_tracker.download_common import DownloadError
+from tests.test_panoramax import encode_tile, make_picture
+
+# Centred on a z15 tile x-boundary so the bbox spans two tiles and a border
+# picture lands in both — the arrangement cross-tile dedup needs.
+SEATTLE = (47.6062, -122.3321)
+
+
+@pytest.fixture
+def straddling_city():
+    from streetscape_metadata_tracker.download_common import (
+        lonlat_to_tile_frac,
+        tile_frac_to_lonlat,
+    )
+
+    lat = SEATTLE[0]
+    fx, fy = lonlat_to_tile_frac(SEATTLE[1], lat, dp.TILE_ZOOM)
+    boundary_lon, _ = tile_frac_to_lonlat(int(fx), fy, dp.TILE_ZOOM)
+    return lat, boundary_lon
+
+
+def _stub_fetch_tile(monkeypatch, fetch, *, empty_tiles=()):
+    """
+    Install ``fetch`` as the tile fetcher, honouring the limiter and the two
+    counters on the stub's behalf.
+
+    Stubbing ``_fetch_tile`` also stubs out its retry decorator, which is what
+    keeps these instant — but #198 moved pacing and counting INSIDE that
+    function deliberately, so a stub ignoring them would leave every city-level
+    test seeing zero requests. ``empty_tiles`` names tiles the stub should treat
+    as a 404, i.e. calling ``on_empty`` as the real fetcher does.
+    """
+
+    async def paced(session, url, timeout, rate_limiter=None, on_request=None, on_empty=None):
+        if rate_limiter is not None:
+            await rate_limiter.acquire()
+        if on_request is not None:
+            on_request()
+        body = await fetch(session, url, timeout)
+        if body == b"" and on_empty is not None and url in empty_tiles:
+            on_empty()
+        return body
+
+    monkeypatch.setattr(dp, "_fetch_tile", paced)
+
+
+def _tile_xy_from_url(url):
+    _, _, tail = url.rpartition("/map/")
+    zoom, x, y = tail.replace(".mvt", "").split("/")
+    assert int(zoom) == dp.TILE_ZOOM, f"a tile was requested at z{zoom}, not z{dp.TILE_ZOOM}"
+    return int(x), int(y)
+
+
+def _run(monkeypatch, tmp_path, tiles_by_xy, center_lat, center_lon, *, empty=(), **kwargs):
+    served = []
+    empty_urls = set()
+
+    async def fake_fetch(session, url, timeout):
+        xy = _tile_xy_from_url(url)
+        served.append(xy)
+        # No credential rides in a Panoramax URL, which is the point.
+        assert "access_token" not in url and "key=" not in url
+        if xy in empty:
+            empty_urls.add(url)
+            return b""
+        return tiles_by_xy.get(xy, mapbox_vector_tile.encode([]))
+
+    _stub_fetch_tile(monkeypatch, fake_fetch, empty_tiles=empty_urls)
+    # The set is filled as URLs are seen, and `paced` reads it after `fetch`
+    # returns, so late binding is fine and deliberate.
+    out_path = str(tmp_path / "test_panoramax_2026-09-06.csv.gz")
+    result = asyncio.run(
+        dp.download_panoramax_metadata_async(
+            "Test City",
+            center_lat,
+            center_lon,
+            kwargs.pop("width", 100),
+            kwargs.pop("height", 100),
+            kwargs.pop("step", 20),
+            out_path,
+            **kwargs,
+        )
+    )
+    return result, served, out_path
+
+
+def _written(path):
+    with gzip.open(path, "rt", encoding="utf-8") as f:
+        return pd.read_csv(f, dtype=str, keep_default_na=False)
+
+
+# ── The bindings the tail actually reaches ─────────────────────────────────
+
+
+def test_the_csv_carries_PANORAMAXS_schema_in_its_own_column_order(
+    monkeypatch, tmp_path, straddling_city
+):
+    """
+    The headline: a wrapper handed another provider's dtypes writes a perfectly
+    valid CSV with the wrong columns, under a filename that says panoramax. The
+    column ORDER is asserted too, because `pd.DataFrame(..., columns=...)`
+    reorders silently and a run file is compared byte-for-byte to its
+    predecessor by `diff.py`.
+    """
+    lat, lon = straddling_city
+    tiles = dp.tiles_for_bbox(*dp.grid_bbox(lat, lon, 100, 100, 20))
+    served_tile = encode_tile([make_picture("p1", lon, lat)], *tiles[0])
+
+    _, _, path = _run(monkeypatch, tmp_path, {tiles[0]: served_tile}, lat, lon)
+    assert list(_written(path).columns) == list(PANORAMAX_METADATA_DTYPES)
+
+
+def test_a_360_picture_a_flat_only_point_and_an_empty_point_are_three_statuses(
+    monkeypatch, tmp_path, straddling_city
+):
+    """
+    #116's stratification, reached through this provider's bindings: a grid
+    point with a pano is OK, one covered ONLY by flat imagery is FLAT_ONLY with
+    a NULL capture date (so flat timestamps never enter a dated statistic), and
+    one with neither is ZERO_RESULTS.
+
+    Panoramax needs this more than Mapillary does, not less: the 360 share is a
+    per-city property running from 99.5% in Des Moines to 0% in Tulsa and Boise,
+    so a collector reporting one coverage number misdescribes half the cities
+    worth collecting.
+    """
+    lat, lon = straddling_city
+    tiles = dp.tiles_for_bbox(*dp.grid_bbox(lat, lon, 100, 100, 20))
+    raw = encode_tile(
+        [
+            make_picture("pano", lon, lat, image_type="equirectangular"),
+            # ~20 m north: the next grid row, covered by flat imagery only.
+            make_picture("flat", lon, lat + 0.00018, image_type="flat"),
+        ],
+        *tiles[0],
+    )
+    result, _, path = _run(monkeypatch, tmp_path, {tiles[0]: raw}, lat, lon)
+    written = _written(path)
+
+    statuses = set(written["status"])
+    assert {"OK", "FLAT_ONLY", "ZERO_RESULTS"} <= statuses
+
+    flat_rows = written[written["status"] == analysis.FLAT_ONLY]
+    assert len(flat_rows) >= 1
+    assert (flat_rows["capture_date"] == "").all(), (
+        "a FLAT_ONLY row carries the picture as a presence marker but must never "
+        "carry its date, or flat timestamps enter every dated statistic"
+    )
+    assert result["num_flat_images"] >= 1
+
+
+def test_the_epoch_sentinel_lands_as_NO_DATE_rather_than_removing_the_picture(
+    monkeypatch, tmp_path, straddling_city
+):
+    """
+    Panoramax's measured sentinel is a 1970 timestamp, and what it must produce
+    is a COVERED point with no date -- `NO_DATE` is in `PRESENT_STATUSES`, so the
+    imagery still counts toward coverage while ageing nothing.
+
+    Dropping the row instead would understate coverage; keeping the date would
+    put 1970 into every capture-date statistic the city has.
+    """
+    lat, lon = straddling_city
+    tiles = dp.tiles_for_bbox(*dp.grid_bbox(lat, lon, 100, 100, 20))
+    raw = encode_tile([make_picture("old", lon, lat, ts="1970-01-01 00:00:00+00")], *tiles[0])
+
+    _, _, path = _run(monkeypatch, tmp_path, {tiles[0]: raw}, lat, lon)
+    written = _written(path)
+    row = written[written["pano_id"] == "old"]
+    assert len(row) == 1
+    assert row.iloc[0]["status"] == "NO_DATE"
+    assert row.iloc[0]["capture_date"] == ""
+    assert "NO_DATE" in analysis.PRESENT_STATUSES
+
+
+def test_an_undownloaded_tile_marks_its_points_REQUEST_FAILED_not_ZERO_RESULTS(
+    monkeypatch, tmp_path, straddling_city
+):
+    """
+    #168's rule, and the `unmeasured_mask` binding is the only place a provider
+    can get it wrong. ZERO_RESULTS is a claim that the provider was asked and
+    said no; a tile that never downloaded supports no such claim, and publishing
+    one into an immutable snapshot is unrecoverable.
+
+    The mask must also be evaluated at THIS provider's zoom: at z14 it would
+    select a four-times-larger square and mark measured points unknown.
+    """
+    lat, lon = straddling_city
+    tiles = dp.tiles_for_bbox(*dp.grid_bbox(lat, lon, 100, 100, 20))
+    assert len(tiles) >= 2, "this fixture is meant to straddle a tile boundary"
+
+    failing = tiles[0]
+
+    async def fake_fetch(session, url, timeout):
+        if _tile_xy_from_url(url) == failing:
+            raise RuntimeError("tile did not download")
+        return mapbox_vector_tile.encode([])
+
+    _stub_fetch_tile(monkeypatch, fake_fetch)
+    out_path = str(tmp_path / "test_panoramax_2026-09-06.csv.gz")
+    # One failed tile of two is 50%, far over the 2% tolerance, so this run must
+    # refuse rather than publish a half-measured city.
+    with pytest.raises(DownloadError, match="refusing to finalize"):
+        asyncio.run(
+            dp.download_panoramax_metadata_async("Test City", lat, lon, 100, 100, 20, out_path)
+        )
+
+    # And the mask itself, at the right zoom: a point inside the failed tile is
+    # selected, one outside it is not.
+    import numpy as np
+
+    from streetscape_metadata_tracker.download_common import tile_frac_to_lonlat
+
+    inside_lon, inside_lat = tile_frac_to_lonlat(failing[0] + 0.5, failing[1] + 0.5, dp.TILE_ZOOM)
+    other = tiles[-1]
+    outside_lon, outside_lat = tile_frac_to_lonlat(other[0] + 0.5, other[1] + 0.5, dp.TILE_ZOOM)
+    mask = dp._points_in_tiles(
+        np.array([inside_lat, outside_lat]), np.array([inside_lon, outside_lon]), [failing]
+    )
+    assert list(mask) == [True, False]
+
+
+def test_a_lattice_that_answers_404_EVERYWHERE_is_refused_rather_than_published(
+    monkeypatch, tmp_path, straddling_city
+):
+    """
+    THE GUARD A 404-IS-EMPTY READING NEEDS. On this host a 404 means "nothing at
+    this tile" and an empty area answers 200 with no layer, so a whole lattice
+    of 404s is not an empty city -- it is what a MOVED OR RENAMED endpoint looks
+    like. Without this the run would finalize 0 panos and `diff.py` would report
+    every pano in the city removed, into an immutable dated snapshot.
+    """
+    lat, lon = straddling_city
+    tiles = dp.tiles_for_bbox(*dp.grid_bbox(lat, lon, 100, 100, 20))
+    with pytest.raises(DownloadError, match="has moved or been renamed"):
+        _run(monkeypatch, tmp_path, {}, lat, lon, empty=set(tiles))
+
+
+def test_one_404_among_answered_tiles_is_a_hole_not_a_moved_endpoint(
+    monkeypatch, tmp_path, straddling_city
+):
+    """
+    The bound on the guard above, and it matters most on a RESUME: a run
+    finishing its last remaining tile asks for exactly one, and refusing the
+    city over that single 404 would leave the crawl unable to finish on any
+    night. Two 404s against a measured baseline of zero in 3,321 requests is a
+    moved endpoint; one is a tile.
+    """
+    lat, lon = straddling_city
+    tiles = dp.tiles_for_bbox(*dp.grid_bbox(lat, lon, 100, 100, 20))
+    result, _, path = _run(monkeypatch, tmp_path, {}, lat, lon, empty={tiles[0]})
+    assert set(_written(path)["status"]) == {"ZERO_RESULTS"}
+    assert result["api_requests"] == len(tiles)
+
+
+def test_an_empty_city_that_answers_200_is_published_as_empty(
+    monkeypatch, tmp_path, straddling_city
+):
+    """
+    The other side of the guard above, and the reason it keys on 404 rather than
+    on emptiness: 730 of 1,144 catalog cities genuinely hold no Panoramax
+    imagery, and every one of them must collect and publish as ZERO_RESULTS.
+    """
+    lat, lon = straddling_city
+    _, _, path = _run(monkeypatch, tmp_path, {}, lat, lon)
+    written = _written(path)
+    assert set(written["status"]) == {"ZERO_RESULTS"}
+
+
+# ── The two counters, and where each one goes ──────────────────────────────
+
+
+def test_the_two_request_counters_are_reported_separately(monkeypatch, tmp_path, straddling_city):
+    """
+    `api_requests` is THIS call's spend, for the additive (date, provider)
+    ledger; `api_requests_total` is the whole crawl's, for the catalog row. On a
+    fresh uninterrupted run they agree, which is exactly why a wrapper that
+    reported one for both would look correct here — so the tile COUNT is
+    asserted too, tying both numbers to the lattice actually walked.
+    """
+    lat, lon = straddling_city
+    tiles = dp.tiles_for_bbox(*dp.grid_bbox(lat, lon, 100, 100, 20))
+    result, served, _ = _run(monkeypatch, tmp_path, {}, lat, lon)
+    assert result["api_requests"] == len(tiles) == len(served)
+    assert result["api_requests_total"] == result["api_requests"]
+
+
+def test_a_failure_after_the_fetch_still_carries_the_spend(monkeypatch, tmp_path, straddling_city):
+    """
+    The census is paid for before the CSV is written, so a crash in the tail
+    must not lose the ledger entry — cli.py records `e.api_requests` from the
+    exception. Without the wrapper's try/except that spend would vanish and the
+    night would under-report what it cost.
+    """
+    lat, lon = straddling_city
+
+    async def fake_fetch(session, url, timeout):
+        return mapbox_vector_tile.encode([])
+
+    _stub_fetch_tile(monkeypatch, fake_fetch)
+
+    def explode(*args, **kwargs):
+        raise OSError("no space left on device")
+
+    monkeypatch.setattr(dp.census_core, "write_census_grid_run", explode)
+    with pytest.raises(OSError) as excinfo:
+        asyncio.run(
+            dp.download_panoramax_metadata_async(
+                "Test City", lat, lon, 100, 100, 20, str(tmp_path / "x_2026-09-06.csv.gz")
+            )
+        )
+    assert excinfo.value.api_requests > 0
+    assert excinfo.value.api_requests_total == excinfo.value.api_requests

--- a/tests/test_panoramax_grid_run.py
+++ b/tests/test_panoramax_grid_run.py
@@ -261,6 +261,54 @@ def test_a_lattice_that_answers_404_EVERYWHERE_is_refused_rather_than_published(
         _run(monkeypatch, tmp_path, {}, lat, lon, empty=set(tiles))
 
 
+def test_a_404_LATTICE_is_still_refused_on_the_NIGHT_AFTER_it_checkpointed(
+    monkeypatch, tmp_path, straddling_city
+):
+    """
+    THE GUARD ABOVE HAS TO SURVIVE THE CHECKPOINT, and the evidence it reads is
+    per-invocation: it asks whether everything REQUESTED answered 404. So a 404
+    must not be committed. If it were, the run that correctly refuses would
+    leave every tile recorded fetched-and-empty, and the NEXT invocation would
+    find `todo` empty, never evaluate the guard, and re-finalize the city from
+    disk as a genuine ZERO_RESULTS snapshot for zero requests -- publishing
+    "every pano in the city removed" through the very path the guard exists to
+    close, and promoting that empty census into the shared #290 cache.
+
+    The sibling test above passes without a checkpoint, which is exactly the
+    blind spot: the CLI always passes one (`crawl_store_for` returns a store for
+    every CENSUS_PROVIDERS member), so the unchecked path is the only one that
+    ever runs in production.
+    """
+    lat, lon = straddling_city
+    tiles = dp.tiles_for_bbox(*dp.grid_bbox(lat, lon, 100, 100, 20))
+    assert len(tiles) >= 2, "the guard is bounded by len(todo) >= 2"
+    checkpoint_path = str(tmp_path / "crawl")
+
+    for night in (1, 2):
+        with pytest.raises(DownloadError, match="has moved or been renamed"):
+            _run(
+                monkeypatch,
+                tmp_path,
+                {},
+                lat,
+                lon,
+                empty=set(tiles),
+                checkpoint_path=checkpoint_path,
+                checkpoint_channel="panoramax",
+            )
+        done = dp._open_tile_checkpoint(
+            checkpoint_path,
+            bbox=dp.grid_bbox(lat, lon, 100, 100, 20),
+            tiles=tiles,
+            channel="panoramax",
+            variant=None,
+        )
+        assert done.done == {}, (
+            f"night {night} committed a 404 tile; the next invocation would find "
+            f"nothing to do and publish the city as empty"
+        )
+
+
 def test_one_404_among_answered_tiles_is_a_hole_not_a_moved_endpoint(
     monkeypatch, tmp_path, straddling_city
 ):

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -2363,7 +2363,7 @@ def test_get_due_cities_has_no_default_membership_default():
     assert param.kind is inspect.Parameter.KEYWORD_ONLY
 
 
-def test_the_two_kartaview_channels_are_the_opt_in_ones_today():
+def test_the_opt_in_channels_today_are_the_two_kartaview_ones_and_panoramax():
     """Pins the actual policy, not just its shape — the four non-KartaView
     channels are cheap enough per city that catalog-wide membership is right for
     them, and flipping one of them to opt-in would silently empty its nightly
@@ -2375,11 +2375,19 @@ def test_the_two_kartaview_channels_are_the_opt_in_ones_today():
     rather than inheriting the grid channel's, so enrolling a city in street
     coverage stays a separate decision from enrolling it in grid coverage and
     schedule_state.member keeps exactly one meaning for NULL (#258).
+
+    panoramax is opt-in on a different argument, and the difference is worth
+    keeping visible: the KartaView pair is opt-in because a whole-catalog pass
+    is unaffordable, while panoramax is opt-in because 730 of 1,144 enabled
+    cities were MEASURED to hold no Panoramax imagery at all and a screened zero
+    is conclusive (issue #316 phase 1). Cost and emptiness are different
+    reasons, and a later provider that is cheap AND widely covered would belong
+    on the other side of this line.
     """
     from streetscape_metadata_tracker.scheduler import CHANNEL_DEFAULT_MEMBERSHIP
 
     opt_in = sorted(c for c, default in CHANNEL_DEFAULT_MEMBERSHIP.items() if not default)
-    assert opt_in == ["kartaview", "kartaview_streets"]
+    assert opt_in == ["kartaview", "kartaview_streets", "panoramax"]
 
 
 def test_the_hoist_is_the_identity_permutation_without_an_opt_in_channel(conn):


### PR DESCRIPTION
Phase 2's first PR: the collector [#316](https://github.com/jonfroehlich/streetscape-tracker/issues/316)'s phase-1 study recommended. Not a scheduler channel yet — that is the next PR.

## Why now

Phase 1 ([#320](https://github.com/jonfroehlich/streetscape-tracker/pull/320)) answered the gate two-sidedly. The gate as [#316](https://github.com/jonfroehlich/streetscape-tracker/issues/316) phrases it **fails** — 730 of 1,144 enabled cities screen to a conclusive zero — but where Panoramax is present it is not marginal: ~20 cities hold 3.16 M pictures between them, 14 of them in the US, and **Des Moines and Ames each hold more 360° pictures than Mapillary's census of the identical frozen bbox**.

Those US deployments are also *new* — Boise's entire corpus is three months old, Lincoln's ten — so unlike GSV there is no archive to backfill. A temporal series exists only if the collector is there when the imagery lands.

## The three things that differ from the Mapillary census it is modelled on

`download_panoramax.py` is shaped on `download_mapillary.py`, not `download_kartaview.py` — same primitive, a lattice of tiles fetched concurrently — so the `(x, y)`-keyed checkpoint, the `tiles_for_bbox` reassembly, the fails-open posture and the [#290](https://github.com/jonfroehlich/streetscape-tracker/issues/290) cache promotion are inherited rather than re-decided. Each of these three is something a reader of that module would otherwise assume away:

- **The census is the z15 `pictures` layer, never `/api/search`.** Search does not paginate, reports no `numberMatched`, and *silently ignores its own `datetime` filter* — measured over 20 cities, the requested windows should have excluded 5,045 pictures and all 5,045 came back. An incremental "everything since the last run" fetch built on it would re-read the whole history and report it as new. z15 is the coarsest zoom that serves the layer at all, so a bbox costs ~4× Mapillary's tiles.
- **A 403/429 is a per-IP refusal and a 404 is an empty tile.** There is no credential, so 403 cannot be a rejected token the way it is on the other two. And an empty area answers 200 with no layer, so a 404 means the tile holds nothing — 0 seen across 3,321 phase-1 requests, *including 20 cities holding nothing at all*. That reading needs its own guard, and it is the one piece with no Mapillary counterpart: **a lattice where every tile 404s is a moved endpoint**, refused rather than published as a city that lost all its imagery.
- **`type` is two-state, so `is_pano` is a non-nullable bool.** The "field of view absent" third state in [#316](https://github.com/jonfroehlich/streetscape-tracker/issues/316) is an EXIF artifact of the search response. The raw value is published as `image_type` anyway, so a third value Panoramax has never served would appear in the data rather than be folded into flat.

## Two defects the tests caught, both silent

- The decoder had copied Mapillary's **fall back to the MVT feature id**. Those are numbered *per tile*, so it would have minted id `0` in every tile of the city into a `dedupe_census` that factorizes on `id`. Properties only now.
- The capture-date floor compared `.dt.date`, which stays `datetime64` on a column that parsed to all-NaT — so a city whose every timestamp was unusable would have raised `InvalidComparison` instead of recording it as undated. Both rules compare timestamps now, and `format="ISO8601"` is pinned for the reason [#226](https://github.com/jonfroehlich/streetscape-tracker/issues/226) and KartaView's mixed-precision pages both record.

## Refactors this needed

**The slippy-map tile math moves down to `download_common.py`** (`lonlat_to_tile_frac`, `tile_frac_to_lonlat`, `tiles_for_bbox`, `points_in_tiles`), exactly as `grid_bbox` and `assign_to_grid` did one refactor earlier: pure geometry that happened to sit in the first provider that wanted it, with the alternative being one provider module importing another's. The shared `tiles_for_bbox` takes zoom as a **required** argument — a helper serving two providers at two zooms has no default to be right about — and each provider re-exposes it with its own, so no call site moved.

`scripts/panoramax_feasibility.py` now **imports** the decoder rather than keeping a copy, the same rule that already kept the pacing formula in one place. Its 114 tests pass unchanged.

**No credential, made first-class rather than special-cased.** `CHANNEL_ENV_VARS["panoramax"]` is an empty tuple, `CREDENTIAL_FREE_CHANNELS` is derived from it, and `load_config` returns `{"access_token": None}` instead of raising — a channel that raised for a key it does not have would take down every *other* provider in the same `--provider all` invocation. The router's credentials table keeps its coverage guarantee, with the row reading "none".

## Access posture

30/min with CV-0.6 jitter — half the Mapillary channels', against the one host here that publishes no limit anywhere found (not the API docs, not the OpenAPI spec, no rate-limit header). `HOST_PANORAMAX` is the fourth locked host, exit codes **84 blocked / 85 busy**.

The forum was **read and not asked**, which `docs/provider-access.md` now records as a decision rather than leaving "the intended first step of phase 2" standing. Two questions still belong in a post; one of them — whether a picture's identity survives an inter-instance migration — remains a **standing caveat on every Panoramax diff** rather than a settled question.

## Not a scheduler channel yet

The token is in `KNOWN_PROVIDERS`, so `streetscape_tracker.py --provider panoramax` collects a city. But `UNWIRED_CHANNELS` still refuses a `[providers.panoramax]` block: `estimate_requests`, `city_timeout_seconds`, the `enabled_providers` rank and the `_run_one_city` pacing flag have no arm for it, and each fails **open** in the way [#238](https://github.com/jonfroehlich/streetscape-tracker/issues/238) records. `CHANNEL_DEFAULT_MEMBERSHIP` is already `False` — on a *measurement* rather than a cost argument, which makes it the clearest case in that table.

## Verified live

One paced run from a laptop against Ames, and it cross-checks phase 1's independent instrument:

| | this collector (z15 per-picture) | phase 1 (z14 grid counters) |
|---|---|---|
| requests | 238, exactly the estimate | — |
| unique panos | 135,389 | 135,501 |
| capture span | 2023-04-23 → 2026-04-26 | 2023-04 → 2026-04 |
| contributors | 3 | 3 |

Both [#116](https://github.com/jonfroehlich/streetscape-tracker/issues/116) coverage numbers populated and different (2.07% / 2.19%), 0 `REQUEST_FAILED`, the census promoted into the shared cache, and the map's picture link resolving 200 `image/jpeg` for a real collected picture.

That link is the **picture, not a 360° viewer**, deliberately: the meta-catalog hosts no viewer and the tile layer carries no instance, so a run row cannot name which of the 23 instances owns a picture. `/api/pictures/{id}/sd.jpg` resolves federation-wide from the id alone (measured: 308 → the owning instance). Guessing an instance is the [#312](https://github.com/jonfroehlich/streetscape-tracker/issues/312) mistake.

## Tests

`2193 passed`. Three new files — decoder/dates/transport, the grid-run join, and resume/cache — plus the five set-equality pins that go red by design when a provider token lands. The headline is **byte identity asserted three ways**: an uninterrupted pass, a run interrupted after one tile and resumed, and a different channel reading the promoted census for zero requests all write the same CSV.

## Review pass (`81c3949`)

A high-effort review of the branch found one correctness defect and four smaller things, all fixed above.

**The moved-endpoint guard only survived one night.** `fetch_one` committed a 404 as a fetched-and-empty tile *before* the all-404 check ran, and that check reads evidence that only exists per invocation — it asks whether everything **requested** answered 404. So the night that correctly refused left a checkpoint recording every tile done-with-0-rows, and the next invocation found `todo` empty, took the COMPLETE branch, and re-finalized the city from disk as a genuine `ZERO_RESULTS` snapshot for zero requests — publishing "every pano in the city removed" through the one path the guard exists to close, then promoting that empty census into the shared [#290](https://github.com/jonfroehlich/streetscape-tracker/issues/290) cache.

Reproduced on the branch (four tiles, all 404): night 1 raises and commits all four; night 2 issues 0 requests and writes 36 `ZERO_RESULTS` rows. `test_a_lattice_that_answers_404_EVERYWHERE_is_refused_rather_than_published` passed only because its harness never passes a `checkpoint_path` and the CLI always does, so the unchecked path was the only one production ever ran. A 404 is no longer committed; the new test drives both nights through a real checkpoint and fails without the fix.

The other four: `estimate_requests` gained a `panoramax` arm (opt-in also means `enroll-city --all` reachable, and it was pricing the z15 lattice with the GSV grid formula, which is the quantity cheapest-first sorts on); CLAUDE.md's exit-code table gained 84/85; `vis.PROVIDER_DISPLAY`'s claim to mirror the frontend registry now states the gap the later frontend PR closes; and the phase-1 writeup's verdict, which priced the census at the z14 screen's median of 12 tiles rather than the z15 census's 35, is corrected against its own cost table and now records the decoder-import provenance.

🤖 Generated with [Claude Code](https://claude.com/claude-code) — Opus 5 (1M context), claude-opus-5[1m]
