### PR TITLE
Land a laptop investigation in prod's catalog: scheduler import-bundle (#330)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,6 +76,7 @@ python scripts/register_frame.py --manifest mapillary_360_cities.csv --overlap-k
 | `screen-provider panoramax` | The weekly whole-catalog growth screen (#316): 113 requests answer all 1,144 cities. Writes UPPER BOUNDS, never counts; `--dry-run` prices it, `--measure --limit N` measures the richest exactly and writes nothing |
 | `regenerate-aggregate [--publish]` | Rebuild `cities.json.gz` from the catalog (no collection), optionally rsync |
 | `reconcile-walks [--dry-run]` | Catalog road walks that finished but were never registered |
+| `import-bundle DIR [--execute] [--enable]` | Land a laptop investigation's artifacts here (#330): a laptop `data/` dir, read-only, DRY-RUN by default; refuses the bundle WHOLE on a geometry, filename, collision, schema or in-flight-batch problem |
 | `fetch-driving-plan [--force]` | Snapshot Google's published driving plan out of band; `--from-file`/`--date` backfills a hand-saved snapshot |
 | `backup-status [--alert]` | Catalog-backup health; nonzero when the newest backup is missing, >48 h old, or the last attempt failed; `--alert` emails when unhealthy (#193 daily timer) |
 | `restore-backup FILE --to PATH` | Restore a dated backup; refuses an existing destination or orphaned `-wal`/`-shm` |
@@ -236,6 +237,8 @@ Deployment lives in `deploy/` (7 systemd units + its README).
 `assess-city` answers a partner inquiry about an untracked city the same day (register + both road walks + the cheap Mapillary grid run + publish).
 **Answer from street coverage, never grid coverage** — grid points land on water, rail, parkland and rooftops, badly understating a deployment (Highland Heights: 55.6% of grid points vs 92.8% of street-km); a rectangle is not a city, and the pre-flight says so before anything is spent.
 Publishing is declared in config (`[publish].local`), never inherited from the environment, so a hand-run publish and the nightly one take the identical path.
+`import-bundle` lands a laptop investigation here instead of re-collecting it (#330), and three things about it are load-bearing: **it is the only place a filename's geometry is checked against the frozen `cities` row** (every `same_grid_geometry` call compares filename to filename), it copies **only files a catalog row names** — a bundle's `data/` holds one-city aggregates that a directory sync would publish over the real index — and it writes `record_attempt` per imported channel, which is what stops the next night re-paying for the crawl.
+Grid stats are RECOMPUTED from the CSV and walk stats are CARRIED and cross-checked, deliberately; spend reaches `api_usage` only for credentials this host shares (`gsv*`, `kartaview*`), never the per-IP ones.
 
 **Catalog backups → [`docs/catalog-backups.md`](docs/catalog-backups.md).**
 The catalog lives in exactly one place, and lab storage being backed up is something to **verify, not assume**.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -51,3 +51,53 @@ So any hand-run publish on makelab2 (`regenerate-aggregate --publish`, and now `
 `[publish].local = true` (set in `scheduler.makelab1.toml`) makes `_publish` pass `--local` explicitly, so the two invocation paths are identical;
 the unit still exports the variable, harmlessly, so a code rollback cannot break nightly publishing.
 `[publish].site_url` is used for nothing but printing operator-facing links.
+
+## Landing a laptop investigation in this catalog: `scheduler import-bundle` (issue #330)
+
+**Added after the 2026-08-22 split.**
+
+An inquiry about an untracked city arrives and the useful window is the next hour, not the next night.
+`assess-city` above answers it, but only from prod — so it competes with the nightly batch for the daily ledgers and, more importantly, for prod's **per-IP** allowance on the three metered hosts, and it can only run outside the batch window.
+Investigating from a laptop avoids all of that and needs no new code: every collector takes `--download-dir`, so a scratch directory becomes a complete, self-describing investigation.
+What `import-bundle` adds is the way back.
+
+```bash
+# 1. Investigate on the laptop — ordinary collector commands, one per provider
+python -m streetscape_street_analyzer.collect "City, Region" --provider kartaview --download-dir /tmp/city/data
+
+# 2. Ship the bundle up. archive/ is gitignored and outside the publish rsync's walk,
+#    so a staged bundle is structurally unpublishable.
+rsync -a /tmp/city/data/ makelab2:~/streetscape-tracker/archive/investigations/city/
+
+# 3. Land it. Dry run is the DEFAULT; it prints exactly the plan --execute carries out.
+scheduler import-bundle archive/investigations/city
+scheduler import-bundle archive/investigations/city --execute --enable
+```
+
+A "bundle" is not a new format — it is exactly the `data/` directory a laptop run already wrote, catalog included, and the importer reads it with a **read-only** connection so it can neither migrate nor mutate the operator's evidence.
+
+**Why the laptop is the right place rather than merely a convenient one.**
+Three of the four providers meter by IP address, not by credential (`docs/provider-access.md`), so moving the work to a laptop isolates it for free and needs no new token.
+GSV is the exception and cuts the other way: Google meters per Cloud **project**, so a laptop walk on `GMAPS_STREETS_API_KEY` draws on exactly the pool prod's own walks draw on — at the collector's default 24,000/min, on top of prod's.
+Pace laptop GSV work explicitly whenever the batch may be running, and note that a run ≥95% `OVER_QUERY_LIMIT` is rejected before cataloging, so the damage would land on prod's in-flight city rather than on the investigation.
+
+**Every refusal happens before anything is written, and rejects the bundle whole.**
+Half an investigation in the catalog is worse than none: `db.add_api_usage` is additive rather than idempotent, so a partial import that the operator retries would double-charge the ledger.
+The collision refusal is what makes a retry safe, and it only makes it safe if the first attempt wrote nothing.
+The refusals are: a bundle on another schema version, a live `-wal` beside its catalog, a geometry that disagrees with this host's frozen grid, a filename this host's generators would not produce, a run or walk that already exists here, an artifact a row names but the bundle lacks, a walk row that disagrees with its own coverage artifact or sample count, and a batch that appears to be in flight.
+
+The geometry check is the load-bearing one, and it did not exist anywhere before this: every `naming.same_grid_geometry` call compares filename to filename, never a filename to the `cities` row.
+A bundle collected on a different rectangle is not a later snapshot of the same series, it is a different series wearing the same `city_id`, and nothing downstream would say so.
+
+**Two asymmetries are deliberate.**
+A grid run's stats are **recomputed** from the copied CSV — one pandas pass through `analysis.calculate_run_stats`, the same call the collector makes — so a stat definition that moved between the two checkouts cannot enter the series as an unattributable step change.
+A road walk's are **carried** from its row and cross-checked against the coverage GeoJSON's own totals and the CSV's row count, because recomputing one means re-running the OSM edge join for a result that can only equal what the artifact beside it already records.
+Second, spend is ledgered only for credentials this host shares — `gsv`, `gsv_streets`, `kartaview`, `kartaview_streets` — under the bundle's own date.
+Charging the per-IP channels here would tighten a budget gate against requests this host never made, on the very channel whose budget is the instrument in an open block investigation.
+
+**The cadence write is the point of the whole exercise.**
+Each imported channel gets `db.record_attempt(success=True)`, the same call `reconcile-walks` makes after a salvage, so the next night does not re-collect what the laptop already paid for.
+A channel with no scheduler arms yet (anything in `UNWIRED_CHANNELS`) is skipped rather than recorded, since a success there would suppress its FIRST real collection once the channel is wired.
+As after `assess-city`, the imported channels are then the *least* stale rows for that city and are **not** due tonight — the closing report says so, because the natural assumption is the opposite.
+
+Three pieces of #330 are deliberately still open: a laptop-side `investigate` driver that runs the collectors and does the rsync itself, a `register-city` subcommand so the laptop asks prod for the frozen grid *before* collecting rather than being checked against it afterward, and a pidfile written by `run-due` to replace the batch check's `ps` heuristic.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -582,3 +582,19 @@ Two more chassis-level pins came with the same work.
 `foldSearchTerms` is asserted to agree with `matchesSearch` on the same queries, because folding the query once per pass instead of once per row is only an optimization if the two spellings cannot diverge.
 And the per-row search haystack cache is asserted to be keyed by the **field list**, not just the row object — a cache ignoring the field list would serve one caller's haystack to a caller asking about different columns, which is a wrong answer rather than a slow one.
 
+
+## Importing a laptop investigation (issue #330)
+
+**Added after the 2026-08-22 split.**
+
+`tests/test_import_bundle.py`. `scheduler import-bundle` writes into the production catalog and the published data directory from a file its operator copied in, so everything standing between those two facts is pinned, and the refusals are pinned **individually** — a bundle refused for the wrong reason is a bundle whose real problem went unlooked-at.
+
+- Each refusal on its own: another schema version, a live `-wal`, a geometry disagreeing with the frozen grid, a filename the generators would not produce, an existing run for the same `(city, provider, date)`, an artifact a row names but the bundle lacks, a walk row disagreeing with its coverage artifact, a truncated walk CSV, a directory with no catalog, and a batch that looks like it is in flight.
+- **A colliding `csv_filename` under a DIFFERENT composite key**, which the `(city_id, provider, run_date)` check does not catch: that column carries its own `UNIQUE`, so an unguarded import raises `IntegrityError` part-way through rather than refusing cleanly, which is precisely the partial write the whole-bundle rule exists to prevent.
+- Dry run writes nothing — asserted on **rows and on the data directory**, not on the catalog file, which `db.connect` legitimately creates in order to ask it anything.
+- **The bundle's one-city `cities.json.gz` is never copied over this host's.** A bundle's `data/` holds laptop-generated aggregates built over a single-city catalog, so a directory sync would replace the published index with them — a site-wide outage produced by a *successful* import. The copy step is file-by-file over the names catalog rows carry, and the test asserts the aggregate is absent from both `_artifact_sources` and the destination.
+- Grid stats are recomputed rather than carried, pinned by **mutating** the bundle's stored value. A test that only checked the imported number equalled the recomputed one would stay green if the importer carried the bundle's row — the two agree whenever both checkouts are in step, which is exactly when the bug is invisible.
+- Spend reaches `api_usage` only for credentials this host shares, where **the absence is the assertion**: a Mapillary tile spend charged here would tighten a per-IP budget gate against requests this host never made.
+- No cadence row for a channel in `UNWIRED_CHANNELS`, driven by relabelling the bundle's grid run to `panoramax` — a success there would suppress that channel's first real collection once it is wired.
+- Re-running a landed import refuses rather than double-charging, which is what makes `add_api_usage`'s additive write safe to retry.
+- An autouse fixture neutralizes the `ps` scan suite-wide, so neither the suite's own command line nor a real nightly batch on the test machine decides whether these pass.

--- a/streetscape_metadata_tracker/bundle_import.py
+++ b/streetscape_metadata_tracker/bundle_import.py
@@ -1,0 +1,723 @@
+"""
+Land a laptop investigation's artifacts in this host's catalog (issue #330).
+
+An inquiry about an untracked city arrives and the useful window for answering
+it is the next hour, not the next night. Investigating from a laptop already
+works — the collectors all take ``--download-dir``, so a scratch ``data/``
+directory holds a complete, self-describing investigation: its own catalog, the
+dated artifacts, and the frozen OSM network they were measured on. What did not
+exist is any way to get that result into production. Registering the city
+instead makes prod re-download everything it *can*, and silently discards what
+it cannot: an opt-in channel nobody enrolled (KartaView) and a provider that is
+not a scheduler channel at all (Panoramax).
+
+So a "bundle" here is not a new format. It is exactly the ``data/`` directory a
+laptop run already produced, and this module reads it the way prod's own
+catalog would be read.
+
+Two rules shape everything below.
+
+**Geometry is frozen, and this host is the authority.** A run's filename encodes
+width/height/step, so two machines freezing two different grids for one
+``city_id`` desynchronises the artifacts *silently* — the immutable-snapshot
+invariant breaks with no error anywhere. Nothing in this codebase checked that
+before: every ``naming.same_grid_geometry`` call compares filename to filename,
+never filename to the ``cities`` row. :func:`check_bundle` does, and refuses.
+
+**A refusal rejects the whole bundle, before anything is written.** Half an
+investigation in the catalog is worse than none: ``db.add_api_usage`` is
+additive rather than idempotent, so a partial import that the operator retries
+double-charges the ledger. The collision check is what makes a retry safe, and
+it only makes it safe if nothing was written the first time.
+
+Validation is all-or-nothing; the write is not, and cannot be — every ``db``
+writer commits for itself, so an outer transaction here would not hold. What
+stands in for atomicity is ORDER. The ledger is written last, after every row
+that a retry's collision check would refuse on, so a crash part-way through
+leaves an import that can be diagnosed and finished by hand but can never
+double-charge: either the ledger write was not reached, or it was reached and
+the rows in front of it will refuse the retry.
+"""
+
+from __future__ import annotations
+
+import gzip
+import json
+import logging
+import os
+import shutil
+import sqlite3
+from dataclasses import dataclass, field
+from datetime import date
+from pathlib import Path
+from typing import Any
+
+from . import analysis, db, fileutils
+from .json_summarizer import regenerate_run_json
+from .naming import (
+    generate_run_filename,
+    generate_streetwalk_filename,
+    streetwalk_coverage_filename,
+)
+
+logger = logging.getLogger(__name__)
+
+# The catalog file inside a bundle, and the subdirectory a bundle's frozen OSM
+# networks live in. The latter mirrors download_street_network._cache_dir, which
+# is the authority; it is restated rather than imported because that module
+# pulls osmnx, and neither the scheduler nor this importer has any business
+# loading it to copy a file. scheduler.py already restates it the same way.
+CATALOG_NAME = "streetscape_tracker.db"
+OSM_CACHE_DIRNAME = "osm_cache"
+
+# The five columns that must agree before a bundle can be imported into a city
+# this host already tracks. Geometry is frozen at registration and shared by
+# every provider precisely so diffs mean something; a bundle collected on a
+# different rectangle is not a later snapshot of the same series, it is a
+# different series wearing the same city_id.
+GEOMETRY_FIELDS = ("center_lat", "center_lon", "grid_width_m", "grid_height_m", "step_m")
+
+# Whose spend belongs in THIS host's api_usage ledger.
+#
+# Three of the four providers meter by IP address rather than by credential
+# (docs/provider-access.md): Mapillary's tile CDN, Overpass, and — for the
+# per-IP half of its limit — kartaview.org. A laptop investigation genuinely
+# spent those against a different IP, so charging them here would tighten a
+# budget gate against requests this host never made. That matters most for
+# Mapillary, whose budget is the instrument in an open block investigation.
+#
+# Google is the exception, and the reason this set is not empty: GSV meters and
+# bills per Cloud *project*, not per key or per IP, so a laptop walk on
+# GMAPS_STREETS_API_KEY drew on exactly the pool prod's own walks draw on. Not
+# recording it would hide real burn while still spending it — worse than doing
+# nothing. KartaView is included for the same reason at a smaller scale: its
+# documented 1,000/h ceiling is per TOKEN, and the laptop used prod's token.
+LEDGERED_PROVIDERS = frozenset({"gsv", "gsv_streets", "kartaview", "kartaview_streets"})
+
+
+class BundleError(ValueError):
+    """A bundle that cannot be read at all — malformed, missing, or wrong schema."""
+
+
+@dataclass(frozen=True)
+class BundleRun:
+    """One ``runs`` row from a bundle, with the artifact names it points at."""
+
+    row: dict[str, Any]
+
+    @property
+    def provider(self) -> str:
+        return self.row["provider"]
+
+    @property
+    def run_date(self) -> date:
+        return date.fromisoformat(self.row["run_date"])
+
+    @property
+    def artifacts(self) -> list[str]:
+        return [n for n in (self.row["csv_filename"], self.row["json_filename"]) if n]
+
+
+@dataclass(frozen=True)
+class BundleWalk:
+    """One ``street_walks`` row from a bundle, with the artifact names it points at."""
+
+    row: dict[str, Any]
+
+    @property
+    def provider(self) -> str:
+        return self.row["provider"]
+
+    @property
+    def run_date(self) -> date:
+        return date.fromisoformat(self.row["run_date"])
+
+    @property
+    def artifacts(self) -> list[str]:
+        return [n for n in (self.row["csv_filename"], self.row["coverage_filename"]) if n]
+
+
+@dataclass
+class Bundle:
+    """A laptop ``data/`` directory, read but not yet validated against this host."""
+
+    root: Path
+    city: dict[str, Any]
+    runs: list[BundleRun] = field(default_factory=list)
+    walks: list[BundleWalk] = field(default_factory=list)
+    networks: list[dict[str, Any]] = field(default_factory=list)
+    api_usage: list[dict[str, Any]] = field(default_factory=list)
+
+    @property
+    def city_id(self) -> str:
+        return self.city["city_id"]
+
+
+def _resolve_root(path: str | os.PathLike[str]) -> Path:
+    """
+    The directory holding the bundle's catalog.
+
+    Accepts either the ``data/`` directory itself or a parent containing one, so
+    an operator can point this at whichever of the two they happen to have
+    rsynced. Anything else is a BundleError rather than an empty import.
+    """
+    p = Path(path)
+    for candidate in (p, p / "data"):
+        if (candidate / CATALOG_NAME).is_file():
+            return candidate
+    raise BundleError(f"No {CATALOG_NAME} found in {p} or {p / 'data'}")
+
+
+def read_bundle(path: str | os.PathLike[str]) -> Bundle:
+    """
+    Read a bundle's catalog without touching it.
+
+    Deliberately NOT ``db.connect``: that runs ``init_schema``, which would
+    migrate the bundle in place — mutating the operator's evidence, and doing it
+    on a copy that may be mid-rsync. A read-only URI connection also makes the
+    schema check below honest, since a connection that can silently upgrade the
+    file cannot report what version it arrived as.
+    """
+    root = _resolve_root(path)
+    db_path = root / CATALOG_NAME
+
+    # A live WAL means the last writes are not in the main file, and a read-only
+    # connection cannot replay one. Reading anyway would import a bundle that is
+    # quietly missing its most recent rows. CLAUDE.md states the sidecar rule for
+    # backups; it is the same rule here.
+    wal = db_path.with_name(db_path.name + "-wal")
+    if wal.exists() and wal.stat().st_size > 0:
+        raise BundleError(
+            f"{wal.name} is non-empty, so {db_path.name} may be missing its most recent "
+            "rows. Close the collector on the machine that wrote it and re-copy the bundle."
+        )
+
+    conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+    try:
+        conn.row_factory = sqlite3.Row
+        version = conn.execute("PRAGMA user_version").fetchone()[0]
+        if version != db.SCHEMA_VERSION:
+            raise BundleError(
+                f"Bundle catalog is schema v{version}, this host is v{db.SCHEMA_VERSION}. "
+                "The stat columns are the contract between the two; re-collect the bundle "
+                "on a checkout matching this host."
+            )
+
+        cities = [dict(r) for r in conn.execute("SELECT * FROM cities ORDER BY city_id")]
+        if len(cities) != 1:
+            raise BundleError(
+                f"Bundle holds {len(cities)} cities; expected exactly 1. "
+                "A bundle is one investigation of one city."
+            )
+        city = cities[0]
+
+        runs = [
+            BundleRun(dict(r))
+            for r in conn.execute(
+                "SELECT * FROM runs WHERE city_id = ? ORDER BY provider, run_date",
+                (city["city_id"],),
+            )
+        ]
+        walks = [
+            BundleWalk(dict(r))
+            for r in conn.execute(
+                "SELECT * FROM street_walks WHERE city_id = ? "
+                "ORDER BY provider, network_type, run_date",
+                (city["city_id"],),
+            )
+        ]
+        networks = [
+            dict(r)
+            for r in conn.execute(
+                "SELECT * FROM street_networks WHERE city_id = ? ORDER BY network_type",
+                (city["city_id"],),
+            )
+        ]
+        usage = [
+            dict(r) for r in conn.execute("SELECT * FROM api_usage ORDER BY usage_date, provider")
+        ]
+    finally:
+        conn.close()
+
+    if not runs and not walks:
+        raise BundleError("Bundle holds no runs and no street walks; nothing to import.")
+
+    return Bundle(root=root, city=city, runs=runs, walks=walks, networks=networks, api_usage=usage)
+
+
+def _expected_run_names(city: dict[str, Any], run: BundleRun) -> tuple[str, str]:
+    """CSV and JSON names this host's generators produce for a bundle's run row."""
+    stem = generate_run_filename(
+        city["city_id"],
+        city["grid_width_m"],
+        city["grid_height_m"],
+        city["step_m"],
+        run.run_date,
+        provider=run.provider,
+    )
+    return stem + ".csv.gz", stem + ".json.gz"
+
+
+def _expected_walk_names(city: dict[str, Any], walk: BundleWalk) -> tuple[str, str]:
+    """CSV and coverage-JSON names this host's generators produce for a bundle's walk row."""
+    stem = generate_streetwalk_filename(
+        city["city_id"],
+        city["grid_width_m"],
+        city["grid_height_m"],
+        city["step_m"],
+        walk.row["spacing_m"],
+        walk.run_date,
+        provider=walk.provider,
+        network_type=walk.row["network_type"],
+    )
+    csv_name = stem + ".csv.gz"
+    return csv_name, streetwalk_coverage_filename(csv_name)
+
+
+def check_bundle(
+    bundle: Bundle, conn: sqlite3.Connection, data_dir: str
+) -> tuple[db.CityRow | None, list[str]]:
+    """
+    Everything that must be true before a single byte is written.
+
+    Returns ``(existing city row or None, problems)``. A non-empty ``problems``
+    list rejects the whole bundle — see the module docstring for why partial
+    imports are not offered.
+    """
+    problems: list[str] = []
+    existing = db.resolve_city(conn, bundle.city_id)
+
+    if existing is not None:
+        # The load-bearing check. A bundle collected on a different rectangle is
+        # a different series, and importing it would put two geometries in one
+        # city's history with nothing anywhere to say so.
+        for f in GEOMETRY_FIELDS:
+            theirs, ours = bundle.city[f], getattr(existing, f)
+            if theirs != ours:
+                problems.append(
+                    f"geometry mismatch on {f}: bundle has {theirs}, this host has {ours}. "
+                    "Grid geometry is frozen; the bundle was not collected on this city's grid."
+                )
+    else:
+        # Registering from the bundle is allowed — that is how a city first
+        # arrives — but only if this checkout derives the same city_id from the
+        # same name parts. A disagreement means the two checkouts' naming rules
+        # differ, and every artifact filename is downstream of that.
+        derived = db.derive_city_id(
+            bundle.city["city_name"], bundle.city["state_name"], bundle.city["country_name"]
+        )
+        if derived != bundle.city_id:
+            problems.append(
+                f"city_id mismatch: the bundle says {bundle.city_id!r} but this checkout "
+                f"derives {derived!r} from the same name parts. The two checkouts disagree "
+                "about naming, which every artifact filename depends on."
+            )
+
+    # Filenames are regenerated, never trusted. A per-(city, provider) artifact
+    # whose provider token is missing silently collides the moment two providers
+    # share a run date, and the second collection then skips as a no-op.
+    for run in bundle.runs:
+        want_csv, want_json = _expected_run_names(bundle.city, run)
+        if run.row["csv_filename"] != want_csv:
+            problems.append(
+                f"run [{run.provider} {run.row['run_date']}] names {run.row['csv_filename']}, "
+                f"but this host's generator produces {want_csv}"
+            )
+        if run.row["json_filename"] and run.row["json_filename"] != want_json:
+            problems.append(
+                f"run [{run.provider} {run.row['run_date']}] names "
+                f"{run.row['json_filename']}, but this host's generator produces {want_json}"
+            )
+    for walk in bundle.walks:
+        want_csv, want_cov = _expected_walk_names(bundle.city, walk)
+        if walk.row["csv_filename"] != want_csv:
+            problems.append(
+                f"walk [{walk.provider}/{walk.row['network_type']} {walk.row['run_date']}] names "
+                f"{walk.row['csv_filename']}, but this host's generator produces {want_csv}"
+            )
+        if walk.row["coverage_filename"] and walk.row["coverage_filename"] != want_cov:
+            problems.append(
+                f"walk [{walk.provider}/{walk.row['network_type']} {walk.row['run_date']}] names "
+                f"{walk.row['coverage_filename']}, but this host's generator produces {want_cov}"
+            )
+
+    # Collisions. BOTH checks are needed: csv_filename carries its own UNIQUE
+    # independent of the composite key, and db.register_street_walk UPSERTS on
+    # the composite key — so an unguarded import would overwrite a walk rather
+    # than refuse. This is also what makes a retry after a refusal safe.
+    already_cataloged: set[str] = set()
+    for run in bundle.runs:
+        if conn.execute(
+            "SELECT 1 FROM runs WHERE city_id = ? AND provider = ? AND run_date = ?",
+            (bundle.city_id, run.provider, run.row["run_date"]),
+        ).fetchone():
+            problems.append(
+                f"this host already has a {run.provider} run for {run.row['run_date']}; "
+                "refusing to overwrite an immutable snapshot"
+            )
+            already_cataloged.update(run.artifacts)
+        elif conn.execute(
+            "SELECT 1 FROM runs WHERE csv_filename = ?", (run.row["csv_filename"],)
+        ).fetchone():
+            problems.append(
+                f"this host already has a run filed under {run.row['csv_filename']} "
+                "(a different city or provider); refusing to collide"
+            )
+    for walk in bundle.walks:
+        if conn.execute(
+            "SELECT 1 FROM street_walks WHERE city_id = ? AND provider = ? "
+            "AND network_type = ? AND run_date = ?",
+            (bundle.city_id, walk.provider, walk.row["network_type"], walk.row["run_date"]),
+        ).fetchone():
+            problems.append(
+                f"this host already has a {walk.provider}/{walk.row['network_type']} walk for "
+                f"{walk.row['run_date']}; refusing to overwrite it"
+            )
+            already_cataloged.update(walk.artifacts)
+        elif conn.execute(
+            "SELECT 1 FROM street_walks WHERE csv_filename = ?", (walk.row["csv_filename"],)
+        ).fetchone():
+            problems.append(
+                f"this host already has a walk filed under {walk.row['csv_filename']}; "
+                "refusing to collide"
+            )
+
+    # Every file a row names has to be here. A catalog row pointing at a missing
+    # artifact is invisible to the aggregate and reads as a lost collection.
+    for name in _artifact_sources(bundle):
+        if not (bundle.root / name).is_file():
+            problems.append(f"row names {name} but it is not in the bundle")
+    for net in bundle.networks:
+        src = bundle.root / OSM_CACHE_DIRNAME / net["graphml_filename"]
+        if not src.is_file():
+            problems.append(
+                f"street_networks names {net['graphml_filename']} but it is not in "
+                f"{OSM_CACHE_DIRNAME}/"
+            )
+        # register_street_network upserts on (city_id, network_type), so an
+        # existing row naming a different file would be replaced without a word.
+        # The graphml IS the network the walk's coverage was measured against.
+        row = conn.execute(
+            "SELECT graphml_filename FROM street_networks WHERE city_id = ? AND network_type = ?",
+            (bundle.city_id, net["network_type"]),
+        ).fetchone()
+        if row is not None and row["graphml_filename"] != net["graphml_filename"]:
+            problems.append(
+                f"this host already has a {net['network_type']} network for this city "
+                f"({row['graphml_filename']}) differing from the bundle's "
+                f"({net['graphml_filename']}); refusing to replace the network a walk was "
+                "measured against"
+            )
+
+    # Destination collisions on disk. Checked separately from the catalog ones
+    # above because they are a different problem — a stray artifact with no row
+    # would otherwise be overwritten silently — but skipped for anything already
+    # reported there, since a cataloged run's files existing is that finding
+    # restated once per file rather than a second finding.
+    for name in _artifact_sources(bundle):
+        if name in already_cataloged:
+            continue
+        if (Path(data_dir) / name).exists():
+            problems.append(f"{name} already exists in {data_dir}; refusing to overwrite")
+
+    problems.extend(verify_walk_artifacts(bundle))
+
+    return existing, problems
+
+
+def _artifact_sources(bundle: Bundle) -> list[str]:
+    """
+    Every published artifact a bundle row names — and deliberately nothing else.
+
+    This is why the copy step below is file-by-file rather than a directory
+    sync. A bundle's ``data/`` also holds ``cities.json.gz``,
+    ``streetwalks.json.gz`` and ``driving_plan.json.gz`` that the laptop
+    generated over a ONE-CITY catalog, plus osmnx's raw HTTP cache. Syncing the
+    directory would overwrite this host's published aggregates with a one-city
+    index — a site-wide outage produced by a successful import.
+    """
+    names: list[str] = []
+    for run in bundle.runs:
+        names.extend(run.artifacts)
+    for walk in bundle.walks:
+        names.extend(walk.artifacts)
+    return names
+
+
+def _copy_atomic(src: Path, dst: Path) -> None:
+    """Copy into place via a temp sibling, so a torn copy can never be read as an artifact."""
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    tmp = dst.with_name(dst.name + ".importtmp")
+    shutil.copyfile(src, tmp)
+    os.replace(tmp, dst)
+
+
+@dataclass
+class ImportResult:
+    """What an import did, for the operator report and for the caller's cadence bookkeeping."""
+
+    city_id: str
+    registered_city: bool
+    files: list[str] = field(default_factory=list)
+    run_providers: list[str] = field(default_factory=list)
+    walk_providers: list[str] = field(default_factory=list)
+    usage: list[tuple[str, str, int]] = field(default_factory=list)
+    stat_corrections: list[str] = field(default_factory=list)
+    networks: list[str] = field(default_factory=list)
+
+
+def apply_bundle(
+    bundle: Bundle,
+    conn: sqlite3.Connection,
+    *,
+    data_dir: str,
+    existing: db.CityRow | None,
+    enable: bool,
+) -> ImportResult:
+    """
+    Write the bundle. Call only on a :func:`check_bundle` that returned no problems.
+
+    Files land before rows, because a row naming a missing artifact is worse
+    than an orphan file: the aggregate skips it, so the run reads as lost rather
+    than as needing a re-copy.
+    """
+    result = ImportResult(city_id=bundle.city_id, registered_city=existing is None)
+
+    if existing is None:
+        city_id = db.register_city(
+            conn,
+            city_name=bundle.city["city_name"],
+            state_name=bundle.city["state_name"],
+            state_code=bundle.city["state_code"],
+            country_name=bundle.city["country_name"],
+            country_code=bundle.city["country_code"],
+            center_lat=bundle.city["center_lat"],
+            center_lon=bundle.city["center_lon"],
+            grid_width_m=bundle.city["grid_width_m"],
+            grid_height_m=bundle.city["grid_height_m"],
+            step_m=bundle.city["step_m"],
+            notes=bundle.city["notes"],
+            # Off unless asked. A city arriving through an investigation has a
+            # boundary nobody has vetted, and a fresh city sorts to the head of
+            # the next night's stalest-first queue — so registering it enabled
+            # commits the whole grid to collection the same night it is first
+            # looked at. scripts/register_frame.py takes the same position.
+            enabled=enable,
+        )
+        assert city_id == bundle.city_id  # check_bundle proved this
+    elif enable and not existing.enabled:
+        db.set_city_enabled(conn, bundle.city_id, True)
+
+    for name in _artifact_sources(bundle):
+        _copy_atomic(bundle.root / name, Path(data_dir) / name)
+        result.files.append(name)
+    for net in bundle.networks:
+        name = net["graphml_filename"]
+        _copy_atomic(
+            bundle.root / OSM_CACHE_DIRNAME / name,
+            Path(data_dir) / OSM_CACHE_DIRNAME / name,
+        )
+        result.files.append(f"{OSM_CACHE_DIRNAME}/{name}")
+
+    for net in bundle.networks:
+        db.register_street_network(
+            conn,
+            city_id=bundle.city_id,
+            graphml_filename=net["graphml_filename"],
+            network_type=net["network_type"],
+            node_count=net["node_count"],
+            edge_count=net["edge_count"],
+            osmnx_version=net["osmnx_version"],
+        )
+        result.networks.append(net["network_type"])
+
+    for run in bundle.runs:
+        _register_run(bundle, run, conn, data_dir, result)
+    for walk in bundle.walks:
+        _register_walk(walk, conn, result)
+
+    # LAST, deliberately — see the module docstring. Every row a retry would
+    # collide on is already committed by this point, so a crash here cannot be
+    # followed by a successful re-import that charges the ledger twice.
+    for row in bundle.api_usage:
+        provider, requests = row["provider"], row["requests"]
+        if provider not in LEDGERED_PROVIDERS or not requests:
+            continue
+        # The bundle's own usage_date, not today's: api_usage is a per-day
+        # record of what a credential spent, and the spend happened then.
+        db.add_api_usage(conn, date.fromisoformat(row["usage_date"]), requests, provider=provider)
+        result.usage.append((row["usage_date"], provider, requests))
+
+    conn.commit()
+    return result
+
+
+def _register_run(
+    bundle: Bundle,
+    run: BundleRun,
+    conn: sqlite3.Connection,
+    data_dir: str,
+    result: ImportResult,
+) -> None:
+    """
+    Catalog one grid run, with its stats RECOMPUTED from the copied CSV.
+
+    Recomputing rather than carrying the numbers is what makes the imported row
+    indistinguishable from one this host collected: the CSV is the artifact, and
+    a stat definition that moved between the two checkouts would otherwise enter
+    the series as a step change with nothing to attribute it to. It is one
+    pandas pass, and it is the same call the collector makes.
+
+    ``num_flat_images`` is the one exception — it is not recoverable from a CSV
+    (see scripts/recompute_run_stats.py) — as are the provenance columns, which
+    describe the collection rather than the data.
+    """
+    csv_path = os.path.join(data_dir, run.row["csv_filename"])
+    df = fileutils.load_city_csv_file(csv_path)
+    stats = analysis.calculate_run_stats(df, run.run_date, provider=run.provider)
+
+    for key, value in stats.items():
+        was = run.row.get(key)
+        if was != value and not _equalish(was, value):
+            result.stat_corrections.append(
+                f"{run.provider} {run.row['run_date']}: {key} {was!r} -> {value!r}"
+            )
+
+    run_id = db.register_run(
+        conn,
+        city_id=bundle.city_id,
+        run_date=run.run_date,
+        csv_filename=run.row["csv_filename"],
+        provider=run.provider,
+        json_filename=run.row["json_filename"],
+        is_baseline=bool(run.row["is_baseline"]),
+        started_at=run.row["started_at"],
+        finished_at=run.row["finished_at"],
+        duration_seconds=run.row["duration_seconds"],
+        num_flat_images=run.row["num_flat_images"],
+        api_requests=run.row["api_requests"],
+        census_fetched_by=run.row["census_fetched_by"],
+        census_fetched_at=run.row["census_fetched_at"],
+        **stats,
+    )
+    result.run_providers.append(run.provider)
+
+    # Regenerated here rather than copied. The bundle's JSON carries a
+    # change_from_previous_run block computed against a catalog holding only
+    # this one run — i.e. "no previous run" — while THIS host may well have a
+    # series to diff against. Only the destination can write that block
+    # correctly, so the copied file is replaced immediately.
+    try:
+        regenerate_run_json(conn, run_id, data_dir)
+    except Exception:
+        logger.exception(
+            f"{bundle.city_id} [{run.provider}]: per-run JSON could not be regenerated; "
+            "the run is cataloged and the bundle's own JSON is in place"
+        )
+
+
+def _register_walk(walk: BundleWalk, conn: sqlite3.Connection, result: ImportResult) -> None:
+    """
+    Catalog one road walk, carrying the bundle's own coverage numbers.
+
+    A deliberate asymmetry with :func:`_register_run`, and worth stating because
+    it looks like an oversight. A grid run's stats are a pandas pass over the
+    CSV that was just copied. A walk's are the output of an OSM edge join —
+    re-running it means re-reading the frozen network and redoing the spatial
+    match, for a result that can only equal what the coverage GeoJSON beside it
+    already records. That GeoJSON *is* the artifact: ``_reconcile_orphaned_walk``
+    rebuilds a lost catalog row from it for exactly this reason.
+
+    So the row is carried, and integrity is checked instead — the coverage
+    artifact's own totals must agree with the row, which catches the failure a
+    recompute would have caught (a row and an artifact that are not about the
+    same walk) at a fraction of the cost.
+    """
+    db.register_street_walk(
+        conn,
+        city_id=walk.row["city_id"],
+        run_date=walk.run_date,
+        csv_filename=walk.row["csv_filename"],
+        provider=walk.provider,
+        coverage_filename=walk.row["coverage_filename"],
+        network_type=walk.row["network_type"],
+        spacing_m=walk.row["spacing_m"],
+        match_dist_m=walk.row["match_dist_m"],
+        sample_points=walk.row["sample_points"],
+        edges_total=walk.row["edges_total"],
+        edges_fully_covered=walk.row["edges_fully_covered"],
+        mean_edge_coverage=walk.row["mean_edge_coverage"],
+        coverage_pct_by_length=walk.row["coverage_pct_by_length"],
+        coverage_pct_by_length_any=walk.row["coverage_pct_by_length_any"],
+        coverage_by_highway=walk.row["coverage_by_highway"],
+        length_km=walk.row["length_km"],
+        length_km_covered=walk.row["length_km_covered"],
+        length_km_covered_any=walk.row["length_km_covered_any"],
+        median_covered_age_years=walk.row["median_covered_age_years"],
+        api_requests=walk.row["api_requests"],
+        census_fetched_by=walk.row["census_fetched_by"],
+        census_fetched_at=walk.row["census_fetched_at"],
+        started_at=walk.row["started_at"],
+        finished_at=walk.row["finished_at"],
+    )
+    result.walk_providers.append(walk.provider)
+
+
+def verify_walk_artifacts(bundle: Bundle) -> list[str]:
+    """
+    Cross-check each walk row against the coverage artifact it names.
+
+    Cheap stand-in for recomputing a walk (see :func:`_register_walk`): if the
+    row and the artifact disagree about how many edges the walk covered, they
+    are not describing the same walk and neither number can be trusted.
+    Returned as problems so they refuse the bundle alongside everything else.
+    """
+    problems: list[str] = []
+    for walk in bundle.walks:
+        # The CSV holds exactly one row per sample point, so its row count
+        # recovers `sample_points`. This is the check that catches a truncated
+        # copy: an rsync cut short leaves a readable gzip whose row count is
+        # simply wrong, and nothing else here would notice.
+        csv_path = bundle.root / walk.row["csv_filename"]
+        if csv_path.is_file() and walk.row["sample_points"] is not None:
+            counted = fileutils.count_streetwalk_samples(csv_path)
+            if counted is not None and counted != walk.row["sample_points"]:
+                problems.append(
+                    f"{walk.row['csv_filename']} holds {counted:,} sample rows but its "
+                    f"catalog row says {walk.row['sample_points']:,}; the snapshot is "
+                    "truncated or is not the walk the row describes"
+                )
+
+        name = walk.row["coverage_filename"]
+        if not name:
+            continue
+        path = bundle.root / name
+        if not path.is_file():
+            continue  # already reported by check_bundle
+        try:
+            with gzip.open(path, "rt", encoding="utf-8") as fh:
+                totals = json.load(fh)["properties"]["metadata"]["totals"]
+        except (OSError, EOFError, ValueError, KeyError, TypeError) as e:
+            problems.append(f"{name} could not be read as a coverage artifact ({e})")
+            continue
+        # (key in the artifact's totals block, column in the catalog row).
+        # The two names differ for the edge count: the artifact calls it
+        # `edges`, the catalog `edges_total`.
+        for totals_key, column in (("edges", "edges_total"), ("coverage_pct_by_length",) * 2):
+            theirs, ours = totals.get(totals_key), walk.row[column]
+            if not _equalish(theirs, ours):
+                problems.append(
+                    f"{name} reports {totals_key}={theirs!r} but its catalog row says "
+                    f"{column}={ours!r}; the row and the artifact are not describing "
+                    "the same walk"
+                )
+    return problems
+
+
+def _equalish(a: Any, b: Any) -> bool:
+    """Tolerant compare, so a float round-trip through SQLite is not a 'correction'."""
+    if a is None or b is None:
+        return a is b or a == b
+    if isinstance(a, (int, float)) and isinstance(b, (int, float)):
+        return abs(float(a) - float(b)) <= 1e-6 * max(1.0, abs(float(a)), abs(float(b)))
+    return a == b

--- a/streetscape_metadata_tracker/db.py
+++ b/streetscape_metadata_tracker/db.py
@@ -1047,6 +1047,29 @@ def register_city(
     return city_id
 
 
+def set_city_enabled(conn: sqlite3.Connection, city_id: str, enabled: bool) -> None:
+    """
+    Turn a registered city's scheduler rotation on or off.
+
+    Separate from ``register_city``'s ``enabled`` argument, which only ever
+    applies at registration (the INSERT is ``OR IGNORE``, so a second call with
+    a different ``enabled`` is silently a no-op). A city registered out of
+    rotation — a sampling-frame city awaiting boundary vetting (issue #110), or
+    one arriving through a laptop investigation (issue #330) — otherwise has no
+    way back in short of hand-editing the catalog.
+
+    Note this is ``cities.enabled``, the city-wide gate, NOT
+    ``schedule_state.member``, the per-channel one. ``get_due_cities`` reads
+    both, and only the second is what ``enroll-city`` writes.
+
+    Raises KeyError if the city is unknown, so a typo cannot be a silent no-op.
+    """
+    cur = conn.execute("UPDATE cities SET enabled = ? WHERE city_id = ?", (int(enabled), city_id))
+    if cur.rowcount == 0:
+        raise KeyError(city_id)
+    conn.commit()
+
+
 def update_city_geometry(
     conn: sqlite3.Connection,
     *,

--- a/streetscape_metadata_tracker/fileutils.py
+++ b/streetscape_metadata_tracker/fileutils.py
@@ -1,4 +1,5 @@
 import glob
+import gzip
 import logging
 import os
 import platform
@@ -230,3 +231,28 @@ def open_in_browser(file_path: str) -> tuple[bool, str | None]:
 
     except Exception as e:
         return False, f"Error opening browser: {str(e)}"
+
+
+def count_streetwalk_samples(csv_path: Path) -> int | None:
+    """
+    Number of sampled locations in a road-walk snapshot: its data rows.
+
+    The walk writes exactly one row per on-street sample point, so the row count
+    recovers ``sample_points`` — which the artifact itself does not carry and
+    which ``estimate_street_samples`` prefers over every other precedence step
+    when budgeting a later walk of the same city. Counted line-by-line rather
+    than via pandas: the caller may be reconciling a multi-hundred-MB snapshot
+    inside the scheduler's memory-capped cgroup, and only the count is wanted.
+
+    Returns None if the snapshot is missing or unreadable.
+
+    Shared by the orphan-walk salvage and the bundle importer (issue #330):
+    both reconstruct a walk's row from artifacts on disk, and a second copy
+    of this would let the two disagree about what a sample is.
+    """
+    try:
+        with gzip.open(csv_path, "rt", encoding="utf-8") as fh:
+            return max(sum(1 for _ in fh) - 1, 0)  # minus the header
+    except (OSError, EOFError, UnicodeDecodeError) as e:
+        logger.warning(f"Could not count samples in {csv_path.name}: {e}")
+        return None

--- a/streetscape_metadata_tracker/scheduler.py
+++ b/streetscape_metadata_tracker/scheduler.py
@@ -14,6 +14,7 @@ Usage (--config accepted on either side of the subcommand):
     python -m streetscape_metadata_tracker.scheduler [--config PATH] run-due [--dry-run] [--limit N] [--provider CHANNEL]
     python -m streetscape_metadata_tracker.scheduler [--config PATH] regenerate-aggregate [--publish]
     python -m streetscape_metadata_tracker.scheduler [--config PATH] reconcile-walks [--date D] [--dry-run]
+    python -m streetscape_metadata_tracker.scheduler [--config PATH] import-bundle DIR [--execute] [--enable]
     python -m streetscape_metadata_tracker.scheduler [--config PATH] fetch-driving-plan [--force] [--from-file P --date D]
     python -m streetscape_metadata_tracker.scheduler [--config PATH] backup-status
     python -m streetscape_metadata_tracker.scheduler [--config PATH] restore-backup PATH [--to DEST]
@@ -47,7 +48,7 @@ from typing import Any, NamedTuple
 
 from tabulate import tabulate
 
-from . import catalog_backup, cgroup_memory, db, driving_plan, panoramax_screen
+from . import bundle_import, catalog_backup, cgroup_memory, db, driving_plan, panoramax_screen
 from .alerting import AlertConfig, send_alert, should_alert
 from .checkpointing import (
     CENSUS_PROVIDERS,
@@ -92,6 +93,7 @@ from .download_mapillary import (
     estimate_tile_count,
 )
 from .download_panoramax import estimate_tile_count as estimate_panoramax_tile_count
+from .fileutils import count_streetwalk_samples
 from .json_summarizer import (
     generate_aggregate_v2,
     generate_driving_plan_summary,
@@ -3695,6 +3697,197 @@ def cmd_reconcile_walks(
 
 
 # ---------------------------------------------------------------------------
+# import-bundle: land a laptop investigation in this catalog (issue #330)
+# ---------------------------------------------------------------------------
+
+
+def _run_due_in_flight() -> str | None:
+    """
+    The command line of a ``run-due`` already running here, or None.
+
+    An import must not land mid-batch for the same reason a deploy must not: the
+    scheduler and every per-city child read the catalog and the data directory
+    this writes into, and a city registered halfway through a night can be
+    picked up by a later channel query in the same run.
+
+    This is a heuristic and the caller says so. It reads `ps` rather than a lock
+    the batch holds, because there is no such lock yet — a pidfile written by
+    ``run-due`` itself is the robust version and is deliberately left to a
+    follow-up. Two failure modes are handled: `ps` being unavailable returns None
+    (advisory checks must never fail the work they speak for), and this process
+    and its parent are excluded, since a `pgrep`-shaped check run over SSH has
+    matched its own command line here before.
+    """
+    try:
+        out = subprocess.run(
+            ["ps", "-eo", "pid=,args="], capture_output=True, text=True, timeout=20
+        ).stdout
+    except (OSError, subprocess.SubprocessError):
+        return None
+    mine = {os.getpid(), os.getppid()}
+    for line in out.splitlines():
+        pid_str, _, args = line.strip().partition(" ")
+        try:
+            pid = int(pid_str)
+        except ValueError:
+            continue
+        if pid in mine:
+            continue
+        if "streetscape_metadata_tracker.scheduler" in args and "run-due" in args:
+            return f"pid {pid}: {args.strip()}"
+    return None
+
+
+def _import_cadence_channel(provider: str, *, walk: bool) -> str | None:
+    """
+    The scheduler channel an imported artifact belongs to, or None if there isn't one.
+
+    Writing this is what stops the next night re-collecting what the laptop
+    already paid for — the same ``record_attempt`` call ``reconcile-walks``
+    makes after a salvage, and for the same reason.
+
+    None has two causes, both meaning "do not write a cadence row". A provider
+    with no street channel yet (Panoramax walks, issue #331) has nothing to
+    record against. A channel in ``UNWIRED_CHANNELS`` has a name but no
+    scheduler arms, so a success there would suppress its FIRST real collection
+    once the channel is wired — the opposite of what the row is for.
+    """
+    if walk:
+        channel = next((c for c, p in STREET_CHANNELS.items() if p == provider), None)
+    else:
+        channel = provider if provider in CHANNEL_DEFAULT_MEMBERSHIP else None
+    if channel is None or channel in UNWIRED_CHANNELS:
+        return None
+    return channel
+
+
+def cmd_import_bundle(
+    cfg: SchedulerConfig,
+    bundle_path: str,
+    *,
+    execute: bool = False,
+    enable: bool = False,
+    force: bool = False,
+) -> int:
+    """
+    Land a laptop investigation's artifacts in this host's catalog (issue #330).
+
+    Dry run by default: it prints exactly the plan ``--execute`` would carry
+    out. That default is not politeness — this writes into the production
+    catalog and the published data directory, and `bundle_import` refuses a
+    bundle whole rather than partially, so the printed plan is the whole
+    decision.
+
+    Returns 0 on a clean import (or a clean dry run), ``USAGE_EXIT_CODE`` for
+    any refusal, and 1 when the import landed but its published tail did not.
+    """
+    if not force:
+        busy = _run_due_in_flight()
+        if busy is not None:
+            print(f"REFUSED: a nightly batch appears to be running ({busy}).")
+            print(
+                "  Importing mid-batch writes into the catalog and data directory the "
+                "batch is reading. Wait for it to finish, or pass --force if you are "
+                "certain that line is not a collection run."
+            )
+            return USAGE_EXIT_CODE
+
+    try:
+        bundle = bundle_import.read_bundle(bundle_path)
+    except bundle_import.BundleError as e:
+        print(f"REFUSED: {e}")
+        return USAGE_EXIT_CODE
+
+    conn = db.connect(cfg.db_path)
+    existing, problems = bundle_import.check_bundle(bundle, conn, cfg.data_dir)
+    if problems:
+        print(f"REFUSED: {bundle.city_id} ({len(problems)} problem(s)); nothing was written.")
+        for p in problems:
+            print(f"  - {p}")
+        return USAGE_EXIT_CODE
+
+    mode = "IMPORT" if execute else "DRY RUN"
+    print(f"{mode}: {bundle.city_id} from {bundle.root}")
+    print(
+        f"  city: {'already registered' if existing else 'NEW — would be registered'}"
+        f"{'' if existing else ' ' + ('enabled' if enable else 'DISABLED (pass --enable to collect it)')}"
+    )
+    print(
+        f"  grid: {bundle.city['grid_width_m']}x{bundle.city['grid_height_m']} m, "
+        f"step {bundle.city['step_m']} m, centered "
+        f"{bundle.city['center_lat']:.4f},{bundle.city['center_lon']:.4f}"
+    )
+    for run in bundle.runs:
+        print(
+            f"  run   [{run.provider}] {run.row['run_date']}: "
+            f"{run.row['csv_filename']} (stats recomputed on import)"
+        )
+    for walk in bundle.walks:
+        print(
+            f"  walk  [{walk.provider}/{walk.row['network_type']}] {walk.row['run_date']}: "
+            f"{walk.row['coverage_pct_by_length']}% of "
+            f"{walk.row['length_km']} street-km"
+        )
+    for net in bundle.networks:
+        print(f"  network [{net['network_type']}]: {net['graphml_filename']}")
+    for row in bundle.api_usage:
+        charged = row["provider"] in bundle_import.LEDGERED_PROVIDERS
+        why = "charged here (shared credential)" if charged else "not charged (metered per IP)"
+        print(f"  spend [{row['provider']}] {row['usage_date']}: {row['requests']:,} — {why}")
+
+    if not execute:
+        print("Nothing written. Re-run with --execute to apply.")
+        return 0
+
+    result = bundle_import.apply_bundle(
+        bundle, conn, data_dir=cfg.data_dir, existing=existing, enable=enable
+    )
+    for correction in result.stat_corrections:
+        logger.warning(f"recomputed stat differs from the bundle's: {correction}")
+
+    # The piece that stops the next night re-collecting what was just imported.
+    recorded, skipped = [], []
+    for provider in result.run_providers:
+        channel = _import_cadence_channel(provider, walk=False)
+        (recorded if channel else skipped).append(channel or provider)
+        if channel:
+            db.record_attempt(conn, result.city_id, success=True, provider=channel)
+    for provider in result.walk_providers:
+        channel = _import_cadence_channel(provider, walk=True)
+        (recorded if channel else skipped).append(channel or f"{provider} walk")
+        if channel:
+            db.record_attempt(conn, result.city_id, success=True, provider=channel)
+    db.assign_schedule(conn, cycle_days=cfg.cycle_days, providers=tuple(cfg.enabled_providers()))
+
+    summary, complete = _regenerate_published_json(conn, cfg)
+    print(summary)
+    published = False
+    if cfg.publish_enabled:
+        if _publish(cfg, f"import-bundle {result.city_id} (manual)") == 0:
+            published = True
+        else:
+            logger.error(f"{result.city_id}: imported and cataloged, but the publish failed")
+    else:
+        print("NOTE: publishing is off in config, so nothing was rsynced to the site.")
+
+    print(
+        f"Imported {result.city_id}: {len(result.run_providers)} run(s), "
+        f"{len(result.walk_providers)} walk(s), {len(result.files)} file(s)"
+        f"{'; published' if published else ''}"
+    )
+    if recorded:
+        # Same caution assess-city prints, for the same reason: the natural
+        # thing to assume here is the opposite of true.
+        print(
+            f"  Cadence recorded for {', '.join(sorted(recorded))} — those channels are now "
+            "the LEAST stale rows for this city and are not due tonight."
+        )
+    if skipped:
+        print(f"  No cadence row for {', '.join(sorted(skipped))} (no scheduler channel yet).")
+    return 0 if complete and (published or not cfg.publish_enabled) else 1
+
+
+# ---------------------------------------------------------------------------
 # assess-city: same-day answer for a new city (issue #215)
 # ---------------------------------------------------------------------------
 
@@ -4668,27 +4861,6 @@ def _reconcile_orphaned_run(
     return True
 
 
-def _count_streetwalk_samples(csv_path: Path) -> int | None:
-    """
-    Number of sampled locations in a road-walk snapshot: its data rows.
-
-    The walk writes exactly one row per on-street sample point, so the row count
-    recovers ``sample_points`` — which the artifact itself does not carry and
-    which ``estimate_street_samples`` prefers over every other precedence step
-    when budgeting a later walk of the same city. Counted line-by-line rather
-    than via pandas: the caller may be reconciling a multi-hundred-MB snapshot
-    inside the scheduler's memory-capped cgroup, and only the count is wanted.
-
-    Returns None if the snapshot is missing or unreadable.
-    """
-    try:
-        with gzip.open(csv_path, "rt", encoding="utf-8") as fh:
-            return max(sum(1 for _ in fh) - 1, 0)  # minus the header
-    except (OSError, EOFError, UnicodeDecodeError) as e:
-        logger.warning(f"Could not count samples in {csv_path.name}: {e}")
-        return None
-
-
 def _reconcile_orphaned_walk(
     conn,
     cfg: SchedulerConfig,
@@ -4755,7 +4927,7 @@ def _reconcile_orphaned_walk(
         )
         return False
 
-    sample_points = _count_streetwalk_samples(Path(cfg.data_dir) / csv_name)
+    sample_points = count_streetwalk_samples(Path(cfg.data_dir) / csv_name)
     # .get()-guarded like the other stats: an artifact written before issue
     # #101 carries no such key, and its absence must never fail the salvage.
     breakdown = meta.get("coverage_by_highway")
@@ -7108,6 +7280,35 @@ def build_parser() -> argparse.ArgumentParser:
     p_rec.add_argument(
         "--dry-run", action="store_true", help="List what would be reconciled; no catalog writes"
     )
+    p_imp = sub.add_parser(
+        "import-bundle",
+        help="Land a laptop investigation's artifacts in this catalog (issue #330)",
+    )
+    _add_global_flags(p_imp)
+    p_imp.add_argument(
+        "bundle",
+        help="The laptop data/ directory to import (or a parent containing one)",
+    )
+    # Dry run is the DEFAULT here, unlike reconcile-walks' opt-in --dry-run:
+    # this writes into the production catalog and the published data directory,
+    # and a bundle is refused whole rather than partially, so the printed plan
+    # is the entire decision. Same convention as `enroll-city --all`.
+    p_imp.add_argument(
+        "--execute", action="store_true", help="Actually write. Without it, only report."
+    )
+    p_imp.add_argument(
+        "--enable",
+        action="store_true",
+        help="Put the city into the scheduler rotation. A city arriving through an "
+        "investigation is registered DISABLED without this, because its boundary "
+        "has not been vetted and a fresh city sorts to the head of the next night.",
+    )
+    p_imp.add_argument(
+        "--force",
+        action="store_true",
+        help="Import even though a run-due appears to be in flight (the check is a "
+        "heuristic over `ps`)",
+    )
     p_plan = sub.add_parser(
         "fetch-driving-plan",
         help="Snapshot Google's published Street View driving-plan feed",
@@ -7310,6 +7511,10 @@ def main() -> int:
     if args.command == "reconcile-walks":
         target = date.fromisoformat(args.date) if args.date else None
         return cmd_reconcile_walks(cfg, target_date=target, dry_run=args.dry_run)
+    if args.command == "import-bundle":
+        return cmd_import_bundle(
+            cfg, args.bundle, execute=args.execute, enable=args.enable, force=args.force
+        )
     if args.command == "fetch-driving-plan":
         target = date.fromisoformat(args.date) if args.date else None
         return cmd_fetch_driving_plan(

--- a/tests/test_import_bundle.py
+++ b/tests/test_import_bundle.py
@@ -1,0 +1,465 @@
+"""
+`scheduler import-bundle` — landing a laptop investigation in this catalog (issue #330).
+
+What these pin, and why each one exists, is in docs/testing.md. The short version:
+the importer writes into the production catalog and the published data directory
+from a file its operator copied in, so every check that stands between those two
+facts gets a test, and the refusals are pinned INDIVIDUALLY — a bundle that is
+refused for the wrong reason is a bundle whose real problem went unlooked-at.
+"""
+
+import gzip
+import json
+import os
+import sqlite3
+from datetime import date
+
+import pytest
+
+from streetscape_metadata_tracker import analysis, bundle_import, db, fileutils
+from streetscape_metadata_tracker.naming import (
+    generate_run_filename,
+    generate_streetwalk_filename,
+    streetwalk_coverage_filename,
+)
+from streetscape_metadata_tracker.scheduler import (
+    ProviderConfig,
+    SchedulerConfig,
+    cmd_import_bundle,
+)
+from tests.conftest import make_mapillary_city_df, write_city_csv_gz
+
+RUN_DATE = date(2026, 9, 10)
+CITY = dict(
+    city_name="San Luis Obispo",
+    state_name="California",
+    state_code="CA",
+    country_name="United States",
+    country_code="us",
+    center_lat=35.2766,
+    center_lon=-120.6704,
+    grid_width_m=10400,
+    grid_height_m=10400,
+    step_m=20,
+)
+CITY_ID = "san-luis-obispo--california--united-states"
+SAMPLE_POINTS = 12
+
+
+def _walk_names(provider="gsv", network_type="drive", spacing_m=15):
+    stem = generate_streetwalk_filename(
+        CITY_ID,
+        CITY["grid_width_m"],
+        CITY["grid_height_m"],
+        CITY["step_m"],
+        spacing_m,
+        RUN_DATE,
+        provider=provider,
+        network_type=network_type,
+    )
+    csv_name = stem + ".csv.gz"
+    return csv_name, streetwalk_coverage_filename(csv_name)
+
+
+def _run_names(provider="mapillary"):
+    stem = generate_run_filename(
+        CITY_ID,
+        CITY["grid_width_m"],
+        CITY["grid_height_m"],
+        CITY["step_m"],
+        RUN_DATE,
+        provider=provider,
+    )
+    return stem + ".csv.gz", stem + ".json.gz"
+
+
+def _write_walk_artifacts(root, csv_name, coverage_name, *, sample_points=SAMPLE_POINTS):
+    """A walk CSV with one row per sample point, and the coverage GeoJSON beside it."""
+    with gzip.open(os.path.join(root, csv_name), "wt", encoding="utf-8") as fh:
+        fh.write("query_lat,query_lon,status\n")
+        for i in range(sample_points):
+            fh.write(f"35.{i:04d},-120.6,OK\n")
+    geojson = {
+        "type": "FeatureCollection",
+        "features": [],
+        "properties": {
+            "metadata": {
+                "schema_version": 1,
+                "kind": "streetwalk_coverage",
+                "spacing_m": 15,
+                "match_dist_m": 25.0,
+                "totals": {"edges": 40, "coverage_pct_by_length": 92.8, "length_km": 375.1},
+            }
+        },
+    }
+    with gzip.open(os.path.join(root, coverage_name), "wt", encoding="utf-8") as fh:
+        json.dump(geojson, fh)
+
+
+@pytest.fixture
+def bundle_dir(tmp_path):
+    """
+    A complete laptop bundle: one city, one Mapillary grid run, one GSV walk,
+    the frozen network, and the spend ledger the laptop wrote.
+
+    Deliberately built with the real ``db`` writers rather than hand-rolled SQL,
+    so the fixture cannot drift from what a laptop run actually produces.
+    """
+    root = tmp_path / "bundle"
+    (root / bundle_import.OSM_CACHE_DIRNAME).mkdir(parents=True)
+    conn = db.connect(str(root / bundle_import.CATALOG_NAME))
+    db.register_city(conn, **CITY)
+
+    run_csv, run_json = _run_names()
+    df = make_mapillary_city_df([("p1", "2024-05-01"), ("p2", "2023-07-01")], run_date=RUN_DATE)
+    write_city_csv_gz(df, str(root / run_csv))
+    (root / run_json).write_bytes(gzip.compress(b'{"metadata": {"schema_version": 2}}'))
+    stats = analysis.calculate_run_stats(
+        fileutils.load_city_csv_file(str(root / run_csv)), RUN_DATE, provider="mapillary"
+    )
+    db.register_run(
+        conn,
+        city_id=CITY_ID,
+        run_date=RUN_DATE,
+        csv_filename=run_csv,
+        provider="mapillary",
+        json_filename=run_json,
+        api_requests=36,
+        num_flat_images=0,
+        census_fetched_by="mapillary",
+        **stats,
+    )
+
+    walk_csv, walk_cov = _walk_names()
+    _write_walk_artifacts(root, walk_csv, walk_cov)
+    db.register_street_walk(
+        conn,
+        city_id=CITY_ID,
+        run_date=RUN_DATE,
+        csv_filename=walk_csv,
+        provider="gsv",
+        coverage_filename=walk_cov,
+        network_type="drive",
+        spacing_m=15,
+        match_dist_m=25.0,
+        sample_points=SAMPLE_POINTS,
+        edges_total=40,
+        coverage_pct_by_length=92.8,
+        length_km=375.1,
+        api_requests=SAMPLE_POINTS,
+    )
+
+    graphml = f"{CITY_ID}_streets_network.graphml"
+    (root / bundle_import.OSM_CACHE_DIRNAME / graphml).write_text("<graphml/>")
+    db.register_street_network(
+        conn, city_id=CITY_ID, graphml_filename=graphml, network_type="drive", edge_count=40
+    )
+
+    db.add_api_usage(conn, RUN_DATE, SAMPLE_POINTS, provider="gsv_streets")
+    db.add_api_usage(conn, RUN_DATE, 36, provider="mapillary_streets")
+    conn.commit()
+    conn.close()
+    return root
+
+
+@pytest.fixture
+def cfg(tmp_path):
+    """A scheduler config whose catalog and data dir are this host's, and publishing off."""
+    data_dir = tmp_path / "prod"
+    data_dir.mkdir()
+    return SchedulerConfig(
+        data_dir=str(data_dir),
+        db_path=str(data_dir / "streetscape_tracker.db"),
+        log_dir=str(tmp_path / "logs"),
+        publish_enabled=False,
+        providers={
+            "gsv": ProviderConfig(),
+            "gsv_streets": ProviderConfig(),
+            "mapillary": ProviderConfig(),
+            "mapillary_streets": ProviderConfig(),
+        },
+    )
+
+
+@pytest.fixture(autouse=True)
+def _no_batch_in_flight(monkeypatch):
+    """
+    Neutralize the `ps` scan suite-wide.
+
+    Without this the suite's own pytest command line, or a real nightly batch on
+    the machine running the tests, decides whether these tests pass.
+    """
+    monkeypatch.setattr("streetscape_metadata_tracker.scheduler._run_due_in_flight", lambda: None)
+
+
+def _prod(cfg):
+    conn = sqlite3.connect(cfg.db_path)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+# ── the happy path ────────────────────────────────────────────────────────
+
+
+def test_dry_run_writes_nothing_to_either_the_catalog_or_the_data_dir(cfg, bundle_dir):
+    assert cmd_import_bundle(cfg, str(bundle_dir)) == 0
+    # Both halves matter: an importer that copied files and then declined to
+    # catalog them would leave artifacts the aggregate never sees. The catalog
+    # FILE is allowed to appear — db.connect creates the schema in order to ask
+    # it anything — so the assertion is on rows, and on the data dir holding no
+    # artifact.
+    assert _prod(cfg).execute("SELECT COUNT(*) FROM cities").fetchone()[0] == 0
+    assert [f for f in os.listdir(cfg.data_dir) if not f.startswith("streetscape_tracker.db")] == []
+
+
+def test_execute_lands_rows_files_and_the_network(cfg, bundle_dir):
+    assert cmd_import_bundle(cfg, str(bundle_dir), execute=True, enable=True) == 0
+    conn = _prod(cfg)
+    assert conn.execute("SELECT COUNT(*) FROM runs").fetchone()[0] == 1
+    assert conn.execute("SELECT COUNT(*) FROM street_walks").fetchone()[0] == 1
+    assert conn.execute("SELECT COUNT(*) FROM street_networks").fetchone()[0] == 1
+    run_csv, _ = _run_names()
+    walk_csv, walk_cov = _walk_names()
+    for name in (run_csv, walk_csv, walk_cov):
+        assert os.path.exists(os.path.join(cfg.data_dir, name)), name
+    assert os.path.exists(
+        os.path.join(
+            cfg.data_dir, bundle_import.OSM_CACHE_DIRNAME, f"{CITY_ID}_streets_network.graphml"
+        )
+    )
+
+
+def test_city_is_registered_disabled_unless_enable_is_passed(cfg, bundle_dir):
+    # The whole point of the default: a city arriving through an investigation
+    # has a boundary nobody vetted, and a fresh city sorts to the head of the
+    # next night's stalest-first queue.
+    assert cmd_import_bundle(cfg, str(bundle_dir), execute=True) == 0
+    assert _prod(cfg).execute("SELECT enabled FROM cities").fetchone()[0] == 0
+
+
+def test_enable_turns_on_a_city_that_is_already_registered_and_off(cfg, bundle_dir):
+    assert cmd_import_bundle(cfg, str(bundle_dir), execute=True) == 0
+    db.set_city_enabled(db.connect(cfg.db_path), CITY_ID, True)
+    assert _prod(cfg).execute("SELECT enabled FROM cities").fetchone()[0] == 1
+
+
+# ── what the import must NOT do ───────────────────────────────────────────
+
+
+def test_the_bundles_one_city_aggregate_is_never_copied_over_this_hosts(cfg, bundle_dir):
+    """
+    The footgun this importer exists next to.
+
+    A bundle's data/ also holds cities.json.gz, streetwalks.json.gz and
+    driving_plan.json.gz that the laptop generated over a ONE-CITY catalog. A
+    directory sync would replace this host's published index with them — a
+    site-wide outage produced by a successful import — so the copy step is
+    file-by-file over the names catalog rows carry, and nothing else.
+    """
+    (bundle_dir / "cities.json.gz").write_bytes(gzip.compress(b'{"cities": ["only-me"]}'))
+    bundle = bundle_import.read_bundle(bundle_dir)
+    assert "cities.json.gz" not in bundle_import._artifact_sources(bundle)
+
+    conn = db.connect(cfg.db_path)
+    existing, problems = bundle_import.check_bundle(bundle, conn, cfg.data_dir)
+    assert problems == []
+    result = bundle_import.apply_bundle(
+        bundle, conn, data_dir=cfg.data_dir, existing=existing, enable=False
+    )
+    assert not os.path.exists(os.path.join(cfg.data_dir, "cities.json.gz"))
+    assert "cities.json.gz" not in result.files
+
+
+def test_spend_is_ledgered_only_for_credentials_this_host_shares(cfg, bundle_dir):
+    """
+    The ABSENCE is the assertion.
+
+    Mapillary meters by IP, so a laptop's tile spend was drawn against a
+    different allowance; charging it here would tighten a budget gate against
+    requests this host never made — on the very channel whose budget is the
+    instrument in an open block investigation.
+    """
+    assert cmd_import_bundle(cfg, str(bundle_dir), execute=True) == 0
+    charged = dict(_prod(cfg).execute("SELECT provider, requests FROM api_usage").fetchall())
+    assert charged == {"gsv_streets": SAMPLE_POINTS}
+    assert "mapillary_streets" not in charged
+
+
+def test_no_cadence_row_for_a_channel_the_scheduler_cannot_run(cfg, bundle_dir):
+    """
+    A success on an unwired channel would suppress its FIRST real collection.
+
+    The bundle's Mapillary GRID run has a channel, so it gets a row. Panoramax
+    is in UNWIRED_CHANNELS, so it must not — even though it is a perfectly good
+    provider token with a perfectly good run.
+    """
+    conn = db.connect(str(bundle_dir / bundle_import.CATALOG_NAME))
+    conn.execute("UPDATE runs SET provider = 'panoramax'")
+    run_csv, run_json = _run_names(provider="panoramax")
+    old_csv, old_json = _run_names(provider="mapillary")
+    conn.execute("UPDATE runs SET csv_filename = ?, json_filename = ?", (run_csv, run_json))
+    conn.commit()
+    conn.close()
+    os.rename(bundle_dir / old_csv, bundle_dir / run_csv)
+    os.rename(bundle_dir / old_json, bundle_dir / run_json)
+
+    assert cmd_import_bundle(cfg, str(bundle_dir), execute=True, enable=True) == 0
+    channels = {
+        r[0]
+        for r in _prod(cfg).execute(
+            "SELECT provider FROM schedule_state WHERE last_success_at IS NOT NULL"
+        )
+    }
+    assert "panoramax" not in channels
+    assert "gsv_streets" in channels  # the walk still recorded one
+
+
+# ── stats ─────────────────────────────────────────────────────────────────
+
+
+def test_grid_stats_are_recomputed_from_the_csv_not_carried(cfg, bundle_dir):
+    """
+    Pinned by MUTATING the bundle's stored value, not by reading a default.
+
+    A test that only checked the imported number equalled the recomputed one
+    would stay green if the importer carried the bundle's row instead — the two
+    agree whenever both checkouts are in step, which is exactly when the bug is
+    invisible.
+    """
+    conn = sqlite3.connect(str(bundle_dir / bundle_import.CATALOG_NAME))
+    conn.execute("UPDATE runs SET coverage_rate_pct = 99.0, total_points = 1")
+    conn.commit()
+    conn.close()
+
+    assert cmd_import_bundle(cfg, str(bundle_dir), execute=True) == 0
+    row = _prod(cfg).execute("SELECT coverage_rate_pct, total_points FROM runs").fetchone()
+    assert row["coverage_rate_pct"] != 99.0
+    assert row["total_points"] != 1
+
+
+def test_walk_row_disagreeing_with_its_coverage_artifact_is_refused(cfg, bundle_dir):
+    conn = sqlite3.connect(str(bundle_dir / bundle_import.CATALOG_NAME))
+    conn.execute("UPDATE street_walks SET edges_total = 4000")
+    conn.commit()
+    conn.close()
+    assert cmd_import_bundle(cfg, str(bundle_dir), execute=True) == 64
+    assert _prod(cfg).execute("SELECT COUNT(*) FROM street_walks").fetchone()[0] == 0
+
+
+def test_a_truncated_walk_csv_is_refused(cfg, bundle_dir):
+    """An rsync cut short leaves a readable gzip whose row count is simply wrong."""
+    walk_csv, walk_cov = _walk_names()
+    _write_walk_artifacts(bundle_dir, walk_csv, walk_cov, sample_points=SAMPLE_POINTS - 3)
+    assert cmd_import_bundle(cfg, str(bundle_dir), execute=True) == 64
+
+
+# ── the refusals, one at a time ───────────────────────────────────────────
+
+
+def test_geometry_mismatch_is_refused(cfg, bundle_dir):
+    """
+    The load-bearing check, and the one nothing in this codebase had.
+
+    Every same_grid_geometry call compares filename to filename; none compares a
+    filename to the cities row. A bundle collected on a different rectangle is
+    not a later snapshot of the same series.
+    """
+    conn = db.connect(cfg.db_path)
+    db.register_city(conn, **{**CITY, "grid_width_m": 9000})
+    conn.close()
+    assert cmd_import_bundle(cfg, str(bundle_dir), execute=True) == 64
+    assert _prod(cfg).execute("SELECT COUNT(*) FROM runs").fetchone()[0] == 0
+
+
+def test_a_filename_the_generators_would_not_produce_is_refused(cfg, bundle_dir):
+    run_csv, _ = _run_names()
+    conn = sqlite3.connect(str(bundle_dir / bundle_import.CATALOG_NAME))
+    # Drop the provider token — the exact shape that silently collides two
+    # providers sharing a run date.
+    conn.execute("UPDATE runs SET csv_filename = ?", (run_csv.replace("_mapillary_", "_"),))
+    conn.commit()
+    conn.close()
+    assert cmd_import_bundle(cfg, str(bundle_dir), execute=True) == 64
+
+
+def test_an_existing_run_for_the_same_city_provider_and_date_is_refused(cfg, bundle_dir):
+    conn = db.connect(cfg.db_path)
+    db.register_city(conn, **CITY)
+    run_csv, _ = _run_names()
+    db.register_run(
+        conn, city_id=CITY_ID, run_date=RUN_DATE, csv_filename=run_csv, provider="mapillary"
+    )
+    conn.close()
+    assert cmd_import_bundle(cfg, str(bundle_dir), execute=True) == 64
+
+
+def test_a_colliding_csv_filename_under_a_DIFFERENT_key_is_refused(cfg, bundle_dir):
+    """
+    The composite key does not catch this one.
+
+    `runs.csv_filename` carries its own UNIQUE, independent of
+    (city_id, provider, run_date) — so a row filed under another city's id can
+    hold the name this bundle is about to write, and register_run would raise
+    IntegrityError mid-import rather than refuse cleanly.
+    """
+    conn = db.connect(cfg.db_path)
+    db.register_city(conn, **CITY)
+    db.register_city(conn, **{**CITY, "city_name": "Elsewhere"})
+    run_csv, _ = _run_names()
+    db.register_run(
+        conn,
+        city_id=db.derive_city_id("Elsewhere", "California", "United States"),
+        run_date=RUN_DATE,
+        csv_filename=run_csv,
+        provider="mapillary",
+    )
+    conn.close()
+    assert cmd_import_bundle(cfg, str(bundle_dir), execute=True) == 64
+
+
+def test_a_row_naming_an_artifact_the_bundle_lacks_is_refused(cfg, bundle_dir):
+    run_csv, _ = _run_names()
+    os.remove(bundle_dir / run_csv)
+    assert cmd_import_bundle(cfg, str(bundle_dir), execute=True) == 64
+
+
+def test_a_bundle_on_another_schema_version_is_refused(cfg, bundle_dir):
+    conn = sqlite3.connect(str(bundle_dir / bundle_import.CATALOG_NAME))
+    conn.execute(f"PRAGMA user_version = {db.SCHEMA_VERSION - 1}")
+    conn.commit()
+    conn.close()
+    assert cmd_import_bundle(cfg, str(bundle_dir), execute=True) == 64
+
+
+def test_a_live_wal_beside_the_bundle_catalog_is_refused(cfg, bundle_dir):
+    """
+    A read-only connection cannot replay a WAL, so reading anyway would import a
+    bundle quietly missing its most recent rows.
+    """
+    (bundle_dir / f"{bundle_import.CATALOG_NAME}-wal").write_bytes(b"not empty")
+    assert cmd_import_bundle(cfg, str(bundle_dir), execute=True) == 64
+
+
+def test_a_directory_with_no_catalog_is_refused(cfg, tmp_path):
+    assert cmd_import_bundle(cfg, str(tmp_path / "nothing-here"), execute=True) == 64
+
+
+def test_an_import_is_refused_while_a_batch_looks_like_it_is_running(cfg, bundle_dir, monkeypatch):
+    monkeypatch.setattr(
+        "streetscape_metadata_tracker.scheduler._run_due_in_flight",
+        lambda: "pid 1234: python -m streetscape_metadata_tracker.scheduler run-due",
+    )
+    assert cmd_import_bundle(cfg, str(bundle_dir), execute=True) == 64
+    # ...and --force is the documented way past a false positive.
+    assert cmd_import_bundle(cfg, str(bundle_dir), execute=True, force=True) == 0
+
+
+def test_re_running_a_landed_import_refuses_rather_than_double_charging(cfg, bundle_dir):
+    """
+    add_api_usage is ADDITIVE, so this refusal is what makes a retry safe: an
+    operator who re-runs after a partial-looking failure must not pay twice.
+    """
+    assert cmd_import_bundle(cfg, str(bundle_dir), execute=True) == 0
+    before = _prod(cfg).execute("SELECT requests FROM api_usage").fetchone()[0]
+    assert cmd_import_bundle(cfg, str(bundle_dir), execute=True) == 64
+    assert _prod(cfg).execute("SELECT requests FROM api_usage").fetchone()[0] == before


### PR DESCRIPTION
Closes the part of #330 that actually blocks work today: there is no way to get a laptop-collected investigation into prod.

## Why

An inquiry about an untracked city arrives and the useful window is the next hour. Investigating from a laptop already works — every collector takes `--download-dir`, so a scratch directory is a complete, self-describing investigation, and three of the four providers meter by **IP** rather than by credential, so moving the work off prod isolates it for free.

What was missing is the way back. Registering the city instead makes prod re-download everything it *can*, and silently discards what it cannot — an opt-in channel nobody enrolled (KartaView) and a provider that is not a scheduler channel at all (Panoramax).

San Luis Obispo, measured this morning across all four providers in ~7 minutes and 25,226 requests, is the worked example and the live test case.

## What this adds

```bash
rsync -a /tmp/city/data/ makelab2:~/streetscape-tracker/archive/investigations/city/
scheduler import-bundle archive/investigations/city              # dry run is the DEFAULT
scheduler import-bundle archive/investigations/city --execute --enable
```

A "bundle" is not a new format — it is exactly the `data/` directory a laptop run already wrote, catalog included, read through a **read-only** connection so the importer can neither migrate nor mutate the operator's evidence.

## The three decisions worth reviewing

**Geometry is checked against the frozen `cities` row.** This guard did not exist anywhere: every `naming.same_grid_geometry` call compares filename to filename, never a filename to the catalog. A bundle collected on a different rectangle is not a later snapshot of the same series, and nothing downstream would have said so.

**Only files a catalog row names are copied.** A bundle's `data/` also holds `cities.json.gz`, `streetwalks.json.gz` and `driving_plan.json.gz` generated over a **one-city** catalog. A directory sync would replace the published index with them — a site-wide outage produced by a *successful* import.

**Grid stats are recomputed, walk stats are carried.** A grid run's stats are one `analysis.calculate_run_stats` pass over the copied CSV — the same call the collector makes — so a stat definition that moved between checkouts cannot enter the series as an unattributable step change. A walk's are carried from its row and cross-checked against the coverage GeoJSON's own totals and the CSV's row count, because recomputing one means re-running the OSM edge join for a result that can only equal what the artifact beside it already records.

Also: spend reaches `api_usage` only for credentials this host shares (`gsv*`, `kartaview*`) — charging the per-IP channels would tighten a budget gate against requests prod never made, on the very channel whose budget is the instrument in an open block investigation. And `record_attempt` per imported channel is the point of the exercise, since it is what stops the next night re-paying for the crawl; channels in `UNWIRED_CHANNELS` are skipped, because a success there would suppress their first real collection once wired.

## Atomicity, stated honestly

Validation is all-or-nothing. The write is not and cannot be — every `db` writer commits for itself. What stands in for atomicity is **order**: the ledger is written last, after every row a retry's collision check would refuse on, so a crash part-way can be finished by hand but can never double-charge.

## Tests

`tests/test_import_bundle.py`, 20 cases. Each refusal individually, including the colliding `csv_filename` under a *different* composite key that the `(city_id, provider, run_date)` check does not catch. The recompute is pinned by **mutating** the bundle's stored stat, and the ledger rule by **absence**. Full suite green (2,300 passed).

## Deliberately still open on #330

A laptop-side `investigate` driver; a `register-city` subcommand so the laptop asks prod for the frozen grid *before* collecting rather than being checked against it afterward; and a pidfile written by `run-due` to replace the batch check's `ps` heuristic.

🤖 Generated with [Claude Code](https://claude.com/claude-code) — Opus 5 (1M context), claude-opus-5[1m]